### PR TITLE
Floating tasks due-now when never completed + add_task last_completed seed (0.2.0b2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,15 @@
   `raw.githubusercontent.com/<owner>/<repo>/<commit-sha>/docs/images/<file>.png`
   URL pinned to the commit that added them. When a change adds a new UI surface,
   add a capture step for it to the capture script in the same PR.
+  - **Embed PR-body screenshots with an HTML `<img src="…" alt="…" width="820">`
+    tag, not markdown `![](…)`.** The `update_pull_request` path can silently wrap a
+    markdown image URL in double backticks (a code span), breaking the image — and it
+    may hit only some of several identical-looking lines. HTML `<img>` avoids markdown
+    link parsing. Keep the SHA-pinned `src` (branch names have slashes and are
+    ambiguous for `raw.githubusercontent.com`). After editing the body, re-read it to
+    confirm the URLs weren't mangled and verify each returns HTTP 200. (In-repo
+    README/docs markdown with relative `docs/images/…` paths is fine — this only bites
+    PR/issue bodies set through the API.)
 - **Always document new major features in `README.md` in the same change.** Add a
   brief section with the **use cases** (what problem it solves) and a little about
   **how it's used**, and include **screenshot(s)** (same Playwright capture, committed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas)
 
 ## [Unreleased]
 
+## [0.2.0b2] - 2026-06-15
+
+- **A brand-new floating task is due now, not a full interval away.** A floating task
+  with no completion history used to be dated one interval into the future (a chore
+  you'd never done showed up as "due in 30 days"). It now reads as **due immediately** —
+  a task you haven't done yet is due now. Completing it (or seeding a "last done" date,
+  below) starts the clock from there. Fixed (calendar-anchored) tasks and appliance
+  wear-part tasks are unaffected.
+
+- **`add_task` accepts an optional `last_completed` "last done" seed.** Integrations
+  that already know when an activity last happened can pass `last_completed` to seed an
+  initial completion, so the first next-due is measured from that date
+  (`next_due = last_completed + interval`) instead of due-now. See `docs/INTEGRATING.md`.
+
 ## [0.2.0b1] - 2026-06-15
 
 - **Managed tasks (stronger integration ownership).** Integrations that create tasks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas)
   you'd never done showed up as "due in 30 days"). It now reads as **due immediately** —
   a task you haven't done yet is due now. Completing it (or seeding a "last done" date,
   below) starts the clock from there. Fixed (calendar-anchored) tasks and appliance
-  wear-part tasks are unaffected.
+  wear-part tasks are unaffected. This applies to newly-created tasks; an existing
+  never-completed floating task keeps its current due date until next edited or completed.
 
 - **`add_task` accepts an optional `last_completed` "last done" seed.** Integrations
   that already know when an activity last happened can pass `last_completed` to seed an

--- a/custom_components/home_keeper/__init__.py
+++ b/custom_components/home_keeper/__init__.py
@@ -41,6 +41,9 @@ ADD_TASK_SCHEMA = vol.Schema(
         vol.Optional("unit"): cv.string,
         vol.Optional("freq"): cv.string,
         vol.Optional("anchor"): cv.string,
+        # Optional "last done" seed: records an initial completion so a floating task
+        # starts measured from this date instead of due-now. See docs/INTEGRATING.md.
+        vol.Optional("last_completed"): cv.datetime,
         vol.Optional("device_id"): cv.string,
         vol.Optional("area_id"): cv.string,
         vol.Optional("source"): dict,

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.2.0b1"
+PANEL_VERSION = "0.2.0b2"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/prestomation/ha-home-keeper/issues",
   "requirements": [],
-  "version": "0.2.0b1"
+  "version": "0.2.0b2"
 }

--- a/custom_components/home_keeper/models.py
+++ b/custom_components/home_keeper/models.py
@@ -141,8 +141,35 @@ def deletion_blocked(task: dict, *, orphaned: bool, force: bool = False) -> bool
     return not orphaned
 
 
+def _coerce_seed(value: Any, *, tz: Any) -> datetime:
+    """Parse a ``last_completed`` seed into an aware datetime.
+
+    Accepts a datetime (passed straight through) or an ISO string. A naive value is
+    qualified with *tz* (the caller's configured zone) just like a fixed anchor, so
+    the recurrence engine can compare it against an aware ``now``.
+    """
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        try:
+            parsed = datetime.fromisoformat(value)
+        except (TypeError, ValueError) as err:
+            raise TaskValidationError(
+                f"invalid last_completed datetime: {value!r}"
+            ) from err
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=tz) if tz is not None else parsed.astimezone()
+    return parsed
+
+
 def build_task(data: dict, *, now: datetime) -> dict:
-    """Create a brand-new task dict (with id, history, and computed next_due)."""
+    """Create a brand-new task dict (with id, history, and computed next_due).
+
+    An optional ``last_completed`` seed records an initial completion so the task
+    starts measured from a known "last done" date rather than due-now. Used by
+    integrations that already know when the activity last happened (e.g. Pawsistant
+    passing a pet's most recent logged event). Without it, a floating task is due now.
+    """
     fields = normalize_fields(data, tz=now.tzinfo)
     validate_managed_by(data.get("managed_by"))
     task: dict[str, Any] = {
@@ -159,7 +186,14 @@ def build_task(data: dict, *, now: datetime) -> dict:
         "managed_by": data.get("managed_by"),
         **fields,
     }
-    task["next_due"] = recurrence.compute_next_due(task, now=now).isoformat()
+    seed = data.get("last_completed")
+    if seed not in (None, ""):
+        # Recording the seed as a completion both stamps last_completed and lets the
+        # recurrence engine derive next_due (floating -> seed + interval; fixed stays
+        # anchor-driven, the seed just becomes its first history entry).
+        recurrence.apply_completion(task, _coerce_seed(seed, tz=now.tzinfo), now=now)
+    else:
+        task["next_due"] = recurrence.compute_next_due(task, now=now).isoformat()
     return task
 
 

--- a/custom_components/home_keeper/recurrence.py
+++ b/custom_components/home_keeper/recurrence.py
@@ -7,10 +7,13 @@ caller is responsible for passing an aware ``now`` from ``homeassistant.util.dt`
 
 Two recurrence models are supported:
 
-* **floating** — the next due date is measured from the last completion (or the
-  task's anchor if never completed): ``next_due = last_completed + interval·unit``.
-  Completing the task resets the clock. A missed task simply stays overdue; the
-  due date does not march forward on its own.
+* **floating** — the next due date is measured from the last completion:
+  ``next_due = last_completed + interval·unit``. A task that has *never* been
+  completed has no clock to measure from, so it is due immediately (``now``) rather
+  than a full interval into the future — a brand-new chore you haven't done yet is
+  due now, not "in N days". Completing the task (or seeding an initial completion at
+  creation) starts the clock. A missed task simply stays overdue; the due date does
+  not march forward on its own.
 
 * **fixed** — the next due date follows a calendar schedule anchored at a fixed
   datetime (``FREQ=DAILY|WEEKLY|MONTHLY`` every ``interval`` steps). Completing an
@@ -77,9 +80,16 @@ def compute_floating_next_due(
     *,
     now: datetime,
 ) -> datetime:
-    """Next due date for a floating task, measured from last completion or *now*."""
-    base = last_completed if last_completed is not None else now
-    return add_interval(base, interval, unit)
+    """Next due date for a floating task, measured from the last completion.
+
+    A task that has never been completed (``last_completed is None``) is due
+    immediately (``now``): there is no completion to measure an interval from, and a
+    chore you have not yet done should read as due now rather than a full interval
+    into the future. Seeding an initial completion opts into the measured behaviour.
+    """
+    if last_completed is None:
+        return now
+    return add_interval(last_completed, interval, unit)
 
 
 def _step(dt: datetime, freq: str, interval: int) -> datetime:

--- a/custom_components/home_keeper/services.yaml
+++ b/custom_components/home_keeper/services.yaml
@@ -57,6 +57,15 @@ add_task:
       example: "2026-01-01T08:00:00"
       selector:
         text:
+    last_completed:
+      name: Last completed
+      description: >-
+        Optional "last done" date. Seeds an initial completion so a floating task
+        starts measured from this date (next due = last done + interval) instead of
+        being due immediately. Omit for a task that has never been done.
+      example: "2026-01-01T08:00:00"
+      selector:
+        datetime:
     device_id:
       name: Device
       description: Optional device to attach this task to.

--- a/custom_components/home_keeper/strings.json
+++ b/custom_components/home_keeper/strings.json
@@ -43,6 +43,10 @@
           "name": "Anchor",
           "description": "For fixed tasks: ISO datetime of the first occurrence (sets the time of day)."
         },
+        "last_completed": {
+          "name": "Last completed",
+          "description": "Optional 'last done' date. Seeds an initial completion so a floating task starts measured from this date (next due = last done + interval) instead of being due immediately. Omit for a task that has never been done."
+        },
         "device_id": {
           "name": "Device",
           "description": "Optional device to attach this task to."

--- a/custom_components/home_keeper/translations/ca.json
+++ b/custom_components/home_keeper/translations/ca.json
@@ -43,6 +43,10 @@
           "name": "Àncora",
           "description": "Per a tasques fixes: data i hora ISO de la primera ocurrència (estableix l'hora del dia)."
         },
+        "last_completed": {
+          "name": "Last completed",
+          "description": "Optional 'last done' date. Seeds an initial completion so a floating task starts measured from this date (next due = last done + interval) instead of being due immediately. Omit for a task that has never been done."
+        },
         "device_id": {
           "name": "Dispositiu",
           "description": "Dispositiu opcional al qual vincular aquesta tasca."

--- a/custom_components/home_keeper/translations/cs.json
+++ b/custom_components/home_keeper/translations/cs.json
@@ -43,6 +43,10 @@
           "name": "Kotva",
           "description": "Pro pevné úkoly: ISO datum a čas prvního výskytu (nastaví denní čas)."
         },
+        "last_completed": {
+          "name": "Last completed",
+          "description": "Optional 'last done' date. Seeds an initial completion so a floating task starts measured from this date (next due = last done + interval) instead of being due immediately. Omit for a task that has never been done."
+        },
         "device_id": {
           "name": "Zařízení",
           "description": "Volitelné zařízení, ke kterému se tento úkol připojí."

--- a/custom_components/home_keeper/translations/da.json
+++ b/custom_components/home_keeper/translations/da.json
@@ -43,6 +43,10 @@
           "name": "Anker",
           "description": "For fixed-opgaver: ISO-dato og -tid for første forekomst (angiver tidspunkt på dagen)."
         },
+        "last_completed": {
+          "name": "Last completed",
+          "description": "Optional 'last done' date. Seeds an initial completion so a floating task starts measured from this date (next due = last done + interval) instead of being due immediately. Omit for a task that has never been done."
+        },
         "device_id": {
           "name": "Enhed",
           "description": "Valgfri enhed at tilknytte denne opgave til."

--- a/custom_components/home_keeper/translations/de.json
+++ b/custom_components/home_keeper/translations/de.json
@@ -43,6 +43,10 @@
           "name": "Anker",
           "description": "Für fixed-Aufgaben: ISO-Datum/Uhrzeit des ersten Auftretens (legt die Tageszeit fest)."
         },
+        "last_completed": {
+          "name": "Last completed",
+          "description": "Optional 'last done' date. Seeds an initial completion so a floating task starts measured from this date (next due = last done + interval) instead of being due immediately. Omit for a task that has never been done."
+        },
         "device_id": {
           "name": "Gerät",
           "description": "Optionales Gerät, an das diese Aufgabe angehängt wird."

--- a/custom_components/home_keeper/translations/en.json
+++ b/custom_components/home_keeper/translations/en.json
@@ -43,6 +43,10 @@
           "name": "Anchor",
           "description": "For fixed tasks: ISO datetime of the first occurrence (sets the time of day)."
         },
+        "last_completed": {
+          "name": "Last completed",
+          "description": "Optional 'last done' date. Seeds an initial completion so a floating task starts measured from this date (next due = last done + interval) instead of being due immediately. Omit for a task that has never been done."
+        },
         "device_id": {
           "name": "Device",
           "description": "Optional device to attach this task to."

--- a/custom_components/home_keeper/translations/es.json
+++ b/custom_components/home_keeper/translations/es.json
@@ -43,6 +43,10 @@
           "name": "Ancla",
           "description": "Para tareas fixed: fecha y hora ISO de la primera aparición (establece la hora del día)."
         },
+        "last_completed": {
+          "name": "Last completed",
+          "description": "Optional 'last done' date. Seeds an initial completion so a floating task starts measured from this date (next due = last done + interval) instead of being due immediately. Omit for a task that has never been done."
+        },
         "device_id": {
           "name": "Dispositivo",
           "description": "Dispositivo opcional al que adjuntar esta tarea."

--- a/custom_components/home_keeper/translations/fi.json
+++ b/custom_components/home_keeper/translations/fi.json
@@ -43,6 +43,10 @@
           "name": "Ankkuri",
           "description": "Kiinteille tehtäville: ensimmäisen esiintymän ISO-aikaleima (asettaa kellonajan)."
         },
+        "last_completed": {
+          "name": "Last completed",
+          "description": "Optional 'last done' date. Seeds an initial completion so a floating task starts measured from this date (next due = last done + interval) instead of being due immediately. Omit for a task that has never been done."
+        },
         "device_id": {
           "name": "Laite",
           "description": "Valinnainen laite, johon tämä tehtävä liitetään."

--- a/custom_components/home_keeper/translations/fr.json
+++ b/custom_components/home_keeper/translations/fr.json
@@ -43,6 +43,10 @@
           "name": "Ancre",
           "description": "Pour les tâches fixed : date/heure ISO de la première occurrence (définit l'heure de la journée)."
         },
+        "last_completed": {
+          "name": "Last completed",
+          "description": "Optional 'last done' date. Seeds an initial completion so a floating task starts measured from this date (next due = last done + interval) instead of being due immediately. Omit for a task that has never been done."
+        },
         "device_id": {
           "name": "Appareil",
           "description": "Appareil facultatif auquel rattacher cette tâche."

--- a/custom_components/home_keeper/translations/it.json
+++ b/custom_components/home_keeper/translations/it.json
@@ -43,6 +43,10 @@
           "name": "Ancora",
           "description": "Per le attività fixed: data/ora ISO della prima occorrenza (imposta l'ora del giorno)."
         },
+        "last_completed": {
+          "name": "Last completed",
+          "description": "Optional 'last done' date. Seeds an initial completion so a floating task starts measured from this date (next due = last done + interval) instead of being due immediately. Omit for a task that has never been done."
+        },
         "device_id": {
           "name": "Dispositivo",
           "description": "Dispositivo facoltativo a cui collegare questa attività."

--- a/custom_components/home_keeper/translations/nb.json
+++ b/custom_components/home_keeper/translations/nb.json
@@ -43,6 +43,10 @@
           "name": "Anker",
           "description": "For fixed-oppgaver: ISO-dato og -tid for første forekomst (angir tid på dagen)."
         },
+        "last_completed": {
+          "name": "Last completed",
+          "description": "Optional 'last done' date. Seeds an initial completion so a floating task starts measured from this date (next due = last done + interval) instead of being due immediately. Omit for a task that has never been done."
+        },
         "device_id": {
           "name": "Enhet",
           "description": "Valgfri enhet å knytte denne oppgaven til."

--- a/custom_components/home_keeper/translations/nl.json
+++ b/custom_components/home_keeper/translations/nl.json
@@ -43,6 +43,10 @@
           "name": "Anker",
           "description": "Voor fixed-taken: ISO-datum/tijd van de eerste keer (stelt het tijdstip van de dag in)."
         },
+        "last_completed": {
+          "name": "Last completed",
+          "description": "Optional 'last done' date. Seeds an initial completion so a floating task starts measured from this date (next due = last done + interval) instead of being due immediately. Omit for a task that has never been done."
+        },
         "device_id": {
           "name": "Apparaat",
           "description": "Optioneel apparaat om deze taak aan te koppelen."

--- a/custom_components/home_keeper/translations/pl.json
+++ b/custom_components/home_keeper/translations/pl.json
@@ -43,6 +43,10 @@
           "name": "Kotwica",
           "description": "Dla zadań fixed: data i czas ISO pierwszego wystąpienia (ustawia porę dnia)."
         },
+        "last_completed": {
+          "name": "Last completed",
+          "description": "Optional 'last done' date. Seeds an initial completion so a floating task starts measured from this date (next due = last done + interval) instead of being due immediately. Omit for a task that has never been done."
+        },
         "device_id": {
           "name": "Urządzenie",
           "description": "Opcjonalne urządzenie, do którego przypisać to zadanie."

--- a/custom_components/home_keeper/translations/pt-BR.json
+++ b/custom_components/home_keeper/translations/pt-BR.json
@@ -43,6 +43,10 @@
           "name": "Âncora",
           "description": "Para tarefas fixed: data e hora ISO da primeira ocorrência (define o horário do dia)."
         },
+        "last_completed": {
+          "name": "Last completed",
+          "description": "Optional 'last done' date. Seeds an initial completion so a floating task starts measured from this date (next due = last done + interval) instead of being due immediately. Omit for a task that has never been done."
+        },
         "device_id": {
           "name": "Dispositivo",
           "description": "Dispositivo opcional ao qual anexar esta tarefa."

--- a/custom_components/home_keeper/translations/ru.json
+++ b/custom_components/home_keeper/translations/ru.json
@@ -43,6 +43,10 @@
           "name": "Привязка",
           "description": "Для фиксированных задач: дата и время первого выполнения в формате ISO (задаёт время суток)."
         },
+        "last_completed": {
+          "name": "Last completed",
+          "description": "Optional 'last done' date. Seeds an initial completion so a floating task starts measured from this date (next due = last done + interval) instead of being due immediately. Omit for a task that has never been done."
+        },
         "device_id": {
           "name": "Устройство",
           "description": "Необязательное устройство, к которому привязывается эта задача."

--- a/custom_components/home_keeper/translations/sv.json
+++ b/custom_components/home_keeper/translations/sv.json
@@ -43,6 +43,10 @@
           "name": "Ankare",
           "description": "För fixed-uppgifter: ISO-datum och -tid för första förekomsten (anger tid på dygnet)."
         },
+        "last_completed": {
+          "name": "Last completed",
+          "description": "Optional 'last done' date. Seeds an initial completion so a floating task starts measured from this date (next due = last done + interval) instead of being due immediately. Omit for a task that has never been done."
+        },
         "device_id": {
           "name": "Enhet",
           "description": "Valfri enhet att koppla denna uppgift till."

--- a/custom_components/home_keeper/translations/zh-Hans.json
+++ b/custom_components/home_keeper/translations/zh-Hans.json
@@ -43,6 +43,10 @@
           "name": "锚点",
           "description": "对于固定任务：首次发生的 ISO 日期时间（设置每日时间）。"
         },
+        "last_completed": {
+          "name": "Last completed",
+          "description": "Optional 'last done' date. Seeds an initial completion so a floating task starts measured from this date (next due = last done + interval) instead of being due immediately. Omit for a task that has never been done."
+        },
         "device_id": {
           "name": "设备",
           "description": "要将此任务关联到的可选设备。"

--- a/docs/INTEGRATING.md
+++ b/docs/INTEGRATING.md
@@ -53,6 +53,13 @@ if hass.services.has_service(DOMAIN_HK, "add_task"):
             #   "interval": 1,
             #   "anchor": "2026-01-01T08:00:00",  # sets the time-of-day; naive is OK
             #
+            # Optional "last done" seed. A floating task with no completion history
+            # is due *immediately* (a chore you've never done is due now, not a full
+            # interval from now). If you already know when the activity last happened,
+            # pass it here to seed an initial completion so the first next-due is
+            # measured from it (next_due = last_completed + interval) instead:
+            #   "last_completed": "2026-01-01T08:00:00",  # naive is OK
+            #
             # Optional: attach the task to an existing device so Home Keeper's
             # next-due sensor, overdue binary_sensor and mark-done button appear on
             # that device's page. Pass a device *registry id* (not your own key).
@@ -315,7 +322,10 @@ weeks"):
 1. Pawsistant calls `add_task` with `recurrence_type="floating"`, `interval=2`,
    `unit="weeks"`, the pet's `device_id`, and
    `source={"pawsistant": {"dog_id": …, "event_type": "medicine", "schedule_id": …}}`,
-   and reads the `task_id` from the `add_task` response.
+   and reads the `task_id` from the `add_task` response. If the pet already has a
+   logged "medicine" event, Pawsistant passes its timestamp as `last_completed` so the
+   first due date is measured from when it was actually last done; otherwise the task
+   is due now.
 2. **Complete in Home Keeper** (checkbox / device button) → `home_keeper_task_completed`
    fires with `origin=None`; Pawsistant logs a "medicine" event for that pet (writing
    straight to its store, so it doesn't re-complete the task).

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -9,7 +9,7 @@ TZ = timezone(timedelta(hours=-4))
 NOW = datetime(2026, 6, 13, 10, tzinfo=TZ)
 
 
-def test_build_floating_task_sets_id_and_next_due():
+def test_build_floating_task_sets_id_and_is_due_now():
     task = m.build_task(
         {"name": "Furnace filter", "recurrence_type": "floating", "interval": 3, "unit": "months"},
         now=NOW,
@@ -17,8 +17,59 @@ def test_build_floating_task_sets_id_and_next_due():
     assert task["id"]
     assert task["name"] == "Furnace filter"
     assert task["last_completed"] is None
-    # 3 months from now.
-    assert task["next_due"] == datetime(2026, 9, 13, 10, tzinfo=TZ).isoformat()
+    # Never completed -> due immediately, not 3 months out.
+    assert task["next_due"] == NOW.isoformat()
+
+
+def test_build_floating_task_with_last_completed_seed():
+    # A "last done" seed records an initial completion and measures next_due from it.
+    seed = datetime(2026, 6, 1, 9, tzinfo=TZ)
+    task = m.build_task(
+        {
+            "name": "Nail trim",
+            "recurrence_type": "floating",
+            "interval": 2,
+            "unit": "weeks",
+            "last_completed": seed.isoformat(),
+        },
+        now=NOW,
+    )
+    assert task["last_completed"] == seed.isoformat()
+    assert task["completions"] == [{"ts": seed.isoformat()}]
+    # 2 weeks after the seed, not due-now and not measured from NOW.
+    assert task["next_due"] == datetime(2026, 6, 15, 9, tzinfo=TZ).isoformat()
+
+
+def test_build_floating_task_seed_naive_is_qualified():
+    # A naive seed (e.g. from a datetime-local picker) is qualified with the caller tz.
+    task = m.build_task(
+        {
+            "name": "Nail trim",
+            "recurrence_type": "floating",
+            "interval": 1,
+            "unit": "weeks",
+            "last_completed": "2026-06-01T09:00",  # naive
+        },
+        now=NOW,
+    )
+    seeded = datetime.fromisoformat(task["last_completed"])
+    assert seeded.tzinfo is not None
+    assert seeded.utcoffset() == NOW.utcoffset()
+    assert datetime.fromisoformat(task["next_due"]).tzinfo is not None
+
+
+def test_build_task_rejects_bad_last_completed():
+    with pytest.raises(m.TaskValidationError):
+        m.build_task(
+            {
+                "name": "x",
+                "recurrence_type": "floating",
+                "interval": 1,
+                "unit": "days",
+                "last_completed": "not-a-date",
+            },
+            now=NOW,
+        )
 
 
 def test_build_fixed_task_requires_anchor_and_freq():
@@ -105,10 +156,19 @@ def test_merge_update_name_only_keeps_schedule():
 
 
 def test_merge_update_interval_recomputes_due():
+    # Seed a completion so the recompute measures from a fixed point (a never-completed
+    # task would just stay due-now, hiding the interval change).
     task = m.build_task(
-        {"name": "Filter", "recurrence_type": "floating", "interval": 1, "unit": "months"},
+        {
+            "name": "Filter",
+            "recurrence_type": "floating",
+            "interval": 1,
+            "unit": "months",
+            "last_completed": NOW.isoformat(),
+        },
         now=NOW,
     )
+    assert task["next_due"] == datetime(2026, 7, 13, 10, tzinfo=TZ).isoformat()
     updated = m.merge_update(task, {"interval": 2}, now=NOW)
     assert updated["interval"] == 2
     assert updated["next_due"] == datetime(2026, 8, 13, 10, tzinfo=TZ).isoformat()

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -40,6 +40,24 @@ def test_build_floating_task_with_last_completed_seed():
     assert task["next_due"] == datetime(2026, 6, 15, 9, tzinfo=TZ).isoformat()
 
 
+def test_build_floating_task_seed_accepts_datetime():
+    # The add_task service (cv.datetime) hands build_task an already-parsed datetime,
+    # not a string — exercise that path directly.
+    seed = datetime(2026, 6, 1, 9, tzinfo=TZ)
+    task = m.build_task(
+        {
+            "name": "Nail trim",
+            "recurrence_type": "floating",
+            "interval": 2,
+            "unit": "weeks",
+            "last_completed": seed,
+        },
+        now=NOW,
+    )
+    assert task["last_completed"] == seed.isoformat()
+    assert task["next_due"] == datetime(2026, 6, 15, 9, tzinfo=TZ).isoformat()
+
+
 def test_build_floating_task_seed_naive_is_qualified():
     # A naive seed (e.g. from a datetime-local picker) is qualified with the caller tz.
     task = m.build_task(

--- a/tests/unit/test_recurrence_floating.py
+++ b/tests/unit/test_recurrence_floating.py
@@ -47,9 +47,10 @@ def test_floating_next_due_from_last_completed():
     assert nd == dt(2026, 7, 1, 9)
 
 
-def test_floating_next_due_uses_now_when_never_completed():
+def test_floating_next_due_is_now_when_never_completed():
+    # A never-completed floating task is due immediately, not a full interval out.
     nd = r.compute_floating_next_due(None, 30, "days", now=dt(2026, 6, 13))
-    assert nd == dt(2026, 7, 13)
+    assert nd == dt(2026, 6, 13)
 
 
 def test_apply_completion_resets_clock_from_completion():
@@ -112,8 +113,8 @@ def test_remove_only_completion_clears_last_completed():
     r.remove_completion(task, dt(2026, 6, 1).isoformat(), now=now)
     assert task["completions"] == []
     assert task["last_completed"] is None
-    # With no completion, next_due re-derives from now.
-    assert task["next_due"] == dt(2026, 7, 13).isoformat()
+    # With no completion left, the task falls back to due-now.
+    assert task["next_due"] == dt(2026, 6, 13).isoformat()
 
 
 def test_remove_completion_missing_ts_is_noop():


### PR DESCRIPTION
## Summary

Two related changes to floating recurrence, plus a beta cut (`0.2.0b2`).

### 1. A never-completed floating task is due *now*, not a full interval away
`compute_floating_next_due` used `base = last_completed or now`, so a brand-new floating task with no completion history was dated one interval into the future — a chore you'd never done showed up as **"due in 30 days"**. It now reads as **due immediately**. Completing it (or seeding a "last done" date) starts the clock from there.

Scope: only truly never-completed floating tasks change. Fixed (calendar-anchored) tasks and appliance wear-part tasks always carry an anchor / seeded `last_completed`, so they're unaffected.

### 2. `add_task` accepts an optional `last_completed` "last done" seed
Integrations that already know when an activity last happened can pass `last_completed` to seed an initial completion, so the first `next_due` is measured from that date (`next_due = last_completed + interval`) instead of due-now. A naive value is qualified with the configured tz, just like a fixed anchor.

This is what lets Pawsistant prefill a care schedule from a pet's most recent logged event (companion PR in `prestomation/pawsistant`).

## Changes
- `recurrence.py` — never-completed floating → `now`; docstrings.
- `models.py` — `build_task` seeds an initial completion from `last_completed` (via `apply_completion`), with a naive-datetime coercer.
- `__init__.py` / `services.yaml` / `strings.json` / all `translations/*.json` — new optional `last_completed` field on `add_task`.
- `docs/INTEGRATING.md` — document the seed and the due-now semantics.
- Version bump to `0.2.0b2` (`manifest.json`, `const.PANEL_VERSION`, `CHANGELOG.md`).

## Tests
- Updated floating/model tests for the due-now behavior; added seed tests (forwarded, naive-qualified, rejects bad input).
- `169 passed` (unit).

## Release
Beta `0.2.0b2`. Pairs with Pawsistant `2.21.0b3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQM425TYMj6S3B3gHPcrh7)_