### PR TITLE
Extract pure wear-part reconciler and unit-test its branches

### DIFF
--- a/custom_components/home_keeper/models.py
+++ b/custom_components/home_keeper/models.py
@@ -17,7 +17,6 @@ from . import recurrence
 from .const import (
     FREQS,
     MAX_INTERVAL,
-    REC_FIXED,
     REC_FLOATING,
     RECURRENCE_TYPES,
     UNITS,

--- a/custom_components/home_keeper/reconcile.py
+++ b/custom_components/home_keeper/reconcile.py
@@ -1,0 +1,145 @@
+"""Pure logic for the wear-part → maintenance-task reconciliation.
+
+A wear part with a ``replace_interval`` yields a floating maintenance task attached
+to the asset's device (so it reuses the existing to-do/calendar/per-task entities).
+The task is keyed by ``source = {"part": {asset_id, part_id}}`` so the reconciler
+exclusively owns it.
+
+This module imports nothing from Home Assistant: it is a pure transformation over
+plain dicts (assets, tasks) that :class:`store.HomeKeeperStore` wraps with
+persistence. Keeping it pure lets the create/anchor/heal/orphan branches be
+unit-tested directly (see ``tests/unit/test_reconcile.py``).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, tzinfo
+from typing import Any
+
+from . import models, recurrence
+from .const import PART_WEAR, TASK_SOURCE_PART
+
+
+def part_source(task: dict[str, Any]) -> dict[str, Any] | None:
+    """Return a task's ``{asset_id, part_id}`` part provenance, or None."""
+    source = task.get("source")
+    if isinstance(source, dict) and isinstance(source.get(TASK_SOURCE_PART), dict):
+        return source[TASK_SOURCE_PART]
+    return None
+
+
+def qualify_iso(value: str | None, tz: tzinfo | None) -> str | None:
+    """Parse an ISO date/datetime and return an aware ISO string (or None).
+
+    A part's ``last_replaced`` is a date-only string; the recurrence engine
+    compares the derived ``next_due`` against an aware ``now``, so a naive value
+    must be qualified to Home Assistant's timezone first.
+    """
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=tz) if tz is not None else parsed.astimezone()
+    return parsed.isoformat()
+
+
+def reconcile_part_tasks(
+    assets: dict[str, dict[str, Any]],
+    tasks: dict[str, dict[str, Any]],
+    *,
+    now: datetime,
+) -> tuple[dict[str, dict[str, Any]], bool]:
+    """Compute the task map derived from wear parts.
+
+    Returns ``(new_tasks, changed)``. ``new_tasks`` is a fresh dict (the input is
+    not mutated); ``changed`` is ``True`` when it differs from ``tasks``. Tasks
+    without a part source are carried through untouched.
+    """
+    result = dict(tasks)
+
+    desired: dict[tuple[str, str], tuple[dict, dict]] = {}
+    for asset in assets.values():
+        for part in asset.get("parts", []):
+            if part.get("type") == PART_WEAR and part.get("replace_interval"):
+                desired[(asset["id"], part["id"])] = (asset, part)
+
+    existing_by_key: dict[tuple[str, str], str] = {}
+    for tid, task in result.items():
+        src = part_source(task)
+        if src:
+            existing_by_key[(src.get("asset_id"), src.get("part_id"))] = tid
+
+    changed = False
+
+    # Remove orphaned part-tasks (the part or its wear cadence went away).
+    for key, tid in list(existing_by_key.items()):
+        if key not in desired:
+            del result[tid]
+            existing_by_key.pop(key, None)
+            changed = True
+
+    # Create or update the rest.
+    for key, (asset, part) in desired.items():
+        name = f"Replace {part['name']} ({asset.get('name') or 'appliance'})"
+        # A part's last_replaced is a date-only string; qualify it to HA's tz so the
+        # derived next_due is timezone-aware. A naive next_due otherwise crashes the
+        # next-due sensor, overdue binary_sensor, and the calendar (which compare it
+        # against an aware "now").
+        anchored = qualify_iso(part.get("last_replaced"), now.tzinfo)
+        tid = existing_by_key.get(key)
+        if tid is None:
+            task = models.build_task(
+                {
+                    "name": name,
+                    "recurrence_type": "floating",
+                    "interval": part["replace_interval"],
+                    "unit": part["replace_unit"],
+                    "device_id": asset.get("device_id"),
+                    "area_id": asset.get("area_id"),
+                    "source": {"part": {"asset_id": asset["id"], "part_id": part["id"]}},
+                },
+                now=now,
+            )
+            # Anchor the floating clock to the recorded replacement, or to creation
+            # ("assumed fresh") so that later interval edits re-base off a stable
+            # point instead of drifting to now+interval on each edit.
+            task["last_completed"] = anchored or task["created"]
+            task["next_due"] = recurrence.compute_next_due(task, now=now).isoformat()
+            result[task["id"]] = task
+            changed = True
+        else:
+            # Only pass fields that actually changed. Passing interval/unit
+            # unconditionally would re-trigger a next_due recompute on every
+            # reconcile (setup, any asset edit) and, for a task with no
+            # last_completed, drift next_due forward to now+interval each time.
+            before = result[tid]
+            updates: dict[str, Any] = {}
+            if before.get("name") != name:
+                updates["name"] = name
+            if before.get("interval") != part["replace_interval"]:
+                updates["interval"] = part["replace_interval"]
+            if before.get("unit") != part["replace_unit"]:
+                updates["unit"] = part["replace_unit"]
+            if before.get("device_id") != asset.get("device_id"):
+                updates["device_id"] = asset.get("device_id")
+            if before.get("area_id") != asset.get("area_id"):
+                updates["area_id"] = asset.get("area_id")
+            merged = models.merge_update(before, updates, now=now) if updates else before
+            # Heal a legacy timezone-naive last_completed (older builds stored a
+            # date-only last_replaced verbatim, yielding a naive next_due that crashed
+            # the sensors/calendar). Only re-qualify a naive value — never overwrite a
+            # real (already-aware) completion timestamp.
+            lc = merged.get("last_completed")
+            healed = qualify_iso(lc, now.tzinfo) if lc else None
+            if healed and healed != lc:
+                merged = dict(merged)
+                merged["last_completed"] = healed
+                merged["next_due"] = recurrence.compute_next_due(merged, now=now).isoformat()
+            if merged is not before:
+                result[tid] = merged
+                changed = True
+
+    return result, changed

--- a/custom_components/home_keeper/store.py
+++ b/custom_components/home_keeper/store.py
@@ -9,7 +9,6 @@ change so entities stay in sync within the current HA tick.
 from __future__ import annotations
 
 import logging
-from datetime import datetime, tzinfo
 from typing import Any
 
 from homeassistant.core import HomeAssistant
@@ -19,39 +18,13 @@ from homeassistant.util import dt as dt_util
 from . import assets, events, models, recurrence
 from .const import (
     EVENT_TASK_COMPLETED,
-    PART_WEAR,
     STORAGE_KEY,
     STORAGE_VERSION,
-    TASK_SOURCE_PART,
 )
+from .reconcile import part_source as _part_source
+from .reconcile import reconcile_part_tasks as _reconcile_part_tasks
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def _part_source(task: dict[str, Any]) -> dict[str, Any] | None:
-    """Return a task's ``{asset_id, part_id}`` part provenance, or None."""
-    source = task.get("source")
-    if isinstance(source, dict) and isinstance(source.get(TASK_SOURCE_PART), dict):
-        return source[TASK_SOURCE_PART]
-    return None
-
-
-def _qualify_iso(value: str | None, tz: tzinfo | None) -> str | None:
-    """Parse an ISO date/datetime and return an aware ISO string (or None).
-
-    A part's ``last_replaced`` is a date-only string; the recurrence engine
-    compares the derived ``next_due`` against an aware ``now``, so a naive value
-    must be qualified to Home Assistant's timezone first.
-    """
-    if not value:
-        return None
-    try:
-        parsed = datetime.fromisoformat(str(value))
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=tz) if tz is not None else parsed.astimezone()
-    return parsed.isoformat()
 
 
 class HomeKeeperStore:
@@ -260,98 +233,14 @@ class HomeKeeperStore:
     async def reconcile_part_tasks(self) -> bool:
         """Create/update/remove the maintenance tasks derived from wear parts.
 
-        A wear part with a ``replace_interval`` yields a floating task attached to
-        the asset's device, so it reuses the existing to-do/calendar/per-task
-        entities. The task is keyed by ``source = {"part": {asset_id, part_id}}`` so
-        this reconciler exclusively owns it. Returns ``True`` if any task changed.
+        Delegates the (pure) computation to :func:`reconcile.reconcile_part_tasks`
+        and persists the result. Returns ``True`` if any task changed.
         """
-        now = dt_util.now()
-        desired: dict[tuple[str, str], dict[str, Any]] = {}
-        for asset in self._assets.values():
-            for part in asset.get("parts", []):
-                if part.get("type") == PART_WEAR and part.get("replace_interval"):
-                    desired[(asset["id"], part["id"])] = (asset, part)
-
-        existing_by_key: dict[tuple[str, str], str] = {}
-        for tid, task in self._tasks.items():
-            src = _part_source(task)
-            if src:
-                existing_by_key[(src.get("asset_id"), src.get("part_id"))] = tid
-
-        changed = False
-        # Remove orphaned part-tasks.
-        for key, tid in list(existing_by_key.items()):
-            if key not in desired:
-                del self._tasks[tid]
-                existing_by_key.pop(key, None)
-                changed = True
-
-        # Create or update the rest.
-        for key, (asset, part) in desired.items():
-            name = f"Replace {part['name']} ({asset.get('name') or 'appliance'})"
-            # A part's last_replaced is a date-only string; qualify it to HA's tz so
-            # the derived next_due is timezone-aware. A naive next_due otherwise
-            # crashes the next-due sensor, overdue binary_sensor, and the calendar
-            # (which compare it against an aware "now").
-            anchored = _qualify_iso(part.get("last_replaced"), now.tzinfo)
-            tid = existing_by_key.get(key)
-            if tid is None:
-                task = models.build_task(
-                    {
-                        "name": name,
-                        "recurrence_type": "floating",
-                        "interval": part["replace_interval"],
-                        "unit": part["replace_unit"],
-                        "device_id": asset.get("device_id"),
-                        "area_id": asset.get("area_id"),
-                        "source": {
-                            "part": {"asset_id": asset["id"], "part_id": part["id"]}
-                        },
-                    },
-                    now=now,
-                )
-                # Anchor the floating clock to the recorded replacement, or to
-                # creation ("assumed fresh") so that later interval edits re-base off
-                # a stable point instead of drifting to now+interval on each edit.
-                task["last_completed"] = anchored or task["created"]
-                task["next_due"] = recurrence.compute_next_due(task, now=now).isoformat()
-                self._tasks[task["id"]] = task
-                changed = True
-            else:
-                # Only pass fields that actually changed. Passing interval/unit
-                # unconditionally would re-trigger a next_due recompute on every
-                # reconcile (setup, any asset edit) and, for a task with no
-                # last_completed, drift next_due forward to now+interval each time.
-                before = self._tasks[tid]
-                updates: dict[str, Any] = {}
-                if before.get("name") != name:
-                    updates["name"] = name
-                if before.get("interval") != part["replace_interval"]:
-                    updates["interval"] = part["replace_interval"]
-                if before.get("unit") != part["replace_unit"]:
-                    updates["unit"] = part["replace_unit"]
-                if before.get("device_id") != asset.get("device_id"):
-                    updates["device_id"] = asset.get("device_id")
-                if before.get("area_id") != asset.get("area_id"):
-                    updates["area_id"] = asset.get("area_id")
-                merged = models.merge_update(before, updates, now=now) if updates else before
-                # Heal a legacy timezone-naive last_completed (older builds stored a
-                # date-only last_replaced verbatim, yielding a naive next_due that
-                # crashed the sensors/calendar). Only re-qualify a naive value — never
-                # overwrite a real (already-aware) completion timestamp.
-                lc = merged.get("last_completed")
-                healed = _qualify_iso(lc, now.tzinfo) if lc else None
-                if healed and healed != lc:
-                    merged = dict(merged)
-                    merged["last_completed"] = healed
-                    merged["next_due"] = recurrence.compute_next_due(
-                        merged, now=now
-                    ).isoformat()
-                if merged is not before:
-                    self._tasks[tid] = merged
-                    changed = True
-
+        new_tasks, changed = _reconcile_part_tasks(
+            self._assets, self._tasks, now=dt_util.now()
+        )
         if changed:
+            self._tasks = new_tasks
             await self._save()
         return changed
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ def _load_pure_modules() -> None:
     pkg = types.ModuleType("hk")
     pkg.__path__ = [str(_COMPONENT_DIR)]  # type: ignore[attr-defined]
     sys.modules["hk"] = pkg
-    for name in ("const", "recurrence", "models", "assets", "events"):
+    for name in ("const", "recurrence", "models", "assets", "events", "reconcile"):
         spec = importlib.util.spec_from_file_location(
             f"hk.{name}", str(_COMPONENT_DIR / f"{name}.py")
         )
@@ -42,6 +42,7 @@ def _load_pure_modules() -> None:
     sys.modules["hk_models"] = sys.modules["hk.models"]
     sys.modules["hk_assets"] = sys.modules["hk.assets"]
     sys.modules["hk_events"] = sys.modules["hk.events"]
+    sys.modules["hk_reconcile"] = sys.modules["hk.reconcile"]
 
 
 _load_pure_modules()

--- a/tests/integration/test_assets.py
+++ b/tests/integration/test_assets.py
@@ -6,7 +6,7 @@ can attach to that virtual device (its per-task entities merge onto the same pag
 and that the asset CRUD services round-trip.
 """
 
-from conftest import call_service, get_state, list_states, poll_state
+from conftest import call_service, list_states
 
 
 def _find_state(ha, predicate):

--- a/tests/unit/test_reconcile.py
+++ b/tests/unit/test_reconcile.py
@@ -1,0 +1,197 @@
+"""Unit tests for the pure wear-part → task reconciler (``reconcile.py``).
+
+These exercise the create/anchor/heal/orphan/update branches directly, without a
+Home Assistant runtime. The store wraps this with persistence (integration tests).
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import hk_reconcile as rc
+import hk_recurrence as r
+
+TZ = timezone(timedelta(hours=-4))
+NOW = datetime(2026, 6, 13, 10, tzinfo=TZ)
+
+
+def _asset(aid="a1", name="Heater", parts=None, **extra):
+    return {"id": aid, "name": name, "parts": parts or [], **extra}
+
+
+def _wear_part(pid="p1", name="Anode", interval=12, unit="months", **extra):
+    return {
+        "id": pid,
+        "name": name,
+        "type": "wear",
+        "replace_interval": interval,
+        "replace_unit": unit,
+        **extra,
+    }
+
+
+def _reconcile(assets, tasks=None):
+    return rc.reconcile_part_tasks(assets, tasks or {}, now=NOW)
+
+
+def _only(tasks):
+    assert len(tasks) == 1, tasks
+    return next(iter(tasks.values()))
+
+
+# ── creation / anchoring ──────────────────────────────────────────────────────
+def test_creates_task_anchored_on_last_replaced():
+    asset = _asset(device_id="dev1", parts=[_wear_part(last_replaced="2025-05-01")])
+    tasks, changed = _reconcile({"a1": asset})
+    assert changed is True
+    task = _only(tasks)
+    assert task["name"] == "Replace Anode (Heater)"
+    assert task["device_id"] == "dev1"
+    assert task["source"]["part"] == {"asset_id": "a1", "part_id": "p1"}
+    anchor = datetime.fromisoformat("2025-05-01").replace(tzinfo=TZ)
+    assert task["last_completed"] == anchor.isoformat()
+    assert task["next_due"] == r.compute_floating_next_due(
+        anchor, 12, "months", now=NOW
+    ).isoformat()
+
+
+def test_creates_task_anchored_on_creation_when_no_last_replaced():
+    asset = _asset(parts=[_wear_part()])
+    tasks, _ = _reconcile({"a1": asset})
+    task = _only(tasks)
+    # No recorded replacement → "assumed fresh" at creation.
+    assert task["last_completed"] == task["created"] == NOW.isoformat()
+    assert task["next_due"] == r.compute_floating_next_due(NOW, 12, "months", now=NOW).isoformat()
+
+
+def test_uses_appliance_fallback_when_asset_name_blank():
+    asset = _asset(name="", parts=[_wear_part()])
+    task = _only(_reconcile({"a1": asset})[0])
+    assert task["name"] == "Replace Anode (appliance)"
+
+
+# ── what does NOT create a task ───────────────────────────────────────────────
+def test_consumable_part_creates_no_task():
+    asset = _asset(parts=[{"id": "p1", "name": "Filter", "type": "consumable"}])
+    tasks, changed = _reconcile({"a1": asset})
+    assert tasks == {} and changed is False
+
+
+def test_wear_part_without_interval_creates_no_task():
+    asset = _asset(parts=[{"id": "p1", "name": "Belt", "type": "wear", "replace_interval": None}])
+    tasks, changed = _reconcile({"a1": asset})
+    assert tasks == {} and changed is False
+
+
+def test_non_part_tasks_are_carried_through_untouched():
+    standalone = {"id": "t9", "name": "Standalone", "source": None}
+    tasks, changed = _reconcile({}, {"t9": standalone})
+    assert changed is False
+    assert tasks["t9"] is standalone
+
+
+# ── idempotency ───────────────────────────────────────────────────────────────
+def test_second_reconcile_is_idempotent():
+    asset = _asset(device_id="dev1", parts=[_wear_part(last_replaced="2025-05-01")])
+    first, _ = _reconcile({"a1": asset})
+    second, changed = _reconcile({"a1": asset}, first)
+    assert changed is False
+    assert second == first
+
+
+# ── orphan removal ────────────────────────────────────────────────────────────
+def test_removes_task_when_part_disappears():
+    asset = _asset(parts=[_wear_part()])
+    created, _ = _reconcile({"a1": asset})
+    # Part removed from the asset entirely.
+    empty_asset = _asset(parts=[])
+    tasks, changed = _reconcile({"a1": empty_asset}, created)
+    assert changed is True and tasks == {}
+
+
+def test_removes_task_when_wear_cadence_cleared():
+    asset = _asset(parts=[_wear_part()])
+    created, _ = _reconcile({"a1": asset})
+    cleared = _asset(parts=[_wear_part(interval=None)])
+    tasks, changed = _reconcile({"a1": cleared}, created)
+    assert changed is True and tasks == {}
+
+
+# ── updates ───────────────────────────────────────────────────────────────────
+def test_renaming_asset_updates_task_name():
+    created, _ = _reconcile({"a1": _asset(parts=[_wear_part()])})
+    renamed = _asset(name="Boiler", parts=[_wear_part()])
+    tasks, changed = _reconcile({"a1": renamed}, created)
+    assert changed is True
+    assert _only(tasks)["name"] == "Replace Anode (Boiler)"
+
+
+def test_changing_interval_rebases_off_anchor_not_now():
+    # A task anchored on last_replaced=2025-05-01; bumping 12→24 months should
+    # extend from the anchor (2027-05-01), not restart from now.
+    asset = _asset(parts=[_wear_part(interval=12, last_replaced="2025-05-01")])
+    created, _ = _reconcile({"a1": asset})
+    bumped = _asset(parts=[_wear_part(interval=24, last_replaced="2025-05-01")])
+    tasks, changed = _reconcile({"a1": bumped}, created)
+    assert changed is True
+    anchor = datetime.fromisoformat("2025-05-01").replace(tzinfo=TZ)
+    assert _only(tasks)["next_due"] == r.compute_floating_next_due(
+        anchor, 24, "months", now=NOW
+    ).isoformat()
+
+
+def test_changing_device_id_updates_task():
+    created, _ = _reconcile({"a1": _asset(device_id="dev1", parts=[_wear_part()])})
+    moved = _asset(device_id="dev2", parts=[_wear_part()])
+    tasks, changed = _reconcile({"a1": moved}, created)
+    assert changed is True and _only(tasks)["device_id"] == "dev2"
+
+
+# ── timezone healing vs. real completions ─────────────────────────────────────
+def test_heals_legacy_naive_last_completed():
+    # Simulate a task persisted by an older build: naive last_completed/next_due.
+    created, _ = _reconcile({"a1": _asset(parts=[_wear_part(last_replaced="2025-05-01")])})
+    task = _only(created)
+    tid = task["id"]
+    task["last_completed"] = "2025-05-01T00:00:00"  # naive (no tz)
+    task["next_due"] = "2026-05-01T00:00:00"  # naive
+    tasks, changed = _reconcile({"a1": _asset(parts=[_wear_part(last_replaced="2025-05-01")])}, created)
+    assert changed is True
+    healed = tasks[tid]
+    assert healed["last_completed"].endswith("-04:00")  # now aware
+    assert datetime.fromisoformat(healed["next_due"]).tzinfo is not None
+
+
+def test_real_aware_completion_is_not_reverted():
+    # A real completion (aware, later than the part's last_replaced anchor) must
+    # survive reconcile untouched — the regression that prompted this extraction.
+    asset = _asset(parts=[_wear_part(last_replaced="2025-05-01")])
+    created, _ = _reconcile({"a1": asset})
+    task = _only(created)
+    tid = task["id"]
+    completion = datetime(2026, 6, 1, 9, tzinfo=TZ).isoformat()
+    task["last_completed"] = completion
+    task["next_due"] = r.compute_floating_next_due(
+        datetime(2026, 6, 1, 9, tzinfo=TZ), 12, "months", now=NOW
+    ).isoformat()
+    tasks, changed = _reconcile({"a1": asset}, created)
+    assert changed is False
+    assert tasks[tid]["last_completed"] == completion
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+def test_part_source_extracts_provenance():
+    assert rc.part_source({"source": {"part": {"asset_id": "a", "part_id": "p"}}}) == {
+        "asset_id": "a",
+        "part_id": "p",
+    }
+    assert rc.part_source({"source": None}) is None
+    assert rc.part_source({}) is None
+    assert rc.part_source({"source": {"part": "notadict"}}) is None
+
+
+def test_qualify_iso():
+    assert rc.qualify_iso("2025-05-01", TZ) == "2025-05-01T00:00:00-04:00"
+    # Already-aware values are returned unchanged.
+    assert rc.qualify_iso("2025-05-01T12:00:00-04:00", TZ) == "2025-05-01T12:00:00-04:00"
+    assert rc.qualify_iso(None, TZ) is None
+    assert rc.qualify_iso("", TZ) is None
+    assert rc.qualify_iso("not-a-date", TZ) is None

--- a/tests/unit/test_reconcile.py
+++ b/tests/unit/test_reconcile.py
@@ -145,6 +145,20 @@ def test_changing_device_id_updates_task():
     assert changed is True and _only(tasks)["device_id"] == "dev2"
 
 
+def test_changing_area_id_updates_task():
+    created, _ = _reconcile({"a1": _asset(area_id="area1", parts=[_wear_part()])})
+    moved = _asset(area_id="area2", parts=[_wear_part()])
+    tasks, changed = _reconcile({"a1": moved}, created)
+    assert changed is True and _only(tasks)["area_id"] == "area2"
+
+
+def test_changing_replace_unit_updates_task():
+    created, _ = _reconcile({"a1": _asset(parts=[_wear_part(unit="months")])})
+    changed_unit = _asset(parts=[_wear_part(unit="weeks")])
+    tasks, changed = _reconcile({"a1": changed_unit}, created)
+    assert changed is True and _only(tasks)["unit"] == "weeks"
+
+
 # ── timezone healing vs. real completions ─────────────────────────────────────
 def test_heals_legacy_naive_last_completed():
     # Simulate a task persisted by an older build: naive last_completed/next_due.


### PR DESCRIPTION
## Why

Follow-up to #7. The coverage bot flagged the HA-coupled modules (`store.py`, `coordinator.py`, `entity.py`) as red. The unit-coverage job runs `pytest tests/ --ignore=tests/integration`, and those modules import Home Assistant — so their logic was only ever exercised by the Docker integration suite, never the unit job.

The highest-value, locally-verifiable target was the most complex (and most recently bug-fixed) red area: the wear-part → maintenance-task reconciliation, which was buried inside `HomeKeeperStore`.

## What

- **New pure `reconcile.py`** — no Home Assistant imports. It transforms plain asset/task dicts and returns `(new_tasks, changed)`. Houses the create/anchor/heal/orphan/update logic plus the `part_source` / `qualify_iso` helpers.
- **`HomeKeeperStore.reconcile_part_tasks` is now a thin wrapper** that calls the pure function and persists the result. No behavior change.
- **Registered the module in the unit-test shim** (`tests/conftest.py`) so it loads under the synthetic `hk` package without HA.
- **`tests/unit/test_reconcile.py`** (16 tests) covering:
  - anchoring on `last_replaced` vs. creation ("assumed fresh")
  - parts that create no task (consumable / no interval), idempotency
  - orphan removal (part gone, wear cadence cleared)
  - name / device / interval updates, and that an **interval change re-bases off the anchor rather than drifting to now**
  - **timezone healing** of legacy naive timestamps, and that a **real aware completion is never reverted** (the regression caught during #7)
  - `part_source` / `qualify_iso` edge cases
- Dropped a few pre-existing unused imports flagged by ruff.

## Verification

- Unit: **99 passed** (was 83; +16).
- Docker integration: **27 passed** — confirms the store refactor is behavior-preserving.
- `ruff check` clean across `custom_components/` and `tests/`.

No user-facing behavior change, so no CHANGELOG entry.

https://claude.ai/code/session_01BB4ZxjHKhwjvB6hP8kkMMW

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB4ZxjHKhwjvB6hP8kkMMW)_