### PR TITLE
Release 0.1.0b4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas)
 
 ## [Unreleased]
 
+## [0.1.0b4] - 2026-06-15
+
+- **Completion history for tasks and appliances.** Click a task to see every time it
+  was completed — the dates, how many, and the average cadence — or click an appliance
+  to see a timeline of *all* maintenance done on it across every related task. Answers
+  "when did I last do this / when was this serviced?" at a glance.
+
+- **Appliance history outlives a deleted task.** When a task that belongs to an
+  appliance is deleted, its completion history is kept on the appliance (shown as a
+  "removed task") so the appliance's maintenance record survives. A standalone task's
+  history is removed with it, and deleting an appliance clears its archive.
+
+- **Undo an accidental completion.** Each entry in the history view has a delete button;
+  removing a completion re-derives the task's next due date (a floating task rewinds to
+  the previous completion; a fixed schedule is unaffected).
+
 - **Device-page entities name themselves by task.** When several Home Keeper tasks
   are attached to the same existing device, their per-task entities (the *mark
   done* button, *next due* sensor, and *overdue* binary sensor) used to all share

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.1.0b3"
+PANEL_VERSION = "0.1.0b4"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/prestomation/ha-home-keeper/issues",
   "requirements": [],
-  "version": "0.1.0b3"
+  "version": "0.1.0b4"
 }


### PR DESCRIPTION
Cuts the **0.1.0b4** beta so the task & appliance completion-history feature (PR #9) is installable via HACS without a manual checkout.

## What this does
- Bumps `manifest.json` and `const.py` `PANEL_VERSION` to `0.1.0b4` (kept in sync, as the release workflow requires).
- Adds a `## [0.1.0b4]` changelog section.

**Merging this to `main` triggers the Release workflow**, which builds `home_keeper.zip`, tags `v0.1.0b4`, and publishes it as a **GitHub pre-release** — i.e. a HACS beta (only offered to users who enabled "Show beta versions").

## Verified locally
- Version matches the workflow's regex → classified as pre-release.
- `manifest.json` version == `const.py` PANEL_VERSION.
- `CHANGELOG.md` has the `## [0.1.0b4]` section (the workflow fails without it) and it extracts cleanly into release notes.
- `ci/build-panel.sh` + `ci/build-zip.sh` produce a valid `home_keeper.zip` containing the built `frontend/home-keeper-panel.js` and `manifest.json`.

Just merge when ready and the beta will publish automatically.

https://claude.ai/code/session_01YSVWQqggHgS6VJ6zeVkbNZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSVWQqggHgS6VJ6zeVkbNZ)_