### PR TITLE
test(e2e): enable recorder in the test HA config (silence unknown_command)

### DIFF
--- a/tests/integration/ha_config/.gitignore
+++ b/tests/integration/ha_config/.gitignore
@@ -2,6 +2,8 @@
 # (e.g. via ci/e2e-up.sh). Only the seeded fixtures below are tracked.
 *.log
 *.log.*
+*.db
+*.db-*
 .HA_VERSION
 .ha_run.lock
 blueprints/

--- a/tests/integration/ha_config/configuration.yaml
+++ b/tests/integration/ha_config/configuration.yaml
@@ -12,6 +12,13 @@ api:
 # Enable frontend (required for the custom sidebar panel + Lovelace resources)
 frontend:
 
+# Enable the recorder. A real HA install always has it (via default_config); this
+# minimal test config omits default_config, so without this the HA frontend's
+# `recorder/info` probe at load is rejected as an unknown command and surfaces as an
+# unhandled websocket rejection in the browser console. Enabling it keeps the e2e
+# environment representative and the console clean.
+recorder:
+
 # Dedicated YAML dashboard used by the Playwright e2e suite. The default
 # (storage-mode) dashboard from onboarding is left untouched. The Home Keeper
 # todo/calendar entities resolve via HA's built-in cards.


### PR DESCRIPTION
## What

Enable the `recorder` integration in the e2e/integration HA config (`tests/integration/ha_config/configuration.yaml`), and gitignore its runtime SQLite DB.

## Why

Exploratory Playwright testing surfaced a single **unhandled websocket rejection at panel load**: `{"code":"unknown_command"}`. Probing the socket showed the failing command is **`recorder/info`** — an HA *core* command issued by the **HA frontend itself**, not by Home Keeper (every `home_keeper/*` command the panel calls is registered).

The test config is minimal and omits `default_config`, so the `recorder` integration was never set up (HA log: `Nothing to set up in stage recorder` → repeated `Received unknown command: recorder/info`). Enabling `recorder:` makes the test environment representative of a real install (which always has recorder via `default_config`) and removes the console noise.

**No user-facing impact** — real installs always have recorder, so users never saw this. This is a developer/test-environment change only (no `CHANGELOG.md` entry per AGENTS.md).

## Verified

- Re-probed the socket after enabling recorder: `WS_ERRORS: []` (rejection gone).
- Full e2e suite green locally (23/23) with recorder enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QCT4anYWAGG57ZKWzhNF97)_