### PR TITLE
Release 0.3.0b5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas)
 
 ## [Unreleased]
 
+## [0.3.0b5] - 2026-06-17
+
+- **Flexible appliance metadata — custom fields replace the fixed metadata form.**
+  An appliance's descriptive details are now a free-form list of **custom fields**
+  instead of a fixed set of inputs. Each field has a label and a type — **text**,
+  **link**, or **date** — and you add as many as you like, with one-click seeds for
+  the common ones (serial number, warranty expiry, purchase/install dates, provider,
+  vendor, notes). Links are clickable and open in the browser. A date field is
+  display-only unless you tick **Track as a sensor**, which surfaces it as a `date`
+  sensor on the device for automations (e.g. *"warranty expiring in 30 days → notify"*)
+  — so you no longer get a sensor for every date whether you use it or not.
+  Manufacturer, model, manual link, cost, icon and area remain dedicated fields (they
+  wire into the Home Assistant device card and the inventory export), and the
+  insurance inventory export keeps its value totals while listing each appliance's
+  custom fields in a new **Details** column. *Note: this changes how appliance
+  metadata is stored; pre-release, an existing appliance's old descriptive fields are
+  not migrated.*
+
 - **A wear-item maintenance task with no recorded replacement date is now due now,
   not "assumed fresh".** When Home Keeper derives a replacement task from an appliance
   wear item that has no "Last replaced" date, it used to assume the part was fresh and

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.3.0b4"
+PANEL_VERSION = "0.3.0b5"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/prestomation/ha-home-keeper/issues",
   "requirements": [],
-  "version": "0.3.0b4"
+  "version": "0.3.0b5"
 }


### PR DESCRIPTION
Beta release **0.3.0b5**.

Bumps `manifest.json` `version` and `const.py` `PANEL_VERSION` to `0.3.0b5` (they match, as `release.yml` requires) and adds the `## [0.3.0b5]` changelog section. Merging this triggers `release.yml` to tag `v0.3.0b5`, build the panel + `home_keeper.zip`, and publish a GitHub **pre-release** (HACS offers it only to users with betas enabled).

### Included since 0.3.0b4
- **Flexible appliance metadata** — descriptive appliance details become a free-form list of typed **custom fields** (text/link/date) with one-click seeds; dates are opt-in `date` sensors via a *Track as a sensor* toggle; links are clickable; inventory export gains a Details column. (#30)
- **Wear-item task with no recorded replacement now reads as due immediately** rather than assuming the part is fresh. (#29)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QCT4anYWAGG57ZKWzhNF97)_