### PR TITLE
chore: release v0.1.0b2 beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas)
 
 ## [Unreleased]
 
+## [0.1.0b2] - 2026-06-14
+
 - **Appliances & virtual devices.** A new **Appliances** tab in the panel lets you
   register an appliance Home Keeper provisions as a real **virtual device** (so
   multiple maintenance tasks share one device page), or attach **asset metadata** to

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.1.0b1"
+PANEL_VERSION = "0.1.0b2"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/prestomation/ha-home-keeper/issues",
   "requirements": [],
-  "version": "0.1.0b1"
+  "version": "0.1.0b2"
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Bumps version to `0.1.0b2` in `manifest.json` and `const.py`
- Promotes the `[Unreleased]` changelog section to `[0.1.0b2] - 2026-06-14`

## What's in this release

- **Appliances & virtual devices** — new Appliances tab, virtual devices, asset metadata (manufacturer/model/serial, dates, warranty), date sensors, and services (`add_asset`, `update_asset`, `delete_asset`, `list_assets`)
- **Structured parts & wear items** — parts list with part numbers/vendor/cost/consumable type; wear items auto-create maintenance tasks with to-do + calendar + mark-done button + next-due sensor
- **Subdevices & related devices** — `via_device` nesting and arbitrary related-device links surfaced in the panel
- **Tighter HA integration** — `area_id` validation, `configuration_url` on virtual devices, optional mdi icon, `diagnostics.py`

## Test plan

- [ ] CI passes (release.yml validates version consistency and builds the HACS zip)
- [ ] Merge to main triggers tag `v0.1.0b2` and GitHub pre-release creation

https://claude.ai/code/session_011rkr2QkT3JUxc6Uv5qDjmo
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011rkr2QkT3JUxc6Uv5qDjmo)_