### PR TITLE
Fix card load-error spinner + double-tap guard; release 0.3.0b3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas)
 
 ## [Unreleased]
 
+## [0.3.0b3] - 2026-06-17
+
 - **Dashboard task card.** A new resizable Lovelace card (`custom:home-keeper-card`)
   shows your tasks as a list with a one-tap **Done** button on each row, and opens an
   inline editor for adding, editing, and deleting tasks without leaving the dashboard.
@@ -14,6 +16,12 @@ versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas)
   type, due-within horizon), sorting, status/area/device grouping, a max-items cap, and
   display toggles. Built entirely from Home Assistant's own components and theme
   variables, and it stays in sync with completions made from any other surface.
+- **Fix: the card no longer spins forever when tasks fail to load.** If the task
+  fetch fails (e.g. the integration isn't set up yet, or was removed while a card
+  is still on a dashboard), the card now shows a clear error and keeps retrying on
+  the next update instead of an endless spinner.
+- **Fix: a fast double-tap of a card's Done button no longer records two
+  completions** — a completion already in flight ignores re-entrant taps.
 
 ## [0.3.0b2] - 2026-06-16
 

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.3.0b2"
+PANEL_VERSION = "0.3.0b3"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/frontend/src/card.ts
+++ b/custom_components/home_keeper/frontend/src/card.ts
@@ -66,6 +66,7 @@ const S: Record<string, string> = {
   description: 'A resizable list of Home Keeper maintenance tasks with one-tap completion.',
   defaultTitle: 'Tasks',
   empty: 'No tasks yet.',
+  loadError: "Couldn't load tasks. Is the Home Keeper integration set up?",
   // editor field labels (keyed by config field name for computeLabel)
   title: 'Title',
   filter: 'Filter',
@@ -193,7 +194,13 @@ export class HomeKeeperCard extends HTMLElement {
   private _config: HomeKeeperCardConfig = { type: '' };
   private _tasks: Task[] = [];
   private _loaded = false;
+  // Set when the last load failed (e.g. integration not set up); rendered as an
+  // error instead of an endless spinner. Cleared on the next successful load.
+  private _error = false;
   private _signal = '';
+  // Task ids with a completion request in flight, so a double-tap of Done can't
+  // record two completions.
+  private _completing = new Set<string>();
   private _edit: EditState = { open: false, task: null };
   private _collapsed = new Set<string>();
   private _liveHassEls: Array<{ hass?: Hass }> = [];
@@ -334,12 +341,17 @@ export class HomeKeeperCard extends HTMLElement {
     this._refreshing = true;
     try {
       this._tasks = await api.getTasks(this._hass);
-      this._loaded = true;
+      this._error = false;
       this._signal = this._stateSignal(this._hass);
     } catch (err) {
+      // Surface an error rather than spinning forever. We still mark the card
+      // "loaded" so the live-refresh path keeps retrying on the next state
+      // change (e.g. once the integration finishes setting up).
+      this._error = true;
       // eslint-disable-next-line no-console
       console.error('home-keeper-card: failed to load tasks', err);
     } finally {
+      this._loaded = true;
       this._refreshing = false;
     }
     this._render();
@@ -361,16 +373,21 @@ export class HomeKeeperCard extends HTMLElement {
 
   // ── completion / CRUD ───────────────────────────────────────────────────────
   private async _complete(task: Task): Promise<void> {
-    if (!this._hass) return;
+    // Ignore a re-entrant tap while this task's completion is already in flight,
+    // so a double-click doesn't record two completions.
+    if (!this._hass || this._completing.has(task.id)) return;
     const prompt = task.managed_by?.completion_prompt;
     if (this._config.confirm_complete || prompt) {
       const msg = prompt || t('btn.done') + ' — ' + task.name + '?';
       if (!window.confirm(msg)) return;
     }
+    this._completing.add(task.id);
     try {
       await api.completeTask(this._hass, task.id);
     } catch (err) {
       console.error('home-keeper-card: complete failed', err);
+    } finally {
+      this._completing.delete(task.id);
     }
     await this._refresh();
   }
@@ -435,6 +452,8 @@ export class HomeKeeperCard extends HTMLElement {
     let body: string;
     if (!this._loaded) {
       body = `<div class="hk-loading"><ha-spinner size="large"></ha-spinner></div>`;
+    } else if (this._error) {
+      body = `<div class="hk-empty"><ha-alert alert-type="error">${escapeHTML(S.loadError)}</ha-alert></div>`;
     } else {
       body = this._listHtml();
     }

--- a/custom_components/home_keeper/frontend/test/card.test.js
+++ b/custom_components/home_keeper/frontend/test/card.test.js
@@ -1,0 +1,133 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { HomeKeeperCard } from '../src/card.ts';
+
+// The card waits for HA's lazy components before first paint and renders them.
+// Register lightweight stand-ins so `whenDefined` resolves and the markup is
+// valid in jsdom, then register the card element itself.
+beforeAll(() => {
+  for (const tag of [
+    'ha-card',
+    'ha-form',
+    'ha-button',
+    'ha-icon-button',
+    'ha-assist-chip',
+    'ha-alert',
+    'ha-spinner',
+    'ha-icon',
+  ]) {
+    if (!customElements.get(tag)) customElements.define(tag, class extends HTMLElement {});
+  }
+  if (!customElements.get('home-keeper-card')) {
+    customElements.define('home-keeper-card', HomeKeeperCard);
+  }
+});
+
+function makeCard(config = { type: 'custom:home-keeper-card' }) {
+  const card = document.createElement('home-keeper-card');
+  card.setConfig(config);
+  document.body.appendChild(card); // connectedCallback -> boot
+  return card;
+}
+
+async function waitFor(fn, timeout = 2000) {
+  const end = Date.now() + timeout;
+  while (Date.now() < end) {
+    if (fn()) return true;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  return false;
+}
+
+const sr = (card) => card.shadowRoot;
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+const sampleTasks = [
+  {
+    id: 't1',
+    name: 'Replace filter',
+    recurrence_type: 'floating',
+    interval: 1,
+    unit: 'months',
+    next_due: new Date(Date.now() + 86_400_000).toISOString(),
+    completions: [],
+  },
+];
+
+describe('HomeKeeperCard load states', () => {
+  it('shows an error (not an endless spinner) when tasks fail to load', async () => {
+    const card = makeCard();
+    card.hass = { callWS: () => Promise.reject(new Error('not_loaded')), language: 'en' };
+
+    const shown = await waitFor(() => sr(card)?.querySelector('ha-alert[alert-type="error"]'));
+    expect(shown, 'an error alert should render').toBe(true);
+    expect(sr(card).querySelector('ha-spinner'), 'spinner should be gone').toBeNull();
+  });
+
+  it('renders task rows on a successful load', async () => {
+    const card = makeCard();
+    card.hass = { callWS: async () => ({ tasks: sampleTasks }), language: 'en' };
+
+    const shown = await waitFor(() => sr(card)?.querySelector('.hk-row'));
+    expect(shown).toBe(true);
+    expect(sr(card).textContent).toContain('Replace filter');
+    expect(sr(card).querySelector('ha-alert[alert-type="error"]')).toBeNull();
+  });
+
+  it('recovers from an error on a later state change (no manual reload)', async () => {
+    const card = makeCard();
+    // First load fails (integration not ready yet).
+    card.hass = { callWS: () => Promise.reject(new Error('not_loaded')), language: 'en' };
+    await waitFor(() => sr(card)?.querySelector('ha-alert[alert-type="error"]'));
+
+    // A later hass update with a changed Home Keeper state signal must trigger a
+    // retry — proving the card keeps trying rather than staying stuck.
+    card.hass = {
+      callWS: async () => ({ tasks: sampleTasks }),
+      language: 'en',
+      states: {
+        'todo.home_keeper_tasks': {
+          entity_id: 'todo.home_keeper_tasks',
+          state: '1',
+          last_updated: new Date().toISOString(),
+          attributes: {},
+        },
+      },
+    };
+
+    const recovered = await waitFor(() => sr(card)?.querySelector('.hk-row'));
+    expect(recovered, 'rows should appear after the retry').toBe(true);
+    expect(sr(card).querySelector('ha-alert[alert-type="error"]')).toBeNull();
+  });
+});
+
+describe('HomeKeeperCard completion guard', () => {
+  it('ignores a re-entrant complete while one is already in flight', async () => {
+    const card = makeCard();
+    let completeCalls = 0;
+    let resolveComplete;
+    card.hass = {
+      language: 'en',
+      callWS: async (msg) => {
+        if (msg.type === 'home_keeper/get_tasks') return { tasks: sampleTasks };
+        if (msg.type === 'home_keeper/complete_task') {
+          completeCalls++;
+          // Keep the first call pending so the second tap overlaps it.
+          await new Promise((r) => (resolveComplete = r));
+          return { task: sampleTasks[0] };
+        }
+        return {};
+      },
+    };
+    await waitFor(() => sr(card)?.querySelector('.hk-done'));
+
+    const done = sr(card).querySelector('.hk-done');
+    done.click();
+    done.click(); // second tap while the first is still pending
+    await new Promise((r) => setTimeout(r, 50));
+    expect(completeCalls, 'only one completion should be sent').toBe(1);
+    resolveComplete?.({});
+  });
+});

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/prestomation/ha-home-keeper/issues",
   "requirements": [],
-  "version": "0.3.0b2"
+  "version": "0.3.0b3"
 }


### PR DESCRIPTION
Follow-up to #25, from exploratory testing of the dashboard card.

## Bug fixes

- **Card no longer spins forever when tasks fail to load.** When `home_keeper/get_tasks` rejected — the integration not set up yet, removed while a card was still on a dashboard, or a transient WS error — the card showed an endless spinner and never recovered: `_refresh()`'s `catch` left `_loaded = false`, and the live-refresh path only re-fetches when loaded, so it never retried. It now renders a clear error (`ha-alert`) and **keeps retrying on the next state change**, so it also **self-heals** once the integration becomes available.
- **Fast double-tap of Done no longer records two completions.** `_complete` now ignores a re-entrant tap while that task's completion is already in flight.

## Tests

- New jsdom (vitest) regression suite `test/card.test.js`: error-state-not-spinner, successful render, **self-heal after a later state change**, and the completion re-entrancy guard.
- `tsc --noEmit` clean; `npm run build` OK; **vitest: 104 pass** (100 + 4 new).
- These came out of exploratory testing that also confirmed good behavior (XSS escaping, empty-name validation, no-match/empty states, bogus-enum fallback, `max_items` + "+N more", `hide_managed`, area/device/recurrence/horizon filters, `no_due` skipping the horizon, headerless config, grouping fallbacks).

## Release

Bumps the beta: `manifest.json` and `const.py` `PANEL_VERSION` → **0.3.0b3**, with a matching `## [0.3.0b3]` CHANGELOG section (the dashboard card from #25 plus these fixes). Merging to `main` triggers the release workflow, which tags `v0.3.0b3` and publishes it as a GitHub **pre-release** (HACS beta channel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Dah5KSswxmcbfAy6oHCf7

---
_Generated by [Claude Code](https://claude.ai/code/session_018Dah5KSswxmcbfAy6oHCf7)_