### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,47 @@ versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas)
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-16
+
+- **Managed tasks (stronger integration ownership).** Integrations that create tasks
+  can declare a `managed_by` block that Home Keeper acts on (unlike the opaque
+  `source`): managed tasks show a **"Managed by {name}"** chip, lock declared fields
+  out of the edit form, surface an optional completion prompt and a deep link back to
+  the owning integration, and can be grouped by integration. If the owner is
+  uninstalled or disabled, its tasks flip to **"Integration offline"**, become
+  deletable again, and a **"Remove orphaned tasks"** banner offers one-click cleanup;
+  `home_keeper.delete_task` gains a `force` option as a last resort. See
+  `docs/INTEGRATING.md` §6.
+
+- **Home inventory export (for insurance).** An **Export inventory** button on the
+  Appliances tab downloads a CSV — make/model/serial, purchase and warranty dates,
+  replacement cost, and the value of spares on hand, with a grand total. Also exposed
+  to automations as the `home_keeper.export_inventory` service.
+
+- **Spare-inventory tracking for parts.** Any part can track a *stock* count and a
+  *reorder-at* threshold. Completing a wear-item replacement consumes a spare, and
+  when stock hits the threshold a `home_keeper_part_low_stock` event fires. The panel
+  shows on-hand count and a **Low stock** chip; `home_keeper.adjust_part_stock`
+  restocks or consumes spares from automations.
+
+- **Deep links & a working Back button in the panel.** Tabs
+  (`/home-keeper/appliances`) and detail pages (`/home-keeper/tasks/<id>`) are now in
+  the URL — linkable, bookmarkable, and refresh-safe — and the browser **Back** button
+  steps back inside the panel instead of leaving it.
+
+- **A brand-new floating task is due now, not a full interval away.** A floating task
+  with no completion history used to be dated one interval into the future (a chore
+  you'd never done showed up as "due in 30 days"); it now reads as **due immediately**.
+  Completing it — or seeding a "last done" date (below) — starts the clock from there.
+  Fixed and appliance wear-part tasks are unaffected. Applies to newly-created tasks;
+  an existing never-completed floating task keeps its current due date until next
+  edited or completed.
+
+- **`add_task` accepts an optional `last_completed` "last done" seed.** Integrations
+  that already know when an activity last happened can pass `last_completed` so the
+  first next-due is measured from that date (`next_due = last_completed + interval`)
+  instead of due-now. See `docs/INTEGRATING.md`.
+
 ## [0.2.0b2] - 2026-06-15
 
 - **A brand-new floating task is due now, not a full interval away.** A floating task

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.2.0b2"
+PANEL_VERSION = "0.2.0"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/prestomation/ha-home-keeper/issues",
   "requirements": [],
-  "version": "0.2.0b2"
+  "version": "0.2.0"
 }


### PR DESCRIPTION
## Release 0.2.0

Cuts the stable **0.2.0** from the `0.2.0b1`/`0.2.0b2` beta line. Per `RELEASE.md`, this PR contains only the release changes:

- `custom_components/home_keeper/manifest.json` — `version` → `0.2.0`
- `custom_components/home_keeper/const.py` — `PANEL_VERSION` → `"0.2.0"`
- `CHANGELOG.md` — new `## [0.2.0]` section consolidating the beta notes

On merge, `release.yml` validates the version/changelog, builds the panel + `home_keeper.zip`, tags `v0.2.0`, and publishes the GitHub release (a normal, non-pre-release this time).

### Highlights since the last stable
- Managed tasks (`managed_by` ownership: chip, locked fields, completion prompt, deep link, orphan cleanup, `force` delete)
- Home inventory CSV export (+ `export_inventory` service)
- Spare-inventory tracking for parts (stock / reorder-at, low-stock event, `adjust_part_stock`)
- Deep links & working Back button in the panel
- Never-completed floating tasks are due **now**, not a full interval out
- `add_task` optional `last_completed` "last done" seed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQM425TYMj6S3B3gHPcrh7)_