### PR TITLE
Release 0.2.0b1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas)
 
 ## [Unreleased]
 
+## [0.2.0b1] - 2026-06-15
+
+- **Managed tasks (stronger integration ownership).** Integrations that create tasks
+  can now declare a `managed_by` block, which Home Keeper acts on (unlike the opaque
+  `source`). Managed tasks show a **"Managed by {name}"** chip; declared fields are
+  locked out of the edit form; and an optional completion prompt and a deep link back
+  to the owning integration are surfaced. Tasks can also be grouped by integration.
+  If the owning integration is uninstalled or disabled, its tasks flip to
+  **"Integration offline"**, become deletable again, and a **"Remove orphaned tasks"**
+  banner offers one-click cleanup; `home_keeper.delete_task` also gains a `force`
+  option as a last resort. See `docs/INTEGRATING.md` §6.
+
 - **Home inventory export (for insurance).** A new **Export inventory** button on
   the Appliances tab downloads a CSV — make/model/serial, purchase and warranty
   dates, replacement cost, and the value of spares on hand, with a grand total —

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.1.0b5"
+PANEL_VERSION = "0.2.0b1"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/prestomation/ha-home-keeper/issues",
   "requirements": [],
-  "version": "0.1.0b5"
+  "version": "0.2.0b1"
 }


### PR DESCRIPTION
Beta release **0.2.0b1**.

Bumps `manifest.json` + `PANEL_VERSION` to `0.2.0b1` and cuts the `## [0.2.0b1]` changelog section. The `bN` suffix publishes this as a GitHub pre-release (HACS beta channel) once merged.

### Included since 0.1.0b5
- **Managed tasks** — `managed_by` ownership block (chip, locked fields, completion prompt, deep link, group-by-integration, orphan detection + cleanup, `force` delete). See `docs/INTEGRATING.md` §6.
- **Home inventory export** (insurance CSV + `export_inventory` service)
- **Spare-inventory tracking** for parts (stock/reorder-at, low-stock event)
- **Panel deep links & working Back button**

No code changes beyond the version/changelog bump — the features already merged via #15 and earlier.

https://claude.ai/code/session_01Wuduy58ZHnxy9t5Eu3x4x4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wuduy58ZHnxy9t5Eu3x4x4)_