### PR TITLE
Fix code-review findings: stock tracking + inventory export

### DIFF
--- a/custom_components/home_keeper/__init__.py
+++ b/custom_components/home_keeper/__init__.py
@@ -82,6 +82,8 @@ _PART_SCHEMA = vol.Schema(
         vol.Optional("replace_interval"): vol.Coerce(int),
         vol.Optional("replace_unit"): cv.string,
         vol.Optional("last_replaced"): cv.string,
+        vol.Optional("stock"): vol.Coerce(int),
+        vol.Optional("reorder_at"): vol.Coerce(int),
     }
 )
 

--- a/custom_components/home_keeper/assets.py
+++ b/custom_components/home_keeper/assets.py
@@ -234,28 +234,22 @@ def _normalize_parts(value: Any) -> list[dict]:
     return parts
 
 
-# Part fields the backend owns and keeps across an edit when the caller omits them:
-# ``last_replaced`` is stamped on completion, and ``stock``/``reorder_at`` are
-# maintained by stock adjustments, so a partial update (e.g. a service call that
-# resubmits a part without them) must not silently wipe them.
-_PRESERVED_PART_FIELDS = ("last_replaced", "stock", "reorder_at")
-
-
 def _merge_parts(existing: list[dict], incoming: list[dict]) -> list[dict]:
-    """Carry backend-managed part fields across an edit.
+    """Carry the backend-managed ``last_replaced`` across an edit.
 
-    The panel submits the full parts list; for parts that already exist (matched by
-    ``id``) we keep the stored backend-managed values (see ``_PRESERVED_PART_FIELDS``)
-    unless the caller explicitly set them.
+    The panel submits the full parts list but never exposes ``last_replaced`` (it is
+    stamped on completion), so for parts that already exist (matched by ``id``) we
+    keep the stored value unless the caller explicitly set it. ``stock``/``reorder_at``
+    are ordinary user-editable fields — incoming wins, including a ``None`` that clears
+    them — so they are intentionally *not* preserved here (otherwise stock tracking
+    could never be switched back off).
     """
     by_id = {p["id"]: p for p in existing}
     merged: list[dict] = []
     for part in incoming:
         prior = by_id.get(part["id"])
-        if prior:
-            for key in _PRESERVED_PART_FIELDS:
-                if part.get(key) is None and prior.get(key) is not None:
-                    part = {**part, key: prior.get(key)}
+        if prior and part.get("last_replaced") is None:
+            part = {**part, "last_replaced": prior.get("last_replaced")}
         merged.append(part)
     return merged
 
@@ -270,25 +264,30 @@ def part_is_low(part: dict) -> bool:
 def consume_part_stock(part: dict) -> bool:
     """Decrement a part's on-hand ``stock`` by one (never below zero).
 
-    A no-op for parts that don't track stock. Returns ``True`` when the part is now
-    at or below its reorder threshold, so the caller can emit a low-stock signal.
+    A no-op for parts that don't track stock. Returns ``True`` only when this
+    consumption *crosses* the part from not-low into low (edge-triggered), so the
+    caller emits one low-stock signal per crossing rather than on every step while
+    already low.
     """
     stock = part.get("stock")
     if stock is None:
         return False
+    was_low = part_is_low(part)
     part["stock"] = max(0, int(stock) - 1)
-    return part_is_low(part)
+    return part_is_low(part) and not was_low
 
 
 def adjust_part_stock(part: dict, delta: int) -> bool:
     """Adjust a part's on-hand ``stock`` by ``delta`` (clamped at zero).
 
-    Begins tracking from zero for a previously untracked part. Returns ``True`` when
-    the part is now at or below its reorder threshold.
+    Begins tracking from zero for a previously untracked part. Returns ``True`` only
+    when the adjustment *crosses* the part from not-low into low (edge-triggered); a
+    restock, or a decrease while already low, returns ``False``.
     """
+    was_low = part_is_low(part)
     current = part.get("stock") or 0
     part["stock"] = max(0, int(current) + int(delta))
-    return part_is_low(part)
+    return part_is_low(part) and not was_low
 
 
 def normalize_fields(data: dict) -> dict:

--- a/custom_components/home_keeper/frontend/src/locales/ca.json
+++ b/custom_components/home_keeper/frontend/src/locales/ca.json
@@ -1,6 +1,7 @@
 {
   "app.title": "Home Keeper",
   "btn.exportInventory": "Exporta l'inventari",
+  "error.exportFailed": "Ha fallat l'exportació de l'inventari",
   "field.stock": "Estoc",
   "field.reorder_at": "Reordena a",
   "part.inStock": "En estoc: {n}",

--- a/custom_components/home_keeper/frontend/src/locales/cs.json
+++ b/custom_components/home_keeper/frontend/src/locales/cs.json
@@ -1,6 +1,7 @@
 {
   "app.title": "Home Keeper",
   "btn.exportInventory": "Exportovat inventář",
+  "error.exportFailed": "Export inventáře selhal",
   "field.stock": "Zásoba",
   "field.reorder_at": "Objednat při",
   "part.inStock": "Skladem: {n}",

--- a/custom_components/home_keeper/frontend/src/locales/da.json
+++ b/custom_components/home_keeper/frontend/src/locales/da.json
@@ -1,6 +1,7 @@
 {
   "app.title": "Home Keeper",
   "btn.exportInventory": "Eksportér inventar",
+  "error.exportFailed": "Eksport af inventar mislykkedes",
   "field.stock": "Lager",
   "field.reorder_at": "Bestil ved",
   "part.inStock": "På lager: {n}",

--- a/custom_components/home_keeper/frontend/src/locales/de.json
+++ b/custom_components/home_keeper/frontend/src/locales/de.json
@@ -1,6 +1,7 @@
 {
   "app.title": "Home Keeper",
   "btn.exportInventory": "Inventar exportieren",
+  "error.exportFailed": "Inventarexport fehlgeschlagen",
   "field.stock": "Bestand",
   "field.reorder_at": "Nachbestellen bei",
   "part.inStock": "Auf Lager: {n}",

--- a/custom_components/home_keeper/frontend/src/locales/en.json
+++ b/custom_components/home_keeper/frontend/src/locales/en.json
@@ -1,6 +1,7 @@
 {
   "app.title": "Home Keeper",
   "btn.exportInventory": "Export inventory",
+  "error.exportFailed": "Inventory export failed",
   "field.stock": "Stock",
   "field.reorder_at": "Reorder at",
   "part.inStock": "In stock: {n}",

--- a/custom_components/home_keeper/frontend/src/locales/es.json
+++ b/custom_components/home_keeper/frontend/src/locales/es.json
@@ -1,6 +1,7 @@
 {
   "app.title": "Home Keeper",
   "btn.exportInventory": "Exportar inventario",
+  "error.exportFailed": "Error al exportar el inventario",
   "field.stock": "Existencias",
   "field.reorder_at": "Reordenar en",
   "part.inStock": "En existencias: {n}",

--- a/custom_components/home_keeper/frontend/src/locales/fi.json
+++ b/custom_components/home_keeper/frontend/src/locales/fi.json
@@ -1,6 +1,7 @@
 {
   "app.title": "Home Keeper",
   "btn.exportInventory": "Vie luettelo",
+  "error.exportFailed": "Luettelon vienti epäonnistui",
   "field.stock": "Varasto",
   "field.reorder_at": "Tilausraja",
   "part.inStock": "Varastossa: {n}",

--- a/custom_components/home_keeper/frontend/src/locales/fr.json
+++ b/custom_components/home_keeper/frontend/src/locales/fr.json
@@ -1,6 +1,7 @@
 {
   "app.title": "Home Keeper",
   "btn.exportInventory": "Exporter l'inventaire",
+  "error.exportFailed": "Échec de l'export de l'inventaire",
   "field.stock": "Stock",
   "field.reorder_at": "Réapprovisionner à",
   "part.inStock": "En stock : {n}",

--- a/custom_components/home_keeper/frontend/src/locales/it.json
+++ b/custom_components/home_keeper/frontend/src/locales/it.json
@@ -1,6 +1,7 @@
 {
   "app.title": "Home Keeper",
   "btn.exportInventory": "Esporta inventario",
+  "error.exportFailed": "Esportazione inventario non riuscita",
   "field.stock": "Scorte",
   "field.reorder_at": "Riordina a",
   "part.inStock": "Disponibili: {n}",

--- a/custom_components/home_keeper/frontend/src/locales/nb.json
+++ b/custom_components/home_keeper/frontend/src/locales/nb.json
@@ -1,6 +1,7 @@
 {
   "app.title": "Home Keeper",
   "btn.exportInventory": "Eksporter inventar",
+  "error.exportFailed": "Eksport av inventar mislyktes",
   "field.stock": "Lager",
   "field.reorder_at": "Bestill ved",
   "part.inStock": "På lager: {n}",

--- a/custom_components/home_keeper/frontend/src/locales/nl.json
+++ b/custom_components/home_keeper/frontend/src/locales/nl.json
@@ -1,6 +1,7 @@
 {
   "app.title": "Home Keeper",
   "btn.exportInventory": "Inventaris exporteren",
+  "error.exportFailed": "Inventaris exporteren mislukt",
   "field.stock": "Voorraad",
   "field.reorder_at": "Bijbestellen bij",
   "part.inStock": "Op voorraad: {n}",

--- a/custom_components/home_keeper/frontend/src/locales/pl.json
+++ b/custom_components/home_keeper/frontend/src/locales/pl.json
@@ -1,6 +1,7 @@
 {
   "app.title": "Home Keeper",
   "btn.exportInventory": "Eksportuj inwentarz",
+  "error.exportFailed": "Eksport inwentarza nie powiódł się",
   "field.stock": "Zapas",
   "field.reorder_at": "Zamów przy",
   "part.inStock": "W magazynie: {n}",

--- a/custom_components/home_keeper/frontend/src/locales/pt-BR.json
+++ b/custom_components/home_keeper/frontend/src/locales/pt-BR.json
@@ -1,6 +1,7 @@
 {
   "app.title": "Home Keeper",
   "btn.exportInventory": "Exportar inventário",
+  "error.exportFailed": "Falha ao exportar inventário",
   "field.stock": "Estoque",
   "field.reorder_at": "Reabastecer em",
   "part.inStock": "Em estoque: {n}",

--- a/custom_components/home_keeper/frontend/src/locales/ru.json
+++ b/custom_components/home_keeper/frontend/src/locales/ru.json
@@ -1,6 +1,7 @@
 {
   "app.title": "Home Keeper",
   "btn.exportInventory": "Экспортировать опись",
+  "error.exportFailed": "Не удалось экспортировать опись",
   "field.stock": "Запас",
   "field.reorder_at": "Заказ при",
   "part.inStock": "В наличии: {n}",

--- a/custom_components/home_keeper/frontend/src/locales/sv.json
+++ b/custom_components/home_keeper/frontend/src/locales/sv.json
@@ -1,6 +1,7 @@
 {
   "app.title": "Home Keeper",
   "btn.exportInventory": "Exportera inventering",
+  "error.exportFailed": "Export av inventering misslyckades",
   "field.stock": "Lager",
   "field.reorder_at": "Beställ vid",
   "part.inStock": "I lager: {n}",

--- a/custom_components/home_keeper/frontend/src/locales/zh-Hans.json
+++ b/custom_components/home_keeper/frontend/src/locales/zh-Hans.json
@@ -1,6 +1,7 @@
 {
   "app.title": "Home Keeper",
   "btn.exportInventory": "导出清单",
+  "error.exportFailed": "清单导出失败",
   "field.stock": "库存",
   "field.reorder_at": "补货阈值",
   "part.inStock": "库存：{n}",

--- a/custom_components/home_keeper/frontend/src/panel.ts
+++ b/custom_components/home_keeper/frontend/src/panel.ts
@@ -600,7 +600,19 @@ export class HomeKeeperPanel extends HTMLElement {
       this._downloadFile(`home-keeper-inventory-${stamp}.csv`, csv, 'text/csv');
     } catch (err) {
       console.error('home-keeper: inventory export failed', err);
+      this._toast(t('error.exportFailed'));
     }
+  }
+
+  /** Surface a transient message via HA's toast notification. */
+  private _toast(message: string): void {
+    this.dispatchEvent(
+      new CustomEvent('hass-notification', {
+        detail: { message },
+        bubbles: true,
+        composed: true,
+      }),
+    );
   }
 
   /** Trigger a client-side file download (no server round-trip for the blob). */
@@ -610,8 +622,13 @@ export class HomeKeeperPanel extends HTMLElement {
     const a = document.createElement('a');
     a.href = url;
     a.download = filename;
+    a.style.display = 'none';
+    document.body.appendChild(a);
     a.click();
-    URL.revokeObjectURL(url);
+    a.remove();
+    // Defer revoke a tick so the download isn't cancelled in browsers that read the
+    // blob URL asynchronously after click().
+    setTimeout(() => URL.revokeObjectURL(url), 0);
   }
 
   // ── completion history ──────────────────────────────────────────────────────

--- a/custom_components/home_keeper/inventory.py
+++ b/custom_components/home_keeper/inventory.py
@@ -62,7 +62,10 @@ def build_inventory(
     total_spares = 0.0
     for asset in assets:
         parts = asset.get("parts") or []
-        spares_value = round(sum(_spares_value(p) for p in parts), 2)
+        # Accumulate the raw spares sum into the total (round once at the end), so the
+        # grand total can't drift a cent from re-rounding already-rounded rows.
+        raw_spares = sum(_spares_value(p) for p in parts)
+        spares_value = round(raw_spares, 2)
         cost = asset.get("cost")
         area_id = asset.get("area_id")
         rows.append(
@@ -86,7 +89,7 @@ def build_inventory(
             }
         )
         total_cost += _num(cost)
-        total_spares += spares_value
+        total_spares += raw_spares
     rows.sort(key=lambda r: (r["name"] or "").lower())
     totals = {
         "asset_count": len(rows),
@@ -114,7 +117,19 @@ _CSV_COLUMNS = (
 
 
 def _cell(value: Any) -> str:
-    return "" if value is None else str(value)
+    """Stringify a CSV cell, neutralizing spreadsheet formula injection.
+
+    A cell that a spreadsheet would treat as a formula (leading ``= + - @`` or a
+    leading tab/CR) is prefixed with an apostrophe so Excel/Sheets/LibreOffice show
+    it as literal text rather than evaluating it. Our numeric columns are
+    non-negative, so this never mangles a real number.
+    """
+    if value is None:
+        return ""
+    text = str(value)
+    if text and text[0] in "=+-@\t\r":
+        return "'" + text
+    return text
 
 
 def inventory_to_csv(inventory: dict[str, Any]) -> str:

--- a/custom_components/home_keeper/store.py
+++ b/custom_components/home_keeper/store.py
@@ -360,18 +360,19 @@ class HomeKeeperStore:
     ) -> dict[str, Any]:
         """Change a part's on-hand spare count by ``delta`` (clamped at zero).
 
-        Persists and, when a *decrease* drops the part to/below its reorder
-        threshold, fires the low-stock event (a restock never nags). Returns the
-        updated asset. Raises ``KeyError`` for an unknown asset or part.
+        Persists and, when the adjustment crosses the part from not-low into low,
+        fires the low-stock event once (a restock, or a decrease while already low,
+        never nags). Returns the updated asset. Raises ``KeyError`` for an unknown
+        asset or part.
         """
         asset = self._assets.get(asset_id)
         if asset is None:
             raise KeyError(asset_id)
         for part in asset.get("parts", []):
             if part.get("id") == part_id:
-                low = assets.adjust_part_stock(part, delta)
+                crossed_low = assets.adjust_part_stock(part, delta)
                 await self._save()
-                if low and delta < 0:
+                if crossed_low:
                     self._emit_low_stock(asset, part)
                 return asset
         raise KeyError(part_id)

--- a/tests/integration/ha_config/configuration.yaml
+++ b/tests/integration/ha_config/configuration.yaml
@@ -36,6 +36,9 @@ input_text:
   hk_last_completed_origin:
     name: HK last completed origin
     max: 255
+  hk_last_low_stock_part:
+    name: HK last low-stock part
+    max: 255
 
 automation:
   - alias: Capture Home Keeper task completed
@@ -53,6 +56,16 @@ automation:
           entity_id: input_text.hk_last_completed_origin
         data:
           value: "{{ trigger.event.data.origin if trigger.event.data.origin is not none else 'none' }}"
+  - alias: Capture Home Keeper part low stock
+    trigger:
+      - platform: event
+        event_type: home_keeper_part_low_stock
+    action:
+      - service: input_text.set_value
+        target:
+          entity_id: input_text.hk_last_low_stock_part
+        data:
+          value: "{{ trigger.event.data.part_id }}@{{ trigger.event.data.stock }}"
 
 # Minimal logging
 logger:

--- a/tests/integration/test_assets.py
+++ b/tests/integration/test_assets.py
@@ -477,3 +477,67 @@ def test_adjust_part_stock_rejects_unknown_part(ha):
         json={"asset_id": wh["id"], "part_id": "no_such_part", "delta": 1},
     )
     assert r.status_code >= 400, "expected rejection for an unknown part_id"
+
+
+def test_add_asset_service_accepts_part_stock(ha):
+    # Regression: the add/update_asset service schema must accept stock/reorder_at on
+    # parts (the websocket path always did) — otherwise the documented service errors.
+    call_service(
+        ha,
+        "home_keeper",
+        "add_asset",
+        {
+            "name": "Stocked widget",
+            "parts": [
+                {"name": "Spare", "type": "consumable", "stock": 4, "reorder_at": 1}
+            ],
+        },
+    )
+    asset = next(a for a in _assets(ha) if a["name"] == "Stocked widget")
+    part = asset["parts"][0]
+    assert part["stock"] == 4 and part["reorder_at"] == 1
+    call_service(ha, "home_keeper", "delete_asset", {"asset_id": asset["id"]})
+
+
+def test_low_stock_event_fires_on_crossing_not_on_restock(ha):
+    # A `home_keeper_part_low_stock` event must fire once when stock crosses from
+    # not-low into low, and NOT on a restock. A configuration.yaml automation mirrors
+    # the event into input_text.hk_last_low_stock_part as "<part_id>@<stock>".
+    import time
+
+    from conftest import get_state
+
+    wh = _water_heater(ha)
+    pid = next(p for p in wh["parts"] if p["name"] == "Anode rod")["id"]
+    sentinel = "input_text.hk_last_low_stock_part"
+
+    def _reset():
+        call_service(ha, "input_text", "set_value",
+                     {"entity_id": sentinel, "value": "none"})
+
+    def _captured():
+        st = get_state(ha, sentinel)
+        return st["state"] if st else None
+
+    # Restock well above the threshold (reorder_at=2) so the next drop is a crossing.
+    call_service(ha, "home_keeper", "adjust_part_stock",
+                 {"asset_id": wh["id"], "part_id": pid, "delta": 10})
+    _reset()
+    # Drop across the threshold to zero -> exactly one low-stock event for this part.
+    call_service(ha, "home_keeper", "adjust_part_stock",
+                 {"asset_id": wh["id"], "part_id": pid, "delta": -100})
+    deadline = time.monotonic() + 10
+    captured = None
+    while time.monotonic() < deadline:
+        captured = _captured()
+        if captured and captured != "none":
+            break
+        time.sleep(0.5)
+    assert captured == f"{pid}@0", f"expected a low-stock event for {pid}, got {captured!r}"
+
+    # A restock that leaves the part not-low must NOT re-fire the event.
+    _reset()
+    call_service(ha, "home_keeper", "adjust_part_stock",
+                 {"asset_id": wh["id"], "part_id": pid, "delta": 10})
+    time.sleep(2)
+    assert _captured() == "none", "a restock must not fire a low-stock event"

--- a/tests/unit/test_assets.py
+++ b/tests/unit/test_assets.py
@@ -351,19 +351,23 @@ def test_part_is_low():
     assert a.part_is_low({"stock": 0, "reorder_at": None}) is False
 
 
-def test_consume_part_stock_decrements_and_flags_low():
+def test_consume_part_stock_flags_low_only_on_crossing():
     part = {"stock": 3, "reorder_at": 1}
     # 3 -> 2, still above the threshold of 1.
     assert a.consume_part_stock(part) is False
     assert part["stock"] == 2
-    # 2 -> 1 lands on the threshold, which counts as low.
+    # 2 -> 1 crosses from not-low into low.
     assert a.consume_part_stock(part) is True
     assert part["stock"] == 1
+    # 1 -> 0, already low: edge-triggered, so no repeat signal.
+    assert a.consume_part_stock(part) is False
+    assert part["stock"] == 0
 
 
-def test_consume_part_stock_floors_at_zero():
+def test_consume_part_stock_floors_at_zero_without_refiring():
+    # Already low (and at zero): consuming again clamps at zero and does not re-fire.
     part = {"stock": 0, "reorder_at": 0}
-    assert a.consume_part_stock(part) is True
+    assert a.consume_part_stock(part) is False
     assert part["stock"] == 0
 
 
@@ -389,16 +393,47 @@ def test_adjust_part_stock_begins_tracking_from_zero():
     assert part["stock"] == 2
 
 
-def test_merge_update_preserves_part_stock():
+def test_adjust_part_stock_no_refire_while_already_low():
+    # Decreasing while already low must not re-signal (edge-triggered).
+    part = {"stock": 1, "reorder_at": 2}
+    assert a.adjust_part_stock(part, -1) is False
+    assert part["stock"] == 0
+    # Restocking back up to/below the threshold also doesn't signal.
+    assert a.adjust_part_stock(part, 2) is False
+    assert part["stock"] == 2
+
+
+def test_merge_update_clears_part_stock_when_omitted():
+    # stock/reorder_at are ordinary editable fields: a resubmit that omits them
+    # clears the tracking (so the user can switch it back off), while the
+    # backend-managed last_replaced is still preserved.
+    asset = a.build_asset(
+        {
+            "name": "Furnace",
+            "parts": [{"name": "Filter", "stock": 3, "reorder_at": 1}],
+        },
+        now=NOW,
+    )
+    pid = asset["parts"][0]["id"]
+    asset["parts"][0]["last_replaced"] = "2025-01-01"  # backend completion stamp
+    updated = a.merge_update(
+        asset, {"parts": [{"id": pid, "name": "Filter"}]}, now=NOW
+    )
+    assert updated["parts"][0]["stock"] is None
+    assert updated["parts"][0]["reorder_at"] is None
+    assert updated["parts"][0]["last_replaced"] == "2025-01-01"
+
+
+def test_merge_update_sets_part_stock_from_incoming():
     asset = a.build_asset(
         {"name": "Furnace", "parts": [{"name": "Filter", "stock": 3, "reorder_at": 1}]},
         now=NOW,
     )
     pid = asset["parts"][0]["id"]
-    asset["parts"][0]["stock"] = 1  # simulate a completion having consumed spares
-    # The panel re-submits the part without stock/reorder_at; merge must keep them.
     updated = a.merge_update(
-        asset, {"parts": [{"id": pid, "name": "Filter"}]}, now=NOW
+        asset,
+        {"parts": [{"id": pid, "name": "Filter", "stock": 5, "reorder_at": 2}]},
+        now=NOW,
     )
-    assert updated["parts"][0]["stock"] == 1
-    assert updated["parts"][0]["reorder_at"] == 1
+    assert updated["parts"][0]["stock"] == 5
+    assert updated["parts"][0]["reorder_at"] == 2

--- a/tests/unit/test_inventory.py
+++ b/tests/unit/test_inventory.py
@@ -144,3 +144,26 @@ def test_csv_has_header_rows_and_total():
     assert total[0] == "TOTAL"
     assert total[-2] == "150.0"
     assert total[-1] == "10.0"
+
+
+def test_csv_neutralizes_formula_injection():
+    # A field a spreadsheet would treat as a formula is prefixed with ' so it renders
+    # as literal text (CSV/formula injection guard).
+    report = inv.build_inventory(
+        [_asset(id="1", name="=HYPERLINK(\"http://evil\")", manufacturer="@SUM(A1)")]
+    )
+    text = inv.inventory_to_csv(report)
+    row = next(r for r in csv.reader(io.StringIO(text)) if r and r[0].endswith("evil\")"))
+    assert row[0].startswith("'="), "a formula-like name must be prefixed with an apostrophe"
+    assert row[2].startswith("'@"), "a formula-like manufacturer must be neutralized"
+
+
+def test_spares_total_does_not_drift_from_per_row_rounding():
+    # Per-row spares are rounded for display, but the grand total accumulates the raw
+    # values and rounds once, so it can't drift from summing rounded rows.
+    a = _asset(id="1", name="A", cost=0.0, parts=[{"name": "p", "cost": 0.005, "stock": 1}])
+    b = _asset(id="2", name="B", cost=0.0, parts=[{"name": "q", "cost": 0.005, "stock": 1}])
+    report = inv.build_inventory([a, b])
+    # Each row rounds 0.005 -> 0.01 (banker's rounding may give 0.0), but the total is
+    # round(0.005 + 0.005) == 0.01 regardless.
+    assert report["totals"]["spares_value"] == 0.01


### PR DESCRIPTION
Follow-up to #13 addressing all findings from the critical code review (the subagent's report + my validation).

## High
- **Services rejected `stock`/`reorder_at` on parts.** `__init__.py` `_PART_SCHEMA` (default `PREVENT_EXTRA`) omitted the two fields, so `home_keeper.add_asset`/`update_asset` errored when a part carried stock — while the websocket path accepted them and `services.yaml` advertised them. Added both as optional coerced ints. Integration test added.
- **CSV formula injection in the inventory export.** `inventory._cell` now prefixes a cell starting with `= + - @ \t \r` with an apostrophe so spreadsheets render it as literal text. Our numeric columns are non-negative, so real numbers are untouched. Unit test added.

## Medium
- **Stock couldn't be un-tracked.** `_merge_parts` no longer preserves `stock`/`reorder_at` on omit (only `last_replaced` stays backend-managed), so clearing the field actually clears tracking. Incoming wins. Tests updated.
- **Low-stock event was level-triggered.** `consume_part_stock`/`adjust_part_stock` now return `True` only on the not-low→low **crossing**, so the event fires once per crossing — not on every decrement while already low, and not on restock. Store firing simplified accordingly. Unit tests updated + a real-event integration test (captures `home_keeper_part_low_stock` via a `configuration.yaml` automation).

## Low
- Inventory totals accumulate **raw** spares and round once (no cent drift from re-rounding rows).
- Panel `_downloadFile` defers `URL.revokeObjectURL` and appends/removes the anchor; export failures now surface a toast (`error.exportFailed`, translated across all 16 locales).

## Verification (all local, green)
`pytest` unit **151** · integration **34** (incl. the new event-firing + service-schema tests, run against a fresh HA container) · `vitest` **78** · `ruff` + `tsc --noEmit` clean · panel builds.

https://claude.ai/code/session_013Qi7HFqqZrS5hmMBXbYKEK

---
_Generated by [Claude Code](https://claude.ai/code/session_013Qi7HFqqZrS5hmMBXbYKEK)_