### PR TITLE
Release 0.3.0b4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas)
 
 ## [Unreleased]
 
+## [0.3.0b4] - 2026-06-17
+
 - **Backdate a wear item's last replacement when adding it.** The parts editor now
   has an optional "Last replaced" date field for wear items, so the maintenance task
   it creates starts its clock from the real replacement date instead of from today —

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.3.0b3"
+PANEL_VERSION = "0.3.0b4"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/prestomation/ha-home-keeper/issues",
   "requirements": [],
-  "version": "0.3.0b3"
+  "version": "0.3.0b4"
 }


### PR DESCRIPTION
## Summary

- Bump version to `0.3.0b4`
- Move unreleased features into the `[0.3.0b4]` changelog section

## What's in this beta

- **Backdate a wear item's last replacement when adding it** — the parts editor gains an optional "Last replaced" date field for wear items, so the maintenance task starts its clock from the real replacement date rather than today.
- **Redesigned appliance parts list** — each part on an appliance detail page now renders as a card with a type icon/badge, replacement cadence, last-replaced date, and spare-stock chips, replacing the cramped one-line summary.

## Release checklist

- [x] `manifest.json` version → `0.3.0b4`
- [x] `const.py` `PANEL_VERSION` → `0.3.0b4`
- [x] `CHANGELOG.md` `[0.3.0b4]` section added
- [ ] CI passes → release workflow tags + publishes GitHub pre-release

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGuBRUusQQJNkFhC6kKuda)_