### PR TITLE
Add high-fidelity deep linking and fix the panel Back button

### DIFF
--- a/.amazonq/rules/architecture-and-code.md
+++ b/.amazonq/rules/architecture-and-code.md
@@ -14,6 +14,29 @@ reviewing code in this repository (the `home_keeper` Home Assistant integration)
   built-in cards over bespoke Lovelace usage cards. Do not put management UI into
   a Lovelace card.
 
+## Panel navigation & high-fidelity deep linking
+- The panel's navigation state is **high-fidelity deep-linked**: every navigable
+  destination maps to a URL under the panel prefix (`/home-keeper`). Current
+  scheme: `/tasks` (default), `/appliances`, `/tasks/<id>`, `/appliances/<id>`
+  (asset detail lives under the `appliances` segment). Forms are ephemeral
+  overlays and are intentionally **not** deep-linked.
+- **The URL is the single source of truth.** HA hands the panel a
+  `route = { prefix, path }` for every in-panel URL change, including browser
+  Back/Forward. The `set route` setter parses `path` and is the *only* place that
+  flips `_view`/`_detail`. Never mutate `_view`/`_detail` directly to navigate —
+  that desyncs the URL and breaks Back.
+- **Navigate by changing the URL**, via the `_navigate(location, replace?)`
+  helper (`history.pushState`/`replaceState` + a bubbling `composed`
+  `location-changed` event). HA re-sets `route` in response, which flows back
+  through `set route`. Drill-in steps (open a detail) **push**; lateral moves
+  (switch tab) and detail-closing/deletes **replace**, so Back never retraces a
+  tab toggle or returns to a deleted object — and Back moves within the panel
+  instead of ejecting from it.
+- Keep route parse/build as **pure functions in `utils.ts`** (`parseRoute`,
+  `buildPath`) so they unit-test in isolation and round-trip losslessly. Unknown
+  or empty paths fall back to the tasks list; a detail URL whose id no longer
+  exists renders the "gone" notice rather than erroring.
+
 ## Pure, HA-free core
 - `recurrence.py` and `models.py` MUST NOT import anything from `homeassistant`.
   They are pure Python so they can be unit-tested without the HA test harness.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,10 @@ rules. Keep the rules and `AGENTS.md` consistent with each other.
 - Entity unique IDs are anchored to the task `id` (survives renames).
 - Per-task device-page entities are created only for tasks with a `device_id`.
 - Escape all user content before innerHTML injection in the panel (`escapeHTML`).
+- Panel navigation is high-fidelity deep-linked: every destination (tab, detail
+  page) maps to a URL under `/home-keeper`, the `route` prop is the single source
+  of truth, and Back/Forward move within the panel — never mutate view/detail
+  state directly to navigate. See `.amazonq/rules/architecture-and-code.md`.
 
 ## Cross-integration contribution (DEFERRED)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas)
 
 ## [Unreleased]
 
+- **Deep links & a working Back button in the panel.** The panel's view now lives
+  in the URL — tabs (`/home-keeper/appliances`) and detail pages
+  (`/home-keeper/tasks/<id>`) are linkable and bookmarkable, and refreshing keeps
+  your place. The browser **Back** button now steps back to the previous page
+  inside the panel (e.g. detail → list) instead of navigating away from Home
+  Keeper entirely.
+
 ## [0.1.0b5] - 2026-06-15
 
 - **Group and filter the task list.** The panel's list view gains a persisted

--- a/custom_components/home_keeper/frontend/src/panel.ts
+++ b/custom_components/home_keeper/frontend/src/panel.ts
@@ -6,14 +6,17 @@ import {
   areaName,
   assetSummary,
   brandLogoUrl,
+  buildPath,
   completionStats,
   deviceDomain,
   deviceName,
   dueLabel,
   escapeHTML,
   isOverdue,
+  parseRoute,
   recurrenceSummary,
   tasksForAsset,
+  type PanelLocation,
 } from './utils';
 
 // mdi:devices — fallback icon when a device has no resolvable brand logo.
@@ -320,6 +323,9 @@ export class HomeKeeperPanel extends HTMLElement {
   private _collapsed = new Set<string>();
   // The object whose full detail page is open, or null for the list view.
   private _detail: { kind: 'task' | 'asset'; id: string } | null = null;
+  // The panel's URL prefix (e.g. `/home-keeper`), supplied by HA via `route`.
+  // Navigation builds absolute paths from it; falls back until the first route.
+  private _routePrefix = '/home-keeper';
   private _loaded = false;
   // Live HA components that need `.hass` refreshed when hass updates.
   private _liveHassEls: Array<{ hass?: Hass }> = [];
@@ -335,6 +341,50 @@ export class HomeKeeperPanel extends HTMLElement {
   }
   get hass(): Hass | undefined {
     return this._hass;
+  }
+
+  /**
+   * HA sets `route = { prefix, path }` on the panel element for every in-panel
+   * URL change, including browser Back/Forward. We treat it as the single source
+   * of truth: derive the view/detail from the path and render. This is what makes
+   * deep links resolve and Back move within the panel instead of ejecting from it.
+   */
+  set route(route: { prefix?: string; path?: string } | undefined) {
+    if (route?.prefix) this._routePrefix = route.prefix;
+    this._applyLocation(parseRoute(route?.path));
+  }
+
+  /** Adopt a parsed location into view/detail state, rendering only on change. */
+  private _applyLocation(loc: PanelLocation): void {
+    const changed =
+      loc.view !== this._view ||
+      loc.detail?.kind !== this._detail?.kind ||
+      loc.detail?.id !== this._detail?.id;
+    if (!changed) return;
+    this._view = loc.view;
+    this._detail = loc.detail;
+    // Leaving a list/detail closes any open form (forms are ephemeral overlays).
+    this._edit = { open: false, task: null };
+    this._assetEdit = { open: false, asset: null };
+    this._render();
+  }
+
+  /**
+   * Navigate the panel by changing the URL — never by mutating view/detail
+   * directly. HA's `location-changed` listener re-sets our `route`, which flows
+   * back through `set route` so there is exactly one path into a state change.
+   * Drill-in steps push (Back-able); lateral moves (tab switch) replace.
+   */
+  private _navigate(loc: PanelLocation, replace = false): void {
+    const url = this._routePrefix + buildPath(loc);
+    history[replace ? 'replaceState' : 'pushState'](null, '', url);
+    this.dispatchEvent(
+      new CustomEvent('location-changed', {
+        detail: { replace },
+        bubbles: true,
+        composed: true,
+      }),
+    );
   }
 
   connectedCallback(): void {
@@ -379,12 +429,13 @@ export class HomeKeeperPanel extends HTMLElement {
 
   // ── detail page lifecycle ───────────────────────────────────────────────────
   private _openDetail(kind: 'task' | 'asset', id: string): void {
-    this._detail = { kind, id };
-    this._render();
+    // Drilling in is a Back-able step: push.
+    this._navigate({ view: kind === 'asset' ? 'appliances' : 'tasks', detail: { kind, id } });
   }
   private _closeDetail(): void {
-    this._detail = null;
-    this._render();
+    // Return to the list this detail belongs to, collapsing the detail entry so
+    // browser Back from the list continues past it rather than re-opening it.
+    this._navigate({ view: this._view, detail: null }, true);
   }
 
   private async _init(): Promise<void> {
@@ -1474,7 +1525,9 @@ export class HomeKeeperPanel extends HTMLElement {
       root.querySelector('.d-done')?.addEventListener('click', () => void this._complete(task));
       root.querySelector('.d-edit')?.addEventListener('click', () => this._openEdit(task));
       root.querySelector('.d-del')?.addEventListener('click', () => {
-        this._detail = null;
+        // The detail is about to vanish: replace it with its list so Forward
+        // can't return to a deleted task.
+        this._navigate({ view: 'tasks', detail: null }, true);
         void this._delete(task);
       });
       return;
@@ -1483,15 +1536,18 @@ export class HomeKeeperPanel extends HTMLElement {
     if (!asset) return;
     root.querySelector('.d-edit')?.addEventListener('click', () => this._openEditAsset(asset));
     root.querySelector('.d-del')?.addEventListener('click', () => {
-      this._detail = null;
+      // The detail is about to vanish: replace it with its list so Forward
+      // can't return to a deleted appliance.
+      this._navigate({ view: 'appliances', detail: null }, true);
       void this._deleteAsset(asset);
     });
   }
 
   private _switchView(view: 'tasks' | 'appliances'): void {
     if (this._view === view) return;
-    this._view = view;
-    this._render();
+    // Switching tabs is a lateral move, not a drill-in: replace so Back doesn't
+    // retrace every tab toggle.
+    this._navigate({ view, detail: null }, true);
   }
 
   private _makeForm(

--- a/custom_components/home_keeper/frontend/src/utils.ts
+++ b/custom_components/home_keeper/frontend/src/utils.ts
@@ -85,6 +85,52 @@ export function areaName(
   return areas?.[areaId]?.name || areaId;
 }
 
+// ── panel routing ────────────────────────────────────────────────────────────
+
+/** The navigable list view; mirrors the panel's two tabs. */
+export type PanelView = 'tasks' | 'appliances';
+
+/**
+ * A fully-resolved panel location: which tab is shown and, optionally, the
+ * detail page open on top of it. This is the panel's entire navigation state —
+ * it round-trips losslessly with the URL via {@link parseRoute} / {@link buildPath}
+ * so the URL can be the single source of truth (high-fidelity deep linking).
+ */
+export interface PanelLocation {
+  view: PanelView;
+  detail: { kind: 'task' | 'asset'; id: string } | null;
+}
+
+/**
+ * Parse the panel's route path (the part after the `/home-keeper` prefix that HA
+ * hands the panel) into a {@link PanelLocation}. Unknown/empty paths fall back to
+ * the tasks list. The asset detail lives under the `appliances` segment but keeps
+ * the internal `asset` kind.
+ */
+export function parseRoute(path: string | undefined | null): PanelLocation {
+  const parts = String(path ?? '')
+    .split('/')
+    .map((p) => p.trim())
+    .filter(Boolean);
+  const view: PanelView = parts[0] === 'appliances' ? 'appliances' : 'tasks';
+  if (parts[1]) {
+    const kind = view === 'appliances' ? 'asset' : 'task';
+    return { view, detail: { kind, id: decodeURIComponent(parts[1]) } };
+  }
+  return { view, detail: null };
+}
+
+/**
+ * Build the route path (under the panel prefix) for a {@link PanelLocation} —
+ * the inverse of {@link parseRoute}. The detail page's URL segment derives from
+ * the view, so a task detail is `/tasks/<id>` and an asset detail is
+ * `/appliances/<id>`.
+ */
+export function buildPath(loc: PanelLocation): string {
+  if (loc.detail) return `/${loc.view}/${encodeURIComponent(loc.detail.id)}`;
+  return `/${loc.view}`;
+}
+
 // ── completion history ───────────────────────────────────────────────────────
 
 /** Parsed, valid completion timestamps sorted newest-first. */

--- a/custom_components/home_keeper/frontend/test/utils.test.js
+++ b/custom_components/home_keeper/frontend/test/utils.test.js
@@ -13,6 +13,8 @@ import {
   completionStats,
   taskRelatesToAsset,
   tasksForAsset,
+  parseRoute,
+  buildPath,
 } from '../src/utils.ts';
 
 describe('escapeHTML', () => {
@@ -214,5 +216,58 @@ describe('taskRelatesToAsset / tasksForAsset', () => {
       { id: 'c', name: 'c', source: { part: { asset_id: 'asset1', part_id: 'p' } } },
     ];
     expect(tasksForAsset(asset, tasks).map((t) => t.id)).toEqual(['a', 'c']);
+  });
+});
+
+describe('parseRoute', () => {
+  it('defaults empty/unknown paths to the tasks list', () => {
+    for (const p of ['', '/', undefined, null, '/bogus']) {
+      expect(parseRoute(p)).toEqual({ view: 'tasks', detail: null });
+    }
+  });
+  it('parses the appliances list', () => {
+    expect(parseRoute('/appliances')).toEqual({ view: 'appliances', detail: null });
+  });
+  it('parses a task detail', () => {
+    expect(parseRoute('/tasks/abc')).toEqual({
+      view: 'tasks',
+      detail: { kind: 'task', id: 'abc' },
+    });
+  });
+  it('parses an asset detail under the appliances segment', () => {
+    expect(parseRoute('/appliances/xyz')).toEqual({
+      view: 'appliances',
+      detail: { kind: 'asset', id: 'xyz' },
+    });
+  });
+  it('decodes percent-encoded ids and tolerates trailing slashes', () => {
+    expect(parseRoute('/tasks/a%2Fb/')).toEqual({
+      view: 'tasks',
+      detail: { kind: 'task', id: 'a/b' },
+    });
+  });
+});
+
+describe('buildPath', () => {
+  it('builds list paths', () => {
+    expect(buildPath({ view: 'tasks', detail: null })).toBe('/tasks');
+    expect(buildPath({ view: 'appliances', detail: null })).toBe('/appliances');
+  });
+  it('builds detail paths and encodes the id', () => {
+    expect(buildPath({ view: 'tasks', detail: { kind: 'task', id: 'a/b' } })).toBe('/tasks/a%2Fb');
+    expect(buildPath({ view: 'appliances', detail: { kind: 'asset', id: 'x' } })).toBe(
+      '/appliances/x',
+    );
+  });
+  it('round-trips with parseRoute', () => {
+    const locs = [
+      { view: 'tasks', detail: null },
+      { view: 'appliances', detail: null },
+      { view: 'tasks', detail: { kind: 'task', id: 'task-1' } },
+      { view: 'appliances', detail: { kind: 'asset', id: 'asset-9' } },
+    ];
+    for (const loc of locs) {
+      expect(parseRoute(buildPath(loc))).toEqual(loc);
+    }
   });
 });

--- a/tests/e2e/tests/smoke.spec.ts
+++ b/tests/e2e/tests/smoke.spec.ts
@@ -149,7 +149,59 @@ test.describe('Home Keeper panel — smoke', () => {
     expect(errors, `panel errors:\n${errors.join('\n')}`).toHaveLength(0);
   });
 
-  test('native to-do + calendar cards render on the dashboard', async ({ page }) => {
+});
+
+test.describe('Home Keeper panel — deep linking & Back', () => {
+  test('opening a detail page reflects in the URL', async ({ page }) => {
+    await openPanel(page);
+    const panel = page.locator('home-keeper-panel').first();
+    await panel.locator('.detail-open[data-detail-id="task_fridge_filter"]').click();
+    await expect(panel.locator('#back-btn')).toBeVisible();
+    await expect(page).toHaveURL(/\/home-keeper\/tasks\/task_fridge_filter$/);
+  });
+
+  test('a task detail URL deep-links straight to the detail page', async ({ page }) => {
+    const errors = trackPanelErrors(page);
+    await page.goto('/home-keeper/tasks/task_fridge_filter', { waitUntil: 'domcontentloaded' });
+    const panel = page.locator('home-keeper-panel').first();
+    await panel.waitFor({ state: 'attached', timeout: 45_000 });
+    // Lands on the detail page (Back button present), not the list.
+    await expect(panel.locator('#back-btn')).toBeVisible();
+    await expect(panel.locator('.hk-hist-list li').first()).toBeVisible();
+    expect(errors, `panel errors:\n${errors.join('\n')}`).toHaveLength(0);
+  });
+
+  test('the appliances tab is deep-linkable', async ({ page }) => {
+    await page.goto('/home-keeper/appliances', { waitUntil: 'domcontentloaded' });
+    const panel = page.locator('home-keeper-panel').first();
+    await panel.waitFor({ state: 'attached', timeout: 45_000 });
+    await expect(panel.locator('.hk-name')).toContainText(['Garage water heater']);
+  });
+
+  test('browser Back returns to the list, not out of the panel', async ({ page }) => {
+    await openPanel(page);
+    const panel = page.locator('home-keeper-panel').first();
+    await panel.locator('.detail-open[data-detail-id="task_fridge_filter"]').click();
+    await expect(panel.locator('#back-btn')).toBeVisible();
+    // The browser Back button steps back to the list inside the panel.
+    await page.goBack();
+    await expect(page).toHaveURL(/\/home-keeper(\/tasks)?$/);
+    await expect(panel.locator('#tab-tasks')).toBeVisible();
+    await expect(panel.locator('#back-btn')).toHaveCount(0);
+  });
+
+  test('the in-panel Back button returns to the list', async ({ page }) => {
+    await openPanel(page);
+    const panel = page.locator('home-keeper-panel').first();
+    await panel.locator('.detail-open[data-detail-id="task_fridge_filter"]').click();
+    await panel.locator('#back-btn').click();
+    await expect(panel.locator('#tab-tasks')).toBeVisible();
+    await expect(panel.locator('#back-btn')).toHaveCount(0);
+  });
+});
+
+test.describe('Home Keeper panel — dashboard', () => {
+  test('native to-do + calendar cards still render on the dashboard', async ({ page }) => {
     await openDashboard(page);
     await expect(page.locator('hui-todo-list-card, todo-list-card').first()).toBeVisible({
       timeout: 30_000,


### PR DESCRIPTION
## Problem

The panel kept all navigation state (active tab, open detail page) in instance
fields that never touched the URL or browser history. So nothing was
deep-linkable, refreshing lost your place, and — the reported bug — **the
browser Back button ejected you from Home Keeper entirely** instead of stepping
back to the previous in-panel page, because the panel never pushed any history
entries.

## Approach

Make the **URL the single source of truth** for panel navigation (high-fidelity
deep linking).

- **URL scheme** under the `/home-keeper` prefix: `/tasks` (default),
  `/appliances`, `/tasks/<id>`, `/appliances/<id>` (asset detail under the
  `appliances` segment). Forms stay ephemeral overlays and are intentionally
  *not* deep-linked.
- **`utils.ts`** — pure `parseRoute` / `buildPath` (round-trip tested). Unknown
  / empty paths fall back to the tasks list.
- **`panel.ts`** — a `set route` setter parses HA's `route.path` and is the only
  place that flips `_view`/`_detail`, so it handles deep links and Back/Forward.
  A single `_navigate(loc, replace?)` helper changes the URL
  (`pushState`/`replaceState` + a bubbling `location-changed` event); drill-in
  steps **push**, tab switches and detail close/delete **replace** so Back never
  retraces a tab toggle or returns to a deleted object.
- Documented the convention in `.amazonq/rules/architecture-and-code.md` and
  `AGENTS.md`.

## Behavior

- Tabs and detail pages are linkable, bookmarkable, and refresh-safe.
- Browser Back (and the in-panel `‹ Back` button) now go detail → list, staying
  inside the panel.

## Tests

- Unit (`vitest`): `parseRoute`/`buildPath` parse + round-trip — **78 passed**.
- e2e (Playwright): opening a detail updates the URL; a detail URL deep-links
  straight to the detail page; the appliances tab is deep-linkable; browser Back
  and the in-panel Back button both return to the list without leaving the panel
  — **15 passed**.

No screenshots: this is a navigation/behavior change with no visual diff to the
panel itself (the change is in the URL bar and Back behavior, exercised by the
e2e tests above).

https://claude.ai/code/session_01H88vYQf3MCE56ZH1hSVqUS

---
_Generated by [Claude Code](https://claude.ai/code/session_01H88vYQf3MCE56ZH1hSVqUS)_