### PR TITLE
Wear-part tasks with no recorded replacement are due now, not "assumed fresh"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas)
 
 ## [Unreleased]
 
+- **A wear-item maintenance task with no recorded replacement date is now due now,
+  not "assumed fresh".** When Home Keeper derives a replacement task from an appliance
+  wear item that has no "Last replaced" date, it used to assume the part was fresh and
+  schedule the first reminder a full interval out. It now reads as **due immediately**,
+  matching how brand-new floating tasks behave: an unknown replacement history is
+  surfaced now rather than hidden for a cycle. Backdate the part's last-replaced date
+  (or mark the task done) to start its clock from a known point instead. Wear items
+  with a recorded replacement date are unaffected.
+
 ## [0.3.0b4] - 2026-06-17
 
 - **Backdate a wear item's last replacement when adding it.** The parts editor now

--- a/custom_components/home_keeper/reconcile.py
+++ b/custom_components/home_keeper/reconcile.py
@@ -103,18 +103,21 @@ def reconcile_part_tasks(
                 },
                 now=now,
             )
-            # Anchor the floating clock to the recorded replacement, or to creation
-            # ("assumed fresh") so that later interval edits re-base off a stable
-            # point instead of drifting to now+interval on each edit.
-            task["last_completed"] = anchored or task["created"]
-            task["next_due"] = recurrence.compute_next_due(task, now=now).isoformat()
+            # Anchor the floating clock to the recorded replacement. With no
+            # recorded replacement we leave last_completed unset (build_task's
+            # default), so the part reads as due now rather than "assumed fresh" a
+            # full interval out: an unknown replacement history is better surfaced
+            # now — the user can backdate the replacement or mark it done — than
+            # silently hidden for a cycle.
+            if anchored:
+                task["last_completed"] = anchored
+                task["next_due"] = recurrence.compute_next_due(task, now=now).isoformat()
             result[task["id"]] = task
             changed = True
         else:
             # Only pass fields that actually changed. Passing interval/unit
             # unconditionally would re-trigger a next_due recompute on every
-            # reconcile (setup, any asset edit) and, for a task with no
-            # last_completed, drift next_due forward to now+interval each time.
+            # reconcile (setup, any asset edit), needlessly churning the schedule.
             before = result[tid]
             updates: dict[str, Any] = {}
             if before.get("name") != name:

--- a/tests/unit/test_reconcile.py
+++ b/tests/unit/test_reconcile.py
@@ -53,13 +53,15 @@ def test_creates_task_anchored_on_last_replaced():
     ).isoformat()
 
 
-def test_creates_task_anchored_on_creation_when_no_last_replaced():
+def test_creates_task_due_now_when_no_last_replaced():
     asset = _asset(parts=[_wear_part()])
     tasks, _ = _reconcile({"a1": asset})
     task = _only(tasks)
-    # No recorded replacement → "assumed fresh" at creation.
-    assert task["last_completed"] == task["created"] == NOW.isoformat()
-    assert task["next_due"] == r.compute_floating_next_due(NOW, 12, "months", now=NOW).isoformat()
+    # No recorded replacement → due now (not "assumed fresh" a full interval out).
+    # An unknown replacement history is surfaced now; the user can backdate the
+    # replacement or mark it done.
+    assert task["last_completed"] is None
+    assert task["next_due"] == NOW.isoformat()
 
 
 def test_uses_appliance_fallback_when_asset_name_blank():


### PR DESCRIPTION
## What

When Home Keeper derives a maintenance task from an appliance **wear item that has no "Last replaced" date**, the task now reads as **due immediately** instead of being scheduled a full replacement interval into the future ("assumed fresh").

## Why

The general floating-task path already does this — a brand-new floating task with no completion history has been due-now since `0.2.0b2` (#17). Wear-part-derived tasks were the one remaining place that still assumed "no history = just done", anchoring the floating clock to the task's creation time.

That assumption is the riskier default: an unknown replacement history is better surfaced now (the user can backdate the part's last-replaced date or mark the task done) than silently hidden for an entire cycle. This makes one consistent mental model across the product — **no history = do it now** — and the backdate escape hatch already shipped in #27.

## Changes

- `reconcile.py`: when a wear part has no `last_replaced`, leave `last_completed` unset (build_task's due-now default) instead of falling back to `created`. Parts *with* a recorded replacement date are unaffected.
- Refreshed two comments in `reconcile.py` that referenced the pre-`0.2.0b2` "now+interval" assumption, which no longer holds (an unseeded floating task now recomputes to `now`, not `now + interval`).
- Updated the unit test (`test_creates_task_due_now_when_no_last_replaced`) and added a CHANGELOG entry.

## Testing

- `pytest tests/unit` — 182 passed.
- No integration test asserts a due date for the one seeded wear part with `last_replaced: null` (T&P relief valve), and the name-edit drift regression still holds (name isn't a recurrence field, so no recompute).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZPPhEnioJ5gCaB8YxwFCd

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZPPhEnioJ5gCaB8YxwFCd)_