### PR TITLE
feat: comprehensive lifecycle events &amp; automation-editor triggers

### DIFF
--- a/.amazonq/rules/architecture-and-code.md
+++ b/.amazonq/rules/architecture-and-code.md
@@ -92,6 +92,29 @@ reviewing code in this repository (the `home_keeper` Home Assistant integration)
 - Read-only/report actions use `SupportsResponse.ONLY`; data mutations reload the
   entry or refresh the coordinator exactly as the equivalent CRUD service does.
 
+## Events are the observation surface — fire one for every state change
+- **Every observable state change fires a documented `home_keeper_<noun>_<verb>` bus
+  event**, built by a **pure function in `events.py`** (no HA imports) so the test fake
+  (`testing.py`) and integrators test against the exact shipped payload — it can't
+  drift. Fire at the **`store.py` mutation chokepoint**, not in a service handler, so
+  every surface (panel, service, websocket, contributing integration) is observed
+  uniformly. *Every* path that mutates the task/asset map counts — including the
+  non-CRUD ones (`reconcile_part_tasks`, `detach_tasks_from_device`, `delete_asset`'s
+  cascade), which must fire their own create/update/delete events.
+- **Edge-triggered transitions live in a pure module + the coordinator.** Time-based
+  events (`overdue`/`due_soon`) are detected by `transitions.detect_transitions` (pure,
+  unit-tested with an injected `now`) and fired from `coordinator._async_update_data`;
+  stock crossings (`low`/`out`/`restocked`) come from `assets.stock_transition`. Fire
+  **once per crossing** (keyed on `next_due` / threshold), never every refresh, and
+  **baseline silently on startup** (the coordinator gates firing until setup completes)
+  so a restart never replays a transition storm.
+- **Keep the catalog in sync.** A new event is not done until it's in
+  [`docs/EVENTS.md`](../../docs/EVENTS.md) (the canonical catalog: when it fires,
+  payload, semantics) and, if device-facing, exposed as a `device_trigger.py` trigger
+  with `strings.json` `device_automation` labels at full translation parity. Events are
+  *observations* of changes that already flow through services/store methods, so they
+  need **no** new service.
+
 ## Errors, validation & security
 - Service handlers raise `ServiceValidationError` for user-facing errors.
   Websocket commands return structured errors via `connection.send_error`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,12 @@ rules. Keep the rules and `AGENTS.md` consistent with each other.
   for the service: add the service first (with a `services.yaml` entry and
   `strings.json` localization parity), and have any websocket command delegate to
   the same store method. See `.amazonq/rules/architecture-and-code.md`.
+- **Fire a `home_keeper_<noun>_<verb>` event for every state change.** Built by a pure
+  builder in `events.py`, fired at the `store.py` chokepoint (including the non-CRUD
+  mutation paths), edge-triggered for transitions (`transitions.py` + the coordinator,
+  baselined silently on startup). A new event isn't done until it's in `docs/EVENTS.md`
+  and, if device-facing, in `device_trigger.py` with translation-parity labels. Events
+  need no new service. See `.amazonq/rules/architecture-and-code.md` and `docs/EVENTS.md`.
 - Tasks are plain dicts: `id, name, notes, recurrence_type, interval, unit|freq,
   anchor, device_id, area_id, enabled, last_completed, next_due, completions[]`.
 - All datetimes are timezone-aware (`homeassistant.util.dt`); `recurrence.py` takes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas)
 
 ## [Unreleased]
 
+### Added
+
+- **Comprehensive events for everything that happens — and automation-editor
+  triggers.** Home Keeper now fires a Home Assistant bus event for every meaningful
+  change, so you can automate on the full lifecycle instead of just completions and
+  low-stock. New events: tasks **created / updated / deleted / uncompleted / triggered**
+  and the time-based **overdue** and **due-soon** transitions; spare parts **out of
+  stock** and **restocked** (alongside the existing low-stock); and appliances
+  **created / updated / deleted**. The time and stock transitions are *edge-triggered*
+  (one event per crossing, never repeated every cycle) and are silently baselined on
+  restart, so a reboot never replays an "overdue" storm. Each event also shows up as a
+  **device trigger** in the visual automation editor — on a task's device or an
+  appliance you can pick *"Task became overdue"* or *"Spare part out of stock"* without
+  knowing the event name. The existing `home_keeper_task_completed` payload gains the
+  full task spine (device/area/recurrence/next-due/enabled) on top of its long-standing
+  fields. See the new [docs/EVENTS.md](docs/EVENTS.md) for the full catalog, payloads
+  and example automations.
+
+### Changed
+
+- **A spare part dropping straight to zero now fires `home_keeper_part_out_of_stock`,
+  not `home_keeper_part_low_stock`.** Out-of-stock is the more specific event and takes
+  precedence. If you had an automation listening for `home_keeper_part_low_stock` to
+  catch a part reaching zero, switch it to (or also listen for)
+  `home_keeper_part_out_of_stock`. A part crossing into low *without* hitting zero still
+  fires `home_keeper_part_low_stock` as before.
+
 ## [0.3.0b5] - 2026-06-17
 
 - **Flexible appliance metadata — custom fields replace the fixed metadata form.**

--- a/README.md
+++ b/README.md
@@ -174,8 +174,44 @@ sensor next to your *Piano*) — which show up alongside the appliance in the pa
 Task services: `home_keeper.add_task`, `update_task`, `delete_task`, `complete_task`,
 `trigger_task` (arm a condition-driven task), and `list_tasks` (returns a response).
 
-Appliance services: `home_keeper.add_asset`, `update_asset`, `delete_asset`, and
-`list_assets` (returns a response). All are available for automations.
+Appliance services: `home_keeper.add_asset`, `update_asset`, `delete_asset`,
+`adjust_part_stock`, `list_assets` and `export_inventory` (the last two return a
+response). All are available for automations.
+
+## Events & automations
+
+**Use case:** *"tell me when maintenance falls behind, or a spare runs out — and let me
+wire it into the rest of my home."* Home Keeper fires a Home Assistant **bus event** for
+every meaningful change so you can automate on it:
+
+- **Tasks** — created, updated, completed, uncompleted, deleted, armed, and the
+  time-based **overdue** / **due-soon** transitions.
+- **Spare parts** — **low stock**, **out of stock**, and **restocked**.
+- **Appliances** — created, updated, deleted.
+
+**How you use it.** Two ways: pick a **device trigger** in the visual automation editor
+(on a task's device or an appliance you'll see entries like *"Task became overdue"* or
+*"Spare part out of stock"* — no event names to memorise), or use a plain `platform:
+event` trigger for global automations. For example, *spare part out of stock → add it to
+the shopping list*:
+
+```yaml
+automation:
+  - alias: "Spare out of stock → shopping list"
+    trigger:
+      - platform: event
+        event_type: home_keeper_part_out_of_stock
+    action:
+      - service: todo.add_item
+        target: { entity_id: todo.shopping_list }
+        data:
+          item: "{{ trigger.event.data.part_name }} ({{ trigger.event.data.vendor }})"
+```
+
+The events are **edge-triggered** (one event per crossing, never repeated each cycle)
+and silently baselined on restart (no “overdue” storm after a reboot). The full catalog
+— every event, its payload, and more examples — is in
+[docs/EVENTS.md](docs/EVENTS.md).
 
 ## Integrating with Home Keeper
 

--- a/custom_components/home_keeper/__init__.py
+++ b/custom_components/home_keeper/__init__.py
@@ -180,6 +180,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     _register_services(hass)
+    # Setup is complete: the refreshes above have baselined current overdue/due-soon
+    # state silently, so start firing those events only for transitions from here on.
+    coordinator.enable_transition_events()
     return True
 
 

--- a/custom_components/home_keeper/assets.py
+++ b/custom_components/home_keeper/assets.py
@@ -311,33 +311,63 @@ def part_is_low(part: dict) -> bool:
     return stock is not None and reorder is not None and stock <= reorder
 
 
-def consume_part_stock(part: dict) -> bool:
+# Stock-change outcomes, returned by ``stock_transition`` / ``consume_part_stock`` /
+# ``adjust_part_stock``. Each maps to one bus event (or none); see store.py.
+STOCK_NONE = "none"
+STOCK_LOW = "low"
+STOCK_OUT = "out"
+STOCK_RESTOCKED = "restocked"
+
+
+def stock_transition(old: int, new: int, reorder_at: int | None) -> str:
+    """Classify a stock change from *old* to *new* as a single edge transition.
+
+    Returns one of ``"none" | "low" | "out" | "restocked"``. This is the pure core
+    behind the edge-triggered stock events: it fires once *per crossing* rather than on
+    every step. Precedence matters — ``"out"`` (reaching zero) wins over ``"low"`` so a
+    single decrement that drops an already-low part to zero is reported as out-of-stock,
+    not a (repeat) low-stock. A part with no ``reorder_at`` threshold is untracked and
+    never transitions.
+    """
+    if reorder_at is None:
+        return STOCK_NONE
+    if new == 0 and old > 0:
+        return STOCK_OUT
+    if new <= reorder_at and old > reorder_at:
+        return STOCK_LOW
+    if new > reorder_at and old <= reorder_at:
+        return STOCK_RESTOCKED
+    return STOCK_NONE
+
+
+def consume_part_stock(part: dict) -> str:
     """Decrement a part's on-hand ``stock`` by one (never below zero).
 
-    A no-op for parts that don't track stock. Returns ``True`` only when this
-    consumption *crosses* the part from not-low into low (edge-triggered), so the
-    caller emits one low-stock signal per crossing rather than on every step while
-    already low.
+    A no-op (``STOCK_NONE``) for parts that don't track stock. Otherwise returns the
+    edge transition (``stock_transition``) this consumption caused, so the caller emits
+    at most one stock event per crossing rather than on every step while already low.
     """
     stock = part.get("stock")
     if stock is None:
-        return False
-    was_low = part_is_low(part)
-    part["stock"] = max(0, int(stock) - 1)
-    return part_is_low(part) and not was_low
+        return STOCK_NONE
+    old = int(stock)
+    new = max(0, old - 1)
+    part["stock"] = new
+    return stock_transition(old, new, part.get("reorder_at"))
 
 
-def adjust_part_stock(part: dict, delta: int) -> bool:
+def adjust_part_stock(part: dict, delta: int) -> str:
     """Adjust a part's on-hand ``stock`` by ``delta`` (clamped at zero).
 
-    Begins tracking from zero for a previously untracked part. Returns ``True`` only
-    when the adjustment *crosses* the part from not-low into low (edge-triggered); a
-    restock, or a decrease while already low, returns ``False``.
+    Begins tracking from zero for a previously untracked part. Returns the edge
+    transition (``stock_transition``) the adjustment caused — ``"low"`` / ``"out"`` on a
+    decrease that crosses a threshold, ``"restocked"`` when a restock lifts it back above
+    the reorder point, else ``"none"``.
     """
-    was_low = part_is_low(part)
-    current = part.get("stock") or 0
-    part["stock"] = max(0, int(current) + int(delta))
-    return part_is_low(part) and not was_low
+    old = int(part.get("stock") or 0)
+    new = max(0, old + int(delta))
+    part["stock"] = new
+    return stock_transition(old, new, part.get("reorder_at"))
 
 
 def normalize_fields(data: dict) -> dict:

--- a/custom_components/home_keeper/binary_sensor.py
+++ b/custom_components/home_keeper/binary_sensor.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
-
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -17,8 +15,7 @@ from . import recurrence
 from .const import DOMAIN
 from .coordinator import HomeKeeperCoordinator
 from .entity import HomeKeeperTaskEntity
-
-DUE_SOON_WINDOW = timedelta(days=3)
+from .transitions import DUE_SOON_WINDOW  # shared so the event and entity agree
 
 
 async def async_setup_entry(

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -44,6 +44,32 @@ EVENT_TASK_COMPLETED = f"{DOMAIN}_task_completed"
 # shopping integration. Payload is built in events.low_stock_event_data.
 EVENT_PART_LOW_STOCK = f"{DOMAIN}_part_low_stock"
 
+# Comprehensive event catalog (see docs/EVENTS.md). Every observable Home Keeper
+# state change fires a bus event built by a pure function in events.py, so
+# automations and other integrations can react to the full lifecycle — not just
+# completion and low-stock. Names follow ``{DOMAIN}_<noun>_<verb>``; payloads share
+# the common "spine" (events.task_event_data / events.asset_event_data).
+#
+# Task lifecycle — fired at the store.py mutation chokepoints.
+EVENT_TASK_CREATED = f"{DOMAIN}_task_created"
+EVENT_TASK_UPDATED = f"{DOMAIN}_task_updated"  # payload carries ``changed_fields``
+EVENT_TASK_DELETED = f"{DOMAIN}_task_deleted"
+EVENT_TASK_UNCOMPLETED = f"{DOMAIN}_task_uncompleted"  # a completion was undone
+EVENT_TASK_TRIGGERED = f"{DOMAIN}_task_triggered"  # a triggered task was armed
+# Time-based transitions — fired (edge-triggered) from the coordinator. A task is
+# announced at most once per ``next_due`` value while HA is running; see
+# transitions.detect_transitions and coordinator._async_update_data.
+EVENT_TASK_OVERDUE = f"{DOMAIN}_task_overdue"  # + ``days_overdue``
+EVENT_TASK_DUE_SOON = f"{DOMAIN}_task_due_soon"  # + ``due_in_hours``
+# Stock transitions — the siblings of EVENT_PART_LOW_STOCK, edge-triggered the same
+# way (see assets.stock_transition). out_of_stock wins over low on a single step.
+EVENT_PART_OUT_OF_STOCK = f"{DOMAIN}_part_out_of_stock"
+EVENT_PART_RESTOCKED = f"{DOMAIN}_part_restocked"
+# Asset (appliance) lifecycle — fired at the store.py asset chokepoints.
+EVENT_ASSET_CREATED = f"{DOMAIN}_asset_created"
+EVENT_ASSET_UPDATED = f"{DOMAIN}_asset_updated"  # payload carries ``changed_fields``
+EVENT_ASSET_DELETED = f"{DOMAIN}_asset_deleted"
+
 # Assets / appliances (virtual devices + asset metadata).
 # A virtual asset device is registered with identifier
 # (DOMAIN, f"{ASSET_IDENTIFIER_PREFIX}_{asset_id}"); the prefix keeps it from

--- a/custom_components/home_keeper/coordinator.py
+++ b/custom_components/home_keeper/coordinator.py
@@ -20,7 +20,9 @@ except ImportError:  # pragma: no cover - older HA fallback
     from homeassistant.helpers.entity import DeviceInfo  # type: ignore[no-redef]
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.util import dt as dt_util
 
+from . import transitions
 from .const import DOMAIN
 from .store import HomeKeeperStore
 
@@ -61,9 +63,33 @@ class HomeKeeperCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         )
         self.store = store
         self.entry = entry
+        # Edge state for the time-based task events (overdue / due-soon). Carried
+        # across refreshes so each is fired at most once per ``next_due``; see
+        # transitions.detect_transitions.
+        self._edge_state: transitions.StateMap = {}
+        # Firing is gated until setup finishes (enable_transition_events) so the
+        # several refreshes during async_setup_entry silently *baseline* current state
+        # — an HA restart never replays an "overdue" storm for tasks already overdue.
+        self._events_enabled = False
+
+    def enable_transition_events(self) -> None:
+        """Start firing overdue/due-soon events (called once setup is complete).
+
+        Until this is called, refreshes still update the edge state but fire nothing,
+        so the post-restart steady state is baselined silently and only genuine
+        transitions observed while running are announced.
+        """
+        self._events_enabled = True
 
     async def _async_update_data(self) -> dict[str, dict[str, Any]]:
-        return self.store.get_tasks()
+        tasks = self.store.get_tasks()
+        fired, self._edge_state = transitions.detect_transitions(
+            self._edge_state, tasks, now=dt_util.now()
+        )
+        if self._events_enabled:
+            for event_name, payload in fired:
+                self.hass.bus.async_fire(event_name, payload)
+        return tasks
 
     def device_attached_task_ids(self) -> list[str]:
         """Enabled task ids attached to a device (so get per-task entities)."""

--- a/custom_components/home_keeper/device_trigger.py
+++ b/custom_components/home_keeper/device_trigger.py
@@ -1,0 +1,159 @@
+"""Device automation triggers for Home Keeper.
+
+Surfaces the Home Keeper bus events (see ``docs/EVENTS.md``) in Home Assistant's
+**visual automation editor**: on a task's device page you can pick *"Task became
+overdue"*; on an appliance you can pick *"Spare part out of stock"* — no need to know
+the raw event name. Each device trigger is a thin wrapper over the corresponding bus
+event, filtered to the chosen device.
+
+The filter key depends on the device kind, because a self-owned task device carries
+``device_id: null`` in its task events (the task has no attached ``device_id``):
+
+* **Self-owned task device** — registry identifier ``(DOMAIN, task_id)``. Its events
+  can only be matched by ``task_id``; filtering by ``device_id`` would match nothing
+  and leak every other standalone task. → filter on ``task_id``.
+* **Existing device with attached tasks**, or a **virtual appliance device** — shared
+  by potentially several tasks/parts; their events carry the registry ``device_id``.
+  → filter on ``device_id``.
+
+Global (non-device) automations use a plain ``platform: event`` trigger instead; see
+``docs/EVENTS.md``.
+"""
+
+from __future__ import annotations
+
+import voluptuous as vol
+from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
+from homeassistant.components.homeassistant.triggers import event as event_trigger
+from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF_TYPE
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
+from homeassistant.helpers.typing import ConfigType
+
+from .const import (
+    ASSET_IDENTIFIER_PREFIX,
+    DOMAIN,
+    EVENT_PART_LOW_STOCK,
+    EVENT_PART_OUT_OF_STOCK,
+    EVENT_PART_RESTOCKED,
+    EVENT_TASK_COMPLETED,
+    EVENT_TASK_CREATED,
+    EVENT_TASK_DUE_SOON,
+    EVENT_TASK_OVERDUE,
+    EVENT_TASK_UPDATED,
+)
+from .coordinator import HomeKeeperCoordinator
+
+# trigger_type -> bus event. Task triggers are offered for any device with Home Keeper
+# tasks; appliance (stock) triggers for any Home Keeper appliance device.
+TASK_TRIGGERS = {
+    "task_completed": EVENT_TASK_COMPLETED,
+    "task_overdue": EVENT_TASK_OVERDUE,
+    "task_due_soon": EVENT_TASK_DUE_SOON,
+    "task_created": EVENT_TASK_CREATED,
+    "task_updated": EVENT_TASK_UPDATED,
+}
+ASSET_TRIGGERS = {
+    "part_low_stock": EVENT_PART_LOW_STOCK,
+    "part_out_of_stock": EVENT_PART_OUT_OF_STOCK,
+    "part_restocked": EVENT_PART_RESTOCKED,
+}
+_EVENT_BY_TYPE = {**TASK_TRIGGERS, **ASSET_TRIGGERS}
+
+# Sentinel filter that can never match a real event id — used when a device has lost
+# the tasks/assets that made a trigger offerable, so the automation simply never fires
+# rather than erroring.
+_NO_MATCH = {"task_id": "\0home_keeper_no_match"}
+
+TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
+    {vol.Required(CONF_TYPE): vol.In(set(_EVENT_BY_TYPE))}
+)
+
+
+def _coordinator(hass: HomeAssistant) -> HomeKeeperCoordinator | None:
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        coord = getattr(entry, "runtime_data", None)
+        if isinstance(coord, HomeKeeperCoordinator):
+            return coord
+    return None
+
+
+def _hk_identifier(device) -> str | None:
+    """Return the Home Keeper registry identifier value for *device*, or None."""
+    for domain, value in device.identifiers:
+        if domain == DOMAIN:
+            return value
+    return None
+
+
+def _filters(hass: HomeAssistant, device_id: str) -> tuple[dict | None, dict | None]:
+    """Return ``(task_filter, asset_filter)`` event-data filters for *device_id*.
+
+    Either is ``None`` when the device has no Home Keeper tasks / appliance parts of
+    that kind (so that trigger type isn't offered). See the module docstring for why the
+    task filter keys on ``task_id`` for a self-owned device but ``device_id`` otherwise.
+    """
+    device = dr.async_get(hass).async_get(device_id)
+    if device is None:
+        return None, None
+    coord = _coordinator(hass)
+    tasks = list(coord.store.get_tasks().values()) if coord else []
+    assets = coord.store.list_assets() if coord else []
+    ident = _hk_identifier(device)
+    asset_prefix = f"{ASSET_IDENTIFIER_PREFIX}_"
+
+    task_filter: dict | None = None
+    asset_filter: dict | None = None
+
+    if ident is not None and not ident.startswith(asset_prefix):
+        # Self-owned task device: identifier is the bare task id; its events carry no
+        # device_id, so match on task_id.
+        if any(task.get("id") == ident for task in tasks):
+            task_filter = {"task_id": ident}
+    else:
+        # Virtual appliance device, or an existing/foreign device tasks & assets attach
+        # to: their events carry this registry device_id.
+        if any(task.get("device_id") == device_id for task in tasks):
+            task_filter = {"device_id": device_id}
+        if any(asset.get("device_id") == device_id for asset in assets):
+            asset_filter = {"device_id": device_id}
+
+    return task_filter, asset_filter
+
+
+async def async_get_triggers(
+    hass: HomeAssistant, device_id: str
+) -> list[dict[str, str]]:
+    """List the Home Keeper device triggers available for *device_id*."""
+    task_filter, asset_filter = _filters(hass, device_id)
+    base = {CONF_PLATFORM: "device", CONF_DOMAIN: DOMAIN, CONF_DEVICE_ID: device_id}
+    triggers: list[dict[str, str]] = []
+    if task_filter is not None:
+        triggers += [{**base, CONF_TYPE: t} for t in TASK_TRIGGERS]
+    if asset_filter is not None:
+        triggers += [{**base, CONF_TYPE: t} for t in ASSET_TRIGGERS]
+    return triggers
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: TriggerActionType,
+    trigger_info: TriggerInfo,
+) -> CALLBACK_TYPE:
+    """Attach a Home Keeper device trigger by delegating to the event trigger."""
+    trigger_type = config[CONF_TYPE]
+    task_filter, asset_filter = _filters(hass, config[CONF_DEVICE_ID])
+    event_data = asset_filter if trigger_type in ASSET_TRIGGERS else task_filter
+
+    event_config = event_trigger.TRIGGER_SCHEMA(
+        {
+            event_trigger.CONF_PLATFORM: "event",
+            event_trigger.CONF_EVENT_TYPE: _EVENT_BY_TYPE[trigger_type],
+            event_trigger.CONF_EVENT_DATA: event_data if event_data is not None else _NO_MATCH,
+        }
+    )
+    return await event_trigger.async_attach_trigger(
+        hass, event_config, action, trigger_info, platform_type="device"
+    )

--- a/custom_components/home_keeper/events.py
+++ b/custom_components/home_keeper/events.py
@@ -11,32 +11,85 @@ from __future__ import annotations
 from typing import Any
 
 
+def task_event_data(
+    task: dict[str, Any], *, extra: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """Return the common "spine" payload shared by every task event.
+
+    One template works across `home_keeper_task_created` / `_updated` / `_deleted` /
+    `_completed` / `_uncompleted` / `_triggered` / `_overdue` / `_due_soon`: the same
+    identity (``task_id``/``name``), attachment (``device_id``/``area_id``), schedule
+    state (``recurrence_type``/``next_due``/``enabled``), and the opaque ``source`` /
+    well-known ``managed_by`` blocks Home Keeper echoes verbatim. ``device_id`` is the
+    task's stored registry device id (already a registry id; echoed as-is, or ``None``
+    when the task isn't attached to a device — its per-task entities then live on a
+    self-owned device keyed on ``task_id``). Per-event extras (``changed_fields``,
+    ``days_overdue``, ``due_in_hours``) are merged in via *extra*.
+    """
+    data: dict[str, Any] = {
+        "task_id": task.get("id"),
+        "name": task.get("name"),
+        "device_id": task.get("device_id"),
+        "area_id": task.get("area_id"),
+        "recurrence_type": task.get("recurrence_type"),
+        "next_due": task.get("next_due"),
+        "enabled": task.get("enabled", True),
+        "source": task.get("source"),
+        "managed_by": task.get("managed_by"),
+    }
+    if extra:
+        data.update(extra)
+    return data
+
+
 def completion_event_data(
     task: dict[str, Any], when: Any, origin: str | None
 ) -> dict[str, Any]:
     """Return the ``home_keeper_task_completed`` event data for a completed task.
 
+    The common task spine plus the completion-specific ``completed_at`` and ``origin``.
     ``when`` is the completion datetime (or an ISO string); ``origin`` is the opaque
-    caller marker. ``source`` is echoed verbatim from the task.
+    caller marker. The task passed in is the *post-completion* task, so ``next_due`` is
+    already the next occurrence (``None`` for a now-dormant triggered task).
     """
-    return {
-        "task_id": task.get("id"),
-        "name": task.get("name"),
-        "source": task.get("source"),
-        "managed_by": task.get("managed_by"),
-        "completed_at": when.isoformat() if hasattr(when, "isoformat") else when,
-        "origin": origin,
+    return task_event_data(
+        task,
+        extra={
+            "completed_at": when.isoformat() if hasattr(when, "isoformat") else when,
+            "origin": origin,
+        },
+    )
+
+
+def asset_event_data(
+    asset: dict[str, Any], *, extra: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """Return the common payload for `home_keeper_asset_*` lifecycle events.
+
+    Carries the appliance identity and its registry ``device_id`` (``None`` until a
+    virtual asset's device is provisioned). Per-event extras (``changed_fields`` for an
+    update) merge in via *extra*.
+    """
+    data: dict[str, Any] = {
+        "asset_id": asset.get("id"),
+        "asset_name": asset.get("name") or "",
+        "device_id": asset.get("device_id"),
     }
+    if extra:
+        data.update(extra)
+    return data
 
 
-def low_stock_event_data(
+def stock_event_data(
     asset: dict[str, Any], part: dict[str, Any]
 ) -> dict[str, Any]:
-    """Return the ``home_keeper_part_low_stock`` event data for a low spare part.
+    """Return the shared payload for the three `home_keeper_part_*` stock events.
 
-    Carries enough to drive an automation (notify, add to a shopping list,
-    reorder) without re-querying: which appliance and part, the part/vendor
-    identifiers needed to rebuy, and the current vs. threshold counts.
+    Low-stock, out-of-stock and restocked all carry the same shape so an automation
+    template is interchangeable across them. Carries enough to drive an automation
+    (notify, add to a shopping list, reorder) without re-querying: which appliance and
+    part, the part/vendor identifiers needed to rebuy, and the current vs. threshold
+    counts.
     """
     return {
         "asset_id": asset.get("id"),
@@ -49,3 +102,8 @@ def low_stock_event_data(
         "stock": part.get("stock"),
         "reorder_at": part.get("reorder_at"),
     }
+
+
+# Back-compat alias: the low-stock event predates the generalised stock events and is
+# the documented name integrators built against (docs/INTEGRATING.md).
+low_stock_event_data = stock_event_data

--- a/custom_components/home_keeper/store.py
+++ b/custom_components/home_keeper/store.py
@@ -17,17 +17,48 @@ from homeassistant.helpers.storage import Store
 from homeassistant.util import dt as dt_util
 
 from . import assets, events, models, recurrence
+from .assets import STOCK_LOW, STOCK_OUT, STOCK_RESTOCKED
 from .const import (
+    EVENT_ASSET_CREATED,
+    EVENT_ASSET_DELETED,
+    EVENT_ASSET_UPDATED,
     EVENT_PART_LOW_STOCK,
+    EVENT_PART_OUT_OF_STOCK,
+    EVENT_PART_RESTOCKED,
     EVENT_TASK_COMPLETED,
+    EVENT_TASK_CREATED,
+    EVENT_TASK_DELETED,
+    EVENT_TASK_TRIGGERED,
+    EVENT_TASK_UNCOMPLETED,
+    EVENT_TASK_UPDATED,
     REC_TRIGGERED,
     STORAGE_KEY,
     STORAGE_VERSION,
 )
+
+# Stock transition -> the bus event it fires (STOCK_NONE maps to nothing).
+_STOCK_EVENT = {
+    STOCK_LOW: EVENT_PART_LOW_STOCK,
+    STOCK_OUT: EVENT_PART_OUT_OF_STOCK,
+    STOCK_RESTOCKED: EVENT_PART_RESTOCKED,
+}
 from .reconcile import part_source as _part_source
 from .reconcile import reconcile_part_tasks as _reconcile_part_tasks
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _changed_fields(before: dict[str, Any], after: dict[str, Any]) -> list[str]:
+    """Top-level keys whose value differs between *before* and *after*.
+
+    Drives the ``changed_fields`` payload on the update events (and the decision to
+    suppress a no-op update event entirely). Backend-managed bookkeeping keys that
+    aren't user-meaningful are ignored so a reschedule doesn't spam ``next_due``/
+    ``completions`` churn as "changes".
+    """
+    ignore = {"completions", "last_completed", "next_due", "created"}
+    keys = (set(before) | set(after)) - ignore
+    return sorted(k for k in keys if before.get(k) != after.get(k))
 
 
 class HomeKeeperStore:
@@ -102,6 +133,7 @@ class HomeKeeperStore:
         self._tasks[task["id"]] = task
         await self._save()
         _LOGGER.debug("Added task %s (%s)", task["id"], task["name"])
+        self._hass.bus.async_fire(EVENT_TASK_CREATED, events.task_event_data(task))
         return task
 
     async def update_task(self, task_id: str, updates: dict[str, Any]) -> dict[str, Any]:
@@ -111,6 +143,14 @@ class HomeKeeperStore:
         merged = models.merge_update(existing, updates, now=dt_util.now())
         self._tasks[task_id] = merged
         await self._save()
+        # Fire only on a real change; carry which fields moved so automations can react
+        # selectively (e.g. a rename vs. a schedule change).
+        changed = _changed_fields(existing, merged)
+        if changed:
+            self._hass.bus.async_fire(
+                EVENT_TASK_UPDATED,
+                events.task_event_data(merged, extra={"changed_fields": changed}),
+            )
         return merged
 
     async def trigger_task(self, task_id: str) -> dict[str, Any]:
@@ -134,6 +174,7 @@ class HomeKeeperStore:
         existing["next_due"] = dt_util.now().isoformat()
         await self._save()
         _LOGGER.debug("Triggered task %s (armed, due now)", task_id)
+        self._hass.bus.async_fire(EVENT_TASK_TRIGGERED, events.task_event_data(existing))
         return existing
 
     async def delete_task(self, task_id: str, *, force: bool = False) -> None:
@@ -155,9 +196,11 @@ class HomeKeeperStore:
                     f"Delete it from {display_name} instead."
                 )
         if task_id in self._tasks:
-            self._archive_task_history(self._tasks[task_id])
+            removed = self._tasks[task_id]
+            self._archive_task_history(removed)
             del self._tasks[task_id]
             await self._save()
+            self._hass.bus.async_fire(EVENT_TASK_DELETED, events.task_event_data(removed))
 
     def managed_task_orphaned(self, task: dict[str, Any]) -> bool:
         """Whether a managed task's owning integration is no longer present.
@@ -208,6 +251,13 @@ class HomeKeeperStore:
                 changed.append(tid)
         if changed:
             await self._save()
+            for tid in changed:
+                self._hass.bus.async_fire(
+                    EVENT_TASK_UPDATED,
+                    events.task_event_data(
+                        self._tasks[tid], extra={"changed_fields": ["device_id"]}
+                    ),
+                )
         return changed
 
     # ── asset reads ────────────────────────────────────────────────────────────
@@ -229,6 +279,7 @@ class HomeKeeperStore:
         self._assets[asset["id"]] = asset
         await self._save()
         _LOGGER.debug("Added asset %s (%s)", asset["id"], asset.get("name"))
+        self._hass.bus.async_fire(EVENT_ASSET_CREATED, events.asset_event_data(asset))
         return asset
 
     async def update_asset(
@@ -244,6 +295,12 @@ class HomeKeeperStore:
         merged = assets.merge_update(existing, updates, now=dt_util.now())
         self._assets[asset_id] = merged
         await self._save()
+        changed = _changed_fields(existing, merged)
+        if changed:
+            self._hass.bus.async_fire(
+                EVENT_ASSET_UPDATED,
+                events.asset_event_data(merged, extra={"changed_fields": changed}),
+            )
         return merged
 
     def _validate_parent(
@@ -289,15 +346,23 @@ class HomeKeeperStore:
         asset = self._assets.pop(asset_id, None)
         if asset is None:
             return None
-        self._tasks = {
-            tid: t
+        dropped_ids = {
+            tid
             for tid, t in self._tasks.items()
-            if _part_source(t) is None or _part_source(t).get("asset_id") != asset_id
+            if _part_source(t) is not None and _part_source(t).get("asset_id") == asset_id
+        }
+        dropped = [self._tasks[tid] for tid in dropped_ids]
+        self._tasks = {
+            tid: t for tid, t in self._tasks.items() if tid not in dropped_ids
         }
         for child in self._assets.values():
             if child.get("parent_asset_id") == asset_id:
                 child["parent_asset_id"] = None
         await self._save()
+        # The appliance and the wear-part tasks it owned are both gone — announce each.
+        for task in dropped:
+            self._hass.bus.async_fire(EVENT_TASK_DELETED, events.task_event_data(task))
+        self._hass.bus.async_fire(EVENT_ASSET_DELETED, events.asset_event_data(asset))
         return asset
 
     async def reconcile_part_tasks(self) -> bool:
@@ -306,19 +371,37 @@ class HomeKeeperStore:
         Delegates the (pure) computation to :func:`reconcile.reconcile_part_tasks`
         and persists the result. Returns ``True`` if any task changed.
         """
+        old_tasks = self._tasks
         new_tasks, changed = _reconcile_part_tasks(
-            self._assets, self._tasks, now=dt_util.now()
+            self._assets, old_tasks, now=dt_util.now()
         )
         if changed:
             # A part-derived task dropped here means its wear part was removed while
             # the appliance remains; preserve its history on the appliance. (Deleting
             # the whole appliance drops its derived tasks via delete_asset, before any
             # reconcile, so this only archives part removals — not appliance deletes.)
-            for tid, task in self._tasks.items():
-                if tid not in new_tasks and _part_source(task):
+            removed = [
+                task for tid, task in old_tasks.items() if tid not in new_tasks
+            ]
+            for task in removed:
+                if _part_source(task):
                     self._archive_task_history(task)
             self._tasks = new_tasks
             await self._save()
+            # Wear-part tasks are created/removed here, bypassing add_task/delete_task,
+            # so fire their lifecycle events directly (else this whole class of task is
+            # silent to automations). Reconcile-time *edits* are intentionally not fired
+            # as updates — they're internal churn (name/interval re-derivation), not a
+            # user action.
+            for task in removed:
+                self._hass.bus.async_fire(
+                    EVENT_TASK_DELETED, events.task_event_data(task)
+                )
+            for tid, task in new_tasks.items():
+                if tid not in old_tasks:
+                    self._hass.bus.async_fire(
+                        EVENT_TASK_CREATED, events.task_event_data(task)
+                    )
         return changed
 
     async def complete_task(
@@ -368,6 +451,7 @@ class HomeKeeperStore:
         updated = recurrence.remove_completion(dict(existing), ts, now=dt_util.now())
         self._tasks[task_id] = updated
         await self._save()
+        self._hass.bus.async_fire(EVENT_TASK_UNCOMPLETED, events.task_event_data(updated))
         return updated
 
     async def delete_archived_completion(
@@ -396,35 +480,40 @@ class HomeKeeperStore:
             if part.get("id") == src.get("part_id"):
                 part["last_replaced"] = when_date
                 # Completing a wear-part replacement consumes one stocked spare;
-                # signal a reorder if that drops it to/below its threshold.
-                if assets.consume_part_stock(part):
-                    self._emit_low_stock(asset, part)
+                # signal a low/out-of-stock crossing so users can automate a reorder.
+                self._emit_stock_event(assets.consume_part_stock(part), asset, part)
                 break
 
-    def _emit_low_stock(self, asset: dict[str, Any], part: dict[str, Any]) -> None:
-        """Fire the low-stock event so users can automate a reorder / shopping-list add."""
-        self._hass.bus.async_fire(
-            EVENT_PART_LOW_STOCK, events.low_stock_event_data(asset, part)
-        )
+    def _emit_stock_event(
+        self, transition: str, asset: dict[str, Any], part: dict[str, Any]
+    ) -> None:
+        """Fire the bus event for a stock *transition* (low / out / restocked), if any.
+
+        Edge-triggered: ``assets.stock_transition`` returns the crossing this change
+        caused (or ``none``), so users can automate a reorder / shopping-list add /
+        "back in stock" notification without Home Keeper owning a shopping integration.
+        """
+        event = _STOCK_EVENT.get(transition)
+        if event is not None:
+            self._hass.bus.async_fire(event, events.stock_event_data(asset, part))
 
     async def adjust_part_stock(
         self, asset_id: str, part_id: str, delta: int
     ) -> dict[str, Any]:
         """Change a part's on-hand spare count by ``delta`` (clamped at zero).
 
-        Persists and, when the adjustment crosses the part from not-low into low,
-        fires the low-stock event once (a restock, or a decrease while already low,
-        never nags). Returns the updated asset. Raises ``KeyError`` for an unknown
-        asset or part.
+        Persists and fires the matching edge-triggered stock event once when the
+        adjustment crosses a threshold — low-stock, out-of-stock, or restocked (a
+        decrease while already low never nags). Returns the updated asset. Raises
+        ``KeyError`` for an unknown asset or part.
         """
         asset = self._assets.get(asset_id)
         if asset is None:
             raise KeyError(asset_id)
         for part in asset.get("parts", []):
             if part.get("id") == part_id:
-                crossed_low = assets.adjust_part_stock(part, delta)
+                transition = assets.adjust_part_stock(part, delta)
                 await self._save()
-                if crossed_low:
-                    self._emit_low_stock(asset, part)
+                self._emit_stock_event(transition, asset, part)
                 return asset
         raise KeyError(part_id)

--- a/custom_components/home_keeper/strings.json
+++ b/custom_components/home_keeper/strings.json
@@ -314,5 +314,17 @@
         "name": "{task_name}Mark done"
       }
     }
+  },
+  "device_automation": {
+    "trigger_type": {
+      "task_completed": "Task completed",
+      "task_overdue": "Task became overdue",
+      "task_due_soon": "Task due soon",
+      "task_created": "Task created",
+      "task_updated": "Task updated",
+      "part_low_stock": "Spare part low on stock",
+      "part_out_of_stock": "Spare part out of stock",
+      "part_restocked": "Spare part restocked"
+    }
   }
 }

--- a/custom_components/home_keeper/testing.py
+++ b/custom_components/home_keeper/testing.py
@@ -36,7 +36,14 @@ from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
 from homeassistant.util import dt as dt_util
 
 from . import events, models, recurrence
-from .const import DOMAIN, EVENT_TASK_COMPLETED
+from .const import (
+    DOMAIN,
+    EVENT_TASK_COMPLETED,
+    EVENT_TASK_CREATED,
+    EVENT_TASK_DELETED,
+    EVENT_TASK_TRIGGERED,
+    EVENT_TASK_UPDATED,
+)
 
 # Permissive schema: the fake mirrors behaviour, not validation. Your integration's
 # real calls still flow through Home Keeper's strict schemas in production.
@@ -60,17 +67,25 @@ class FakeHomeKeeper:
     async def _add_task(self, call: ServiceCall) -> dict[str, Any]:
         task = models.build_task(dict(call.data), now=dt_util.now())
         self.tasks[task["id"]] = task
+        self.hass.bus.async_fire(EVENT_TASK_CREATED, events.task_event_data(task))
         return {"task_id": task["id"]}
 
     async def _update_task(self, call: ServiceCall) -> None:
         data = dict(call.data)
         task_id = data.pop("task_id")
-        self.tasks[task_id] = models.merge_update(
-            self.tasks[task_id], data, now=dt_util.now()
-        )
+        merged = models.merge_update(self.tasks[task_id], data, now=dt_util.now())
+        self.tasks[task_id] = merged
+        changed = sorted(k for k in data if k != "task_id")
+        if changed:
+            self.hass.bus.async_fire(
+                EVENT_TASK_UPDATED,
+                events.task_event_data(merged, extra={"changed_fields": changed}),
+            )
 
     async def _delete_task(self, call: ServiceCall) -> None:
-        self.tasks.pop(call.data["task_id"], None)
+        task = self.tasks.pop(call.data["task_id"], None)
+        if task is not None:
+            self.hass.bus.async_fire(EVENT_TASK_DELETED, events.task_event_data(task))
 
     async def _complete_task(self, call: ServiceCall) -> None:
         self._complete(
@@ -91,6 +106,7 @@ class FakeHomeKeeper:
                 "trigger_task is only valid for triggered (condition-driven) tasks"
             )
         task["next_due"] = dt_util.now().isoformat()
+        self.hass.bus.async_fire(EVENT_TASK_TRIGGERED, events.task_event_data(task))
 
     async def _list_tasks(self, call: ServiceCall) -> dict[str, Any]:
         return {"tasks": [dict(t) for t in self.tasks.values()]}

--- a/custom_components/home_keeper/transitions.py
+++ b/custom_components/home_keeper/transitions.py
@@ -1,0 +1,97 @@
+"""Pure edge-detection for Home Keeper's time-based task events.
+
+The coordinator wakes periodically (and after every mutation) and holds the current
+task map, but a due date passing is not itself a mutation — nothing *calls* anything
+when ``now`` crosses a task's ``next_due``. This module turns "what the tasks look
+like now" plus "what we already announced" into the set of `home_keeper_task_overdue`
+/ `home_keeper_task_due_soon` events to fire, **edge-triggered** so each is announced
+at most once per ``next_due`` value.
+
+It imports nothing from Home Assistant (only the pure ``recurrence``/``events`` core
+and ``const``), so the crossing logic — fire-once, reset-on-reschedule, skip
+dormant/disabled — is unit-testable with an injected ``now``. The coordinator owns the
+small state map and does the actual ``hass.bus`` firing; see
+``coordinator._async_update_data``.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+from . import events, recurrence
+from .const import EVENT_TASK_DUE_SOON, EVENT_TASK_OVERDUE
+
+# How far ahead of ``next_due`` a task counts as "due soon". Matches the binary
+# sensor's ``due_soon`` attribute window so the event and the entity agree.
+DUE_SOON_WINDOW = timedelta(days=3)
+
+# Per-task edge state carried between coordinator refreshes. Keyed by task id:
+#   {"next_due": <iso|None>, "due_soon_fired": bool, "overdue_fired": bool}
+# The two flags are independent because a task crosses *due-soon first, then overdue*
+# against the **same** ``next_due`` — a bare next_due key couldn't fire both. The flags
+# reset whenever ``next_due`` changes (a completion/reschedule/re-arm), which naturally
+# re-arms the next announcement.
+TaskEdgeState = dict[str, Any]
+StateMap = dict[str, TaskEdgeState]
+
+
+def detect_transitions(
+    prev: StateMap,
+    tasks: dict[str, dict[str, Any]],
+    *,
+    now: Any,
+    window: timedelta = DUE_SOON_WINDOW,
+) -> tuple[list[tuple[str, dict[str, Any]]], StateMap]:
+    """Return ``(fired, next_state)`` for the current *tasks* against *prev* state.
+
+    ``fired`` is a list of ``(event_name, payload)`` ready for the caller to put on the
+    bus; ``next_state`` is the new per-task edge state to carry forward. A task fires
+    ``due_soon`` once when it enters the window and ``overdue`` once when it reaches
+    ``next_due`` — never again for the same ``next_due``. Dormant (``next_due is None``)
+    and disabled tasks never fire (they're still tracked, so re-arming/re-enabling
+    starts fresh). Tasks absent from *tasks* drop out of the state (deleted tasks can't
+    leak stale flags).
+    """
+    fired: list[tuple[str, dict[str, Any]]] = []
+    next_state: StateMap = {}
+
+    for tid, task in tasks.items():
+        next_due = task.get("next_due")
+        prior = prev.get(tid)
+        if prior is not None and prior.get("next_due") == next_due:
+            due_soon_fired = bool(prior.get("due_soon_fired"))
+            overdue_fired = bool(prior.get("overdue_fired"))
+        else:
+            # New task, or its schedule moved — re-arm both announcements.
+            due_soon_fired = False
+            overdue_fired = False
+
+        if task.get("enabled", True) and next_due is not None:
+            parsed = recurrence._parse(next_due)
+            if not due_soon_fired and recurrence.is_due_soon(task, window, now=now):
+                due_in_hours = round((parsed - now).total_seconds() / 3600, 1)
+                fired.append(
+                    (
+                        EVENT_TASK_DUE_SOON,
+                        events.task_event_data(task, extra={"due_in_hours": due_in_hours}),
+                    )
+                )
+                due_soon_fired = True
+            if not overdue_fired and recurrence.is_overdue(task, now=now):
+                days_overdue = (now - parsed).days
+                fired.append(
+                    (
+                        EVENT_TASK_OVERDUE,
+                        events.task_event_data(task, extra={"days_overdue": days_overdue}),
+                    )
+                )
+                overdue_fired = True
+
+        next_state[tid] = {
+            "next_due": next_due,
+            "due_soon_fired": due_soon_fired,
+            "overdue_fired": overdue_fired,
+        }
+
+    return fired, next_state

--- a/custom_components/home_keeper/translations/ca.json
+++ b/custom_components/home_keeper/translations/ca.json
@@ -314,5 +314,17 @@
         "name": "{task_name}Marca com a fet"
       }
     }
+  },
+  "device_automation": {
+    "trigger_type": {
+      "task_completed": "Task completed",
+      "task_overdue": "Task became overdue",
+      "task_due_soon": "Task due soon",
+      "task_created": "Task created",
+      "task_updated": "Task updated",
+      "part_low_stock": "Spare part low on stock",
+      "part_out_of_stock": "Spare part out of stock",
+      "part_restocked": "Spare part restocked"
+    }
   }
 }

--- a/custom_components/home_keeper/translations/cs.json
+++ b/custom_components/home_keeper/translations/cs.json
@@ -314,5 +314,17 @@
         "name": "{task_name}Označit jako hotové"
       }
     }
+  },
+  "device_automation": {
+    "trigger_type": {
+      "task_completed": "Task completed",
+      "task_overdue": "Task became overdue",
+      "task_due_soon": "Task due soon",
+      "task_created": "Task created",
+      "task_updated": "Task updated",
+      "part_low_stock": "Spare part low on stock",
+      "part_out_of_stock": "Spare part out of stock",
+      "part_restocked": "Spare part restocked"
+    }
   }
 }

--- a/custom_components/home_keeper/translations/da.json
+++ b/custom_components/home_keeper/translations/da.json
@@ -314,5 +314,17 @@
         "name": "{task_name}Markér som udført"
       }
     }
+  },
+  "device_automation": {
+    "trigger_type": {
+      "task_completed": "Task completed",
+      "task_overdue": "Task became overdue",
+      "task_due_soon": "Task due soon",
+      "task_created": "Task created",
+      "task_updated": "Task updated",
+      "part_low_stock": "Spare part low on stock",
+      "part_out_of_stock": "Spare part out of stock",
+      "part_restocked": "Spare part restocked"
+    }
   }
 }

--- a/custom_components/home_keeper/translations/de.json
+++ b/custom_components/home_keeper/translations/de.json
@@ -314,5 +314,17 @@
         "name": "{task_name}Als erledigt markieren"
       }
     }
+  },
+  "device_automation": {
+    "trigger_type": {
+      "task_completed": "Task completed",
+      "task_overdue": "Task became overdue",
+      "task_due_soon": "Task due soon",
+      "task_created": "Task created",
+      "task_updated": "Task updated",
+      "part_low_stock": "Spare part low on stock",
+      "part_out_of_stock": "Spare part out of stock",
+      "part_restocked": "Spare part restocked"
+    }
   }
 }

--- a/custom_components/home_keeper/translations/en.json
+++ b/custom_components/home_keeper/translations/en.json
@@ -314,5 +314,17 @@
         "name": "{task_name}Mark done"
       }
     }
+  },
+  "device_automation": {
+    "trigger_type": {
+      "task_completed": "Task completed",
+      "task_overdue": "Task became overdue",
+      "task_due_soon": "Task due soon",
+      "task_created": "Task created",
+      "task_updated": "Task updated",
+      "part_low_stock": "Spare part low on stock",
+      "part_out_of_stock": "Spare part out of stock",
+      "part_restocked": "Spare part restocked"
+    }
   }
 }

--- a/custom_components/home_keeper/translations/es.json
+++ b/custom_components/home_keeper/translations/es.json
@@ -314,5 +314,17 @@
         "name": "{task_name}Marcar como hecho"
       }
     }
+  },
+  "device_automation": {
+    "trigger_type": {
+      "task_completed": "Task completed",
+      "task_overdue": "Task became overdue",
+      "task_due_soon": "Task due soon",
+      "task_created": "Task created",
+      "task_updated": "Task updated",
+      "part_low_stock": "Spare part low on stock",
+      "part_out_of_stock": "Spare part out of stock",
+      "part_restocked": "Spare part restocked"
+    }
   }
 }

--- a/custom_components/home_keeper/translations/fi.json
+++ b/custom_components/home_keeper/translations/fi.json
@@ -314,5 +314,17 @@
         "name": "{task_name}Merkitse valmiiksi"
       }
     }
+  },
+  "device_automation": {
+    "trigger_type": {
+      "task_completed": "Task completed",
+      "task_overdue": "Task became overdue",
+      "task_due_soon": "Task due soon",
+      "task_created": "Task created",
+      "task_updated": "Task updated",
+      "part_low_stock": "Spare part low on stock",
+      "part_out_of_stock": "Spare part out of stock",
+      "part_restocked": "Spare part restocked"
+    }
   }
 }

--- a/custom_components/home_keeper/translations/fr.json
+++ b/custom_components/home_keeper/translations/fr.json
@@ -314,5 +314,17 @@
         "name": "{task_name}Marquer comme terminé"
       }
     }
+  },
+  "device_automation": {
+    "trigger_type": {
+      "task_completed": "Task completed",
+      "task_overdue": "Task became overdue",
+      "task_due_soon": "Task due soon",
+      "task_created": "Task created",
+      "task_updated": "Task updated",
+      "part_low_stock": "Spare part low on stock",
+      "part_out_of_stock": "Spare part out of stock",
+      "part_restocked": "Spare part restocked"
+    }
   }
 }

--- a/custom_components/home_keeper/translations/it.json
+++ b/custom_components/home_keeper/translations/it.json
@@ -314,5 +314,17 @@
         "name": "{task_name}Segna come completata"
       }
     }
+  },
+  "device_automation": {
+    "trigger_type": {
+      "task_completed": "Task completed",
+      "task_overdue": "Task became overdue",
+      "task_due_soon": "Task due soon",
+      "task_created": "Task created",
+      "task_updated": "Task updated",
+      "part_low_stock": "Spare part low on stock",
+      "part_out_of_stock": "Spare part out of stock",
+      "part_restocked": "Spare part restocked"
+    }
   }
 }

--- a/custom_components/home_keeper/translations/nb.json
+++ b/custom_components/home_keeper/translations/nb.json
@@ -314,5 +314,17 @@
         "name": "{task_name}Merk som fullført"
       }
     }
+  },
+  "device_automation": {
+    "trigger_type": {
+      "task_completed": "Task completed",
+      "task_overdue": "Task became overdue",
+      "task_due_soon": "Task due soon",
+      "task_created": "Task created",
+      "task_updated": "Task updated",
+      "part_low_stock": "Spare part low on stock",
+      "part_out_of_stock": "Spare part out of stock",
+      "part_restocked": "Spare part restocked"
+    }
   }
 }

--- a/custom_components/home_keeper/translations/nl.json
+++ b/custom_components/home_keeper/translations/nl.json
@@ -314,5 +314,17 @@
         "name": "{task_name}Als klaar markeren"
       }
     }
+  },
+  "device_automation": {
+    "trigger_type": {
+      "task_completed": "Task completed",
+      "task_overdue": "Task became overdue",
+      "task_due_soon": "Task due soon",
+      "task_created": "Task created",
+      "task_updated": "Task updated",
+      "part_low_stock": "Spare part low on stock",
+      "part_out_of_stock": "Spare part out of stock",
+      "part_restocked": "Spare part restocked"
+    }
   }
 }

--- a/custom_components/home_keeper/translations/pl.json
+++ b/custom_components/home_keeper/translations/pl.json
@@ -314,5 +314,17 @@
         "name": "{task_name}Oznacz jako wykonane"
       }
     }
+  },
+  "device_automation": {
+    "trigger_type": {
+      "task_completed": "Task completed",
+      "task_overdue": "Task became overdue",
+      "task_due_soon": "Task due soon",
+      "task_created": "Task created",
+      "task_updated": "Task updated",
+      "part_low_stock": "Spare part low on stock",
+      "part_out_of_stock": "Spare part out of stock",
+      "part_restocked": "Spare part restocked"
+    }
   }
 }

--- a/custom_components/home_keeper/translations/pt-BR.json
+++ b/custom_components/home_keeper/translations/pt-BR.json
@@ -314,5 +314,17 @@
         "name": "{task_name}Marcar como concluído"
       }
     }
+  },
+  "device_automation": {
+    "trigger_type": {
+      "task_completed": "Task completed",
+      "task_overdue": "Task became overdue",
+      "task_due_soon": "Task due soon",
+      "task_created": "Task created",
+      "task_updated": "Task updated",
+      "part_low_stock": "Spare part low on stock",
+      "part_out_of_stock": "Spare part out of stock",
+      "part_restocked": "Spare part restocked"
+    }
   }
 }

--- a/custom_components/home_keeper/translations/ru.json
+++ b/custom_components/home_keeper/translations/ru.json
@@ -314,5 +314,17 @@
         "name": "{task_name}Отметить выполненным"
       }
     }
+  },
+  "device_automation": {
+    "trigger_type": {
+      "task_completed": "Task completed",
+      "task_overdue": "Task became overdue",
+      "task_due_soon": "Task due soon",
+      "task_created": "Task created",
+      "task_updated": "Task updated",
+      "part_low_stock": "Spare part low on stock",
+      "part_out_of_stock": "Spare part out of stock",
+      "part_restocked": "Spare part restocked"
+    }
   }
 }

--- a/custom_components/home_keeper/translations/sv.json
+++ b/custom_components/home_keeper/translations/sv.json
@@ -314,5 +314,17 @@
         "name": "{task_name}Markera som klar"
       }
     }
+  },
+  "device_automation": {
+    "trigger_type": {
+      "task_completed": "Task completed",
+      "task_overdue": "Task became overdue",
+      "task_due_soon": "Task due soon",
+      "task_created": "Task created",
+      "task_updated": "Task updated",
+      "part_low_stock": "Spare part low on stock",
+      "part_out_of_stock": "Spare part out of stock",
+      "part_restocked": "Spare part restocked"
+    }
   }
 }

--- a/custom_components/home_keeper/translations/zh-Hans.json
+++ b/custom_components/home_keeper/translations/zh-Hans.json
@@ -314,5 +314,17 @@
         "name": "{task_name}标记为完成"
       }
     }
+  },
+  "device_automation": {
+    "trigger_type": {
+      "task_completed": "Task completed",
+      "task_overdue": "Task became overdue",
+      "task_due_soon": "Task due soon",
+      "task_created": "Task created",
+      "task_updated": "Task updated",
+      "part_low_stock": "Spare part low on stock",
+      "part_out_of_stock": "Spare part out of stock",
+      "part_restocked": "Spare part restocked"
+    }
   }
 }

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -1,0 +1,164 @@
+# Home Keeper events & automation triggers
+
+Home Keeper fires a Home Assistant **bus event** for every meaningful thing that
+happens — a task is created, edited, completed, deleted, becomes overdue or due-soon; a
+spare part runs low, runs out, or is restocked; an appliance is added, changed, or
+removed. This is the surface automations and other integrations build on.
+
+You can react to these events two ways:
+
+1. **Visual automation editor (device triggers).** On a task's device page or an
+   appliance, *Add automation → When* lists Home Keeper triggers like **“Task became
+   overdue”** or **“Spare part out of stock”** — no need to know the event name. These
+   are scoped to that device.
+2. **Event trigger (any automation).** For global automations (“*any* part low → add to
+   one shopping list”), use a plain `platform: event` trigger on the event name below.
+
+> Integrators pushing tasks into Home Keeper should also read
+> [INTEGRATING.md](INTEGRATING.md); this document is the full event reference.
+
+## Event catalog
+
+All event names follow `home_keeper_<noun>_<verb>`. Task events share a common
+**spine**; stock events share one shape; asset events share another (see
+[Payloads](#payloads)).
+
+### Task lifecycle
+
+| Event | Fires when |
+|---|---|
+| `home_keeper_task_created` | a task is created (panel, service, contributing integration, or a wear-part task auto-generated from an appliance) |
+| `home_keeper_task_updated` | a task actually changes; payload adds `changed_fields` |
+| `home_keeper_task_deleted` | a task is removed (directly, or because its appliance/part was) |
+| `home_keeper_task_completed` | a task is completed from **any** surface (to-do checkbox, device button, `complete_task`); payload adds `completed_at`, `origin` |
+| `home_keeper_task_uncompleted` | a completion is undone (`next_due` is re-derived) |
+| `home_keeper_task_triggered` | a condition-driven (triggered) task is armed (dormant → due-now) |
+
+### Time-based transitions (edge-triggered)
+
+| Event | Fires when |
+|---|---|
+| `home_keeper_task_overdue` | a task first crosses its due date (`now ≥ next_due`); payload adds `days_overdue` |
+| `home_keeper_task_due_soon` | a task enters the 3-day window before `next_due`; payload adds `due_in_hours` |
+
+These are detected by the coordinator’s periodic refresh (every 5 minutes) and are
+**edge-triggered**: each fires **at most once per `next_due` value**. A task that stays
+overdue does not re-fire; completing or rescheduling it re-arms the next announcement.
+
+**Restart behaviour.** On startup Home Keeper *baselines* the current state silently —
+a restart never replays an “overdue” storm for tasks that were already overdue. Only
+transitions observed while Home Assistant is running fire. (The per-task overdue
+`binary_sensor` always reflects the steady state regardless.)
+
+### Stock transitions (edge-triggered)
+
+| Event | Fires when |
+|---|---|
+| `home_keeper_part_low_stock` | spare stock crosses to **≤ `reorder_at`** |
+| `home_keeper_part_out_of_stock` | spare stock reaches **0** |
+| `home_keeper_part_restocked` | spare stock recovers **back above `reorder_at`** |
+
+Edge-triggered the same way: one event per crossing, never on every step while already
+low. A part must track **both** `stock` and `reorder_at` to fire anything. A single
+change that drops an already-low part to zero fires **`out_of_stock`** (the more
+specific event), not `low_stock`.
+
+### Asset (appliance) lifecycle
+
+| Event | Fires when |
+|---|---|
+| `home_keeper_asset_created` | an appliance is created |
+| `home_keeper_asset_updated` | an appliance changes; payload adds `changed_fields` |
+| `home_keeper_asset_deleted` | an appliance is removed |
+
+## Payloads
+
+### Task event spine
+
+Every task event carries this core (per-event extras noted above are merged in):
+
+| Field | Type | Notes |
+|---|---|---|
+| `task_id` | `str` | |
+| `name` | `str` | |
+| `device_id` | `str \| None` | the task’s registry device id, or `None` when it’s a standalone task (its entities then live on a self-owned device) |
+| `area_id` | `str \| None` | |
+| `recurrence_type` | `str` | `floating` / `fixed` / `triggered` |
+| `next_due` | `str \| None` | ISO; `None` for a dormant triggered task |
+| `enabled` | `bool` | |
+| `source` | `dict \| None` | opaque provenance, echoed verbatim ([INTEGRATING.md](INTEGRATING.md)) |
+| `managed_by` | `dict \| None` | well-known ownership block, or `None` |
+
+### Stock event payload
+
+`asset_id`, `asset_name`, `device_id`, `part_id`, `part_name`, `part_number`, `vendor`,
+`stock`, `reorder_at` — enough to drive a reorder/notify without re-querying. The three
+stock events are interchangeable in one template.
+
+### Asset event payload
+
+`asset_id`, `asset_name`, `device_id` (+ `changed_fields` for an update).
+
+## Example automations
+
+### Notify when anything becomes overdue (event trigger)
+
+```yaml
+automation:
+  - alias: "Maintenance overdue → notify"
+    trigger:
+      - platform: event
+        event_type: home_keeper_task_overdue
+    action:
+      - service: notify.mobile_app_phone
+        data:
+          message: >-
+            {{ trigger.event.data.name }} is overdue
+            ({{ trigger.event.data.days_overdue }} day(s)).
+```
+
+### Add a spare to the shopping list when it runs out (event trigger)
+
+```yaml
+automation:
+  - alias: "Spare out of stock → shopping list"
+    trigger:
+      - platform: event
+        event_type: home_keeper_part_out_of_stock
+    action:
+      - service: todo.add_item
+        target:
+          entity_id: todo.shopping_list
+        data:
+          item: >-
+            {{ trigger.event.data.part_name }}
+            {{ trigger.event.data.part_number }} ({{ trigger.event.data.vendor }})
+```
+
+### React only to a specific appliance (device trigger)
+
+In the automation editor, choose the appliance’s device and the **“Spare part low on
+stock”** trigger. The equivalent YAML:
+
+```yaml
+automation:
+  - alias: "Furnace filter low"
+    trigger:
+      - platform: device
+        domain: home_keeper
+        device_id: <furnace device id>
+        type: part_low_stock
+    action: ...
+```
+
+Device triggers filter to the chosen device automatically: an appliance/existing-device
+trigger matches the event’s `device_id`; a standalone task’s self-owned device matches
+its `task_id` (those task events carry `device_id: null`).
+
+## Notes for integrators
+
+- The `home_keeper_task_completed` payload now carries the full task spine in addition
+  to its long-standing `completed_at`/`origin` fields. If you only read `task_id`,
+  `source`, `origin`, and `completed_at`, nothing changes for you.
+- Home Keeper never inspects `source`; use it (and the `origin` echo on completions) to
+  recognise and de-dupe your own tasks. See [INTEGRATING.md](INTEGRATING.md).

--- a/docs/EVENTS_PLAN.md
+++ b/docs/EVENTS_PLAN.md
@@ -77,6 +77,16 @@ template uniformly.
 | `home_keeper_task_uncompleted` | `delete_completion` | a completion is undone (re-derives `next_due`) |
 | `home_keeper_task_triggered` | `trigger_task` | a condition-driven task is armed (dormant → due-now) |
 
+> **`add_task`/`delete_task` are not the only mutation paths.** Wear-part maintenance tasks
+> are created and removed by `reconcile_part_tasks` (`store.py:303`), which rewrites
+> `self._tasks` directly and **bypasses** `add_task`/`delete_task`. It must therefore fire
+> `task_created` / `task_deleted` for the tasks it adds/removes (diff `new_tasks` against the
+> old map), or that whole class of tasks is silent. Likewise `detach_tasks_from_device`
+> (`store.py:196`) clears `device_id` in place — fire `task_updated` with
+> `changed_fields: ["device_id"]` (or explicitly document it as a non-event). The "fire at
+> the chokepoint" rule means *every* path that mutates the task map, not just the two CRUD
+> services.
+
 ### Time-based transitions — fired from the coordinator, **edge-triggered**
 
 | Event | When |
@@ -108,7 +118,7 @@ Task events carry a common core, so one automation template works across all of 
 {
   "task_id": "…",
   "name": "…",
-  "device_id": "…",          // resolved registry device id, or null
+  "device_id": "…",          // the task's stored registry device id, echoed verbatim; null if unset
   "area_id": "…",            // null if none
   "recurrence_type": "floating|fixed|triggered",
   "next_due": "…ISO… | null",
@@ -119,8 +129,11 @@ Task events carry a common core, so one automation template works across all of 
 ```
 
 - `task_completed` adopts the common spine and carries its completion-specific extras
-  (`completed_at`, `origin`) on top. (Its current fields are a subset of the spine plus
-  these two, so in practice this is the spine + 2 — but we're no longer *constrained* to
+  (`completed_at`, `origin`) on top. Concretely, `completion_event_data` (`events.py:14`,
+  today only `task_id, name, source, managed_by, completed_at, origin`) gains the missing
+  spine fields `device_id, area_id, recurrence_type, next_due, enabled`. The task dict it's
+  built from is the *post-completion* task (`store.py:346-355`), so `next_due` is already
+  the next occurrence — echo `task.get("next_due")`. (We're no longer *constrained* to
   preserve the exact legacy shape; see the pre-1.0 note above.)
 - `task_updated` adds `changed_fields: ["name", "interval", …]`.
 - `task_overdue` adds `next_due` and `days_overdue`; `task_due_soon` adds `next_due` and
@@ -141,35 +154,75 @@ Keep the **detection logic pure and unit-testable** (matching the `recurrence.py
 `assets.py` convention) in a new `transitions.py` (no HA imports):
 
 ```python
-detect_transitions(prev: dict[str, str], tasks, now) -> (events: list, next_state: dict)
+# state per task: the next_due we announced for, and which events already fired for it
+detect_transitions(prev: dict[str, TaskEdgeState], tasks, now) -> (events, next_state)
 ```
 
-The coordinator holds the small `prev` state map (task_id → the `next_due` value already
-announced) and fires what `detect_transitions` returns. Firing stays in the HA layer; the
-edge logic stays pure.
+**Where it runs — the plan's earlier draft glossed this.** `_async_update_data`
+(`coordinator.py:65`) today only *reads* the store; it fires nothing. Override it so each
+refresh does: read the task map → call `detect_transitions(self._prev, tasks, now)` → fire
+the returned events on the bus → store `next_state` as `self._prev` → return the map. Because
+this runs on **both** the 5-min interval **and** every post-mutation
+`async_request_refresh()` (every service/store mutation already requests a refresh), a
+completion that re-arms a triggered task is observed promptly without a second mechanism.
+Firing stays in the HA layer; the edge logic in `transitions.py` stays pure.
 
 ### Decision B — Edge-triggering and idempotency (don't spam)
 
-Every transition event fires **once per crossing**, never on every 5-minute tick:
+Every transition event fires **once per crossing**, never on every 5-minute tick.
 
-- **Overdue / due-soon:** announce a task at most once per `next_due` value. Completing or
-  rescheduling advances `next_due`, which re-arms the next announcement naturally. The
-  state is keyed on `next_due`, so a task that is *still* overdue next cycle does **not**
-  refire.
+- **Per-task edge state — not a bare `next_due` key.** Keying only on the `next_due` *value*
+  isn't enough: a task crosses **due-soon first, then overdue** against the *same* `next_due`,
+  so the two events need independent "already-fired" flags, and re-firing must reset when
+  `next_due` changes. The state per task is therefore:
+
+  ```python
+  TaskEdgeState = {"next_due": str | None, "due_soon_fired": bool, "overdue_fired": bool}
+  ```
+
+  On each refresh, per task: if its `next_due` differs from the stored one, reset both flags
+  (a reschedule/completion re-arms it). Then fire `due_soon` once if now in the window and
+  `not due_soon_fired`; fire `overdue` once if `now >= next_due` and `not overdue_fired`;
+  set the flags. A task that is *still* overdue next cycle does **not** refire.
+- **Skip non-eligible tasks.** `recurrence.is_overdue`/`is_due_soon` (`recurrence.py:289`)
+  already return `False` when `next_due is None` — so **dormant triggered tasks** (next_due
+  `None`) and tasks with no due date never fire, and arming one (`trigger_task` → a fresh
+  `now` timestamp) is a `next_due` change that correctly re-arms a single overdue
+  announcement. Additionally **filter `enabled is False`**: a disabled task with a stale past
+  `next_due` must not fire. (Re-enabling does not replay missed events — its state is
+  baselined as of the next refresh.)
 - **Restart semantics (recommended): baseline silently on first refresh.** On the first
-  coordinator run after startup, seed the `prev` map from current state **without firing**,
-  so HA restarting doesn't replay an "overdue" storm for tasks that were already overdue.
-  Events then fire only for transitions observed *while HA is running*. The overdue
-  binary_sensor still reflects the steady state regardless, so nothing is lost — this only
-  governs the one-shot *event*. (Alternative: persist a per-task `overdue_announced` marker
-  in the store for cross-restart firing — rejected for v1 as storage churn for little gain;
-  noted as a future option.)
-- **Stock:** out-of-stock and restocked are edge-triggered exactly like the existing
-  low-stock crossing — extend the pure `assets.py` helpers to return a richer **transition
-  descriptor** (`none | low | out | restocked`) instead of today's bare `crossed_low`
-  boolean, then `store.py` maps that to the right event. One chokepoint, three events, no
-  double-firing (a single decrement that goes low *and* to zero fires the most specific:
-  `out_of_stock`).
+  coordinator run after startup, seed the per-task state from current values **without
+  firing**, so an HA restart doesn't replay an "overdue" storm for tasks that were already
+  overdue. Events then fire only for transitions observed *while HA is running*; the overdue
+  binary_sensor still reflects steady state, so nothing is lost — this governs only the
+  one-shot *event*. The state is in-memory (no per-tick storage writes). (Alternative:
+  persist the per-task markers for cross-restart firing — rejected for v1 as churn for
+  little gain; noted as a future option, along with a possible `replay`/clear escape hatch.)
+- **Stock — a pure transition function, not a bare boolean.** Today `consume_part_stock` /
+  `adjust_part_stock` (`assets.py:314,330`) return only `crossed_low: bool`, which **cannot
+  express out-of-stock**. Replace with a pure helper that compares old/new against *both*
+  thresholds, with `out` taking precedence over `low`:
+
+  ```python
+  def stock_transition(old: int, new: int, reorder_at: int | None) -> str:
+      if reorder_at is None:        # untracked part — never fires
+          return "none"
+      if new == 0 and old > 0:      # most specific; wins over a simultaneous low crossing
+          return "out"
+      if new <= reorder_at and old > reorder_at:
+          return "low"
+      if new > reorder_at and old <= reorder_at:
+          return "restocked"
+      return "none"
+  ```
+
+  `store.py` maps `out|low|restocked` to the corresponding event. Events fire **only when the
+  part tracks both `stock` and `reorder_at`** (untracked parts return `none`). This also
+  closes the gap where a part already at/below threshold drops to zero — the old boolean saw
+  "already low" and stayed silent; `stock_transition` fires `out`. Enumerate and update both
+  current callers (`_stamp_part_replacement` consume path, `adjust_part_stock`) when changing
+  the return type.
 
 ### Decision C — Automation-UI surface: device triggers
 
@@ -184,9 +237,20 @@ This works broadly because nearly everything in Home Keeper already has a regist
 `async_get_triggers(hass, device_id)` offers, per device, the relevant subset: *Task
 completed / overdue / due-soon* (and created/updated) for task devices; *Low stock /
 Out of stock / Restocked* for appliance devices. `async_attach_trigger` delegates to HA's
-`event_trigger` with the event type and a `device_id` filter on the payload — so the device
-trigger is a thin, well-tested wrapper over the same bus event. Trigger labels live in
-`strings.json` under `device_automation`, with **translation parity** across all 16 locales
+`event_trigger`, filtering the event payload — **but on the right key**:
+
+- A **self-owned task device** is `(DOMAIN, task_id)`, yet that task's event payload carries
+  `device_id: null` (its `device_id` is unset). Filtering by `device_id` would match nothing
+  *and* leak every other standalone task's events. So for a self-owned task device, resolve
+  the registry device back to its `task_id` (read the `(DOMAIN, …)` identifier) and filter on
+  **`event.data.task_id`**.
+- A task **attached to an existing device** (or an **asset/appliance** virtual device) is
+  shared by potentially several tasks/parts; filter on **`event.data.device_id`**.
+
+So `async_attach_trigger` picks the filter key from the device kind. (This is why the
+detector/builders must populate `task_id` on every task event and `device_id` on stock/asset
+events.) Trigger labels live in `strings.json` under `device_automation`, with **translation
+parity** across all 16 locales
 (enforced by `test_translations_parity.py`).
 
 Global, non-device automations (e.g. "*any* part low" → one shopping-list automation)
@@ -222,37 +286,56 @@ HA best-practices for the device triggers).
 3. **`assets.py`** — change `consume_part_stock` / `adjust_part_stock` to return a
    transition descriptor (`none|low|out|restocked`) instead of a bare boolean; pure, fully
    unit-tested across boundary values (`stock == reorder_at`, `0`, recovery).
-4. **`store.py`** — fire events at the chokepoints: `add_task`/`update_task`/`delete_task`/
-   `trigger_task`/`delete_completion`, `add_asset`/`update_asset`/`delete_asset`, and map
-   the stock descriptor in `_emit_low_stock`'s sibling(s). `update_task` fires only when
-   `merged != existing`, with `changed_fields` computed from the diff.
-5. **`testing.py`** — extend the fake to expose the new events via the same builders, so
-   integrators can test reactions (mirrors the existing `fire_user_completion`).
-6. **Tests** — unit (`events.py` builders, `assets.py` transitions), integration (each
-   mutation fires exactly one event with the right payload; no double-fire on a single
-   decrement that goes low-and-zero).
+4. **`store.py`** — fire events at **every** chokepoint that mutates the map, not just the
+   CRUD services:
+   - `add_task`/`update_task`/`delete_task`/`trigger_task`/`delete_completion`,
+     `add_asset`/`update_asset`/`delete_asset`, and the stock descriptor in the
+     `_emit_low_stock` sibling(s).
+   - **`reconcile_part_tasks`** (`store.py:303`) — diff `new_tasks` vs the old map and fire
+     `task_created`/`task_deleted` for the wear-part tasks it adds/removes (else they're
+     silent).
+   - **`detach_tasks_from_device`** (`store.py:196`) — fire `task_updated`
+     (`changed_fields: ["device_id"]`) for each task it clears.
+   - `update_task` fires only when `merged != existing`, with `changed_fields` from the diff.
+5. **`testing.py`** — extend the fake to fire the new events via the same `events.py`
+   builders (so the integrator contract can't drift), adding helpers mirroring
+   `fire_user_completion`: at least `fire_task_created(task)`, `fire_task_updated(task,
+   changed_fields)`, `fire_task_deleted(task_id)`, and the stock-event helpers. (Time-based
+   overdue/due-soon helpers come with Phase 2's `now` injection.)
+6. **Tests** — unit (`events.py` builders, `assets.py` `stock_transition` across all
+   boundaries: `==reorder_at`, →0, restock-from-0, untracked→`none`), integration (each
+   mutation fires exactly one event with the right payload; a single decrement crossing both
+   low and zero fires **`out_of_stock` only**; `reconcile_part_tasks` create/remove fire).
 
 ### Phase 2 — Time-based transitions (overdue / due-soon)
 
-1. **`transitions.py`** (new, pure) — `detect_transitions(prev, tasks, now)` returning the
-   events to fire and the next state map; `DUE_SOON_WINDOW` constant (default 24 h).
-2. **`coordinator.py`** — hold the `prev` map, baseline-on-first-refresh (Decision B), call
-   the detector each refresh, fire results on the bus. Fire on the **immediate** post-mutation
-   refresh too, so completing a task that re-arms a triggered one is observed promptly.
-3. **Tests** — unit: crossing fires once, still-overdue doesn't refire, completion re-arms,
-   startup baselines silently, DST/timezone-aware `now` (deterministic, injected `now`).
+1. **`transitions.py`** (new, pure) — `detect_transitions(prev, tasks, now)` over the
+   `TaskEdgeState` map (Decision B): per-task `due_soon_fired`/`overdue_fired` flags reset on
+   `next_due` change, skip `next_due is None` and `enabled is False`; `DUE_SOON_WINDOW`
+   constant (default 24 h).
+2. **`coordinator.py`** — override `_async_update_data` (Decision A) to read → detect → fire →
+   store `self._prev` → return. Baseline-on-first-refresh (no firing on the first run). Runs on
+   both the 5-min interval and every post-mutation `async_request_refresh()`, so a completion
+   re-arming a triggered task is observed promptly — no second mechanism.
+3. **Tests** — unit: due-soon then overdue both fire once for one `next_due`; still-overdue
+   doesn't refire; completion/reschedule re-arms; disabled task with stale `next_due` never
+   fires; dormant triggered task fires only on arm; startup baselines silently; DST/timezone
+   boundary on the due-soon window (deterministic, injected `now`).
 
 ### Phase 3 — Automation-UI device triggers
 
 1. **`device_trigger.py`** (new) — `async_get_triggers` (task vs appliance device subsets),
-   `async_attach_trigger` delegating to `event_trigger` with a `device_id` data filter,
-   `TRIGGER_SCHEMA`, and `async_get_trigger_capabilities` where useful.
+   `async_attach_trigger` delegating to `event_trigger` with the **filter key chosen by
+   device kind** (Decision C): `task_id` for self-owned task devices, `device_id` for
+   existing-device/asset devices. `TRIGGER_SCHEMA`, and `async_get_trigger_capabilities`
+   where useful.
 2. **`strings.json` + `translations/*.json`** — `device_automation.trigger_type` labels,
    parity across all locales (enforced by the parity test).
 3. **`manifest.json`** — no change (device triggers need no extra dependency).
-4. **Tests** — `async_get_triggers` returns the right set per device kind;
-   `async_attach_trigger` fires the action when the matching bus event is emitted; a
-   non-matching `device_id` does not.
+4. **Tests** — `async_get_triggers` returns the right set per device kind; a **self-owned
+   task device** trigger fires for *its* task's event and **not** for another standalone
+   task's (the `device_id: null` leak this avoids); an existing-device trigger fires for any
+   task on that device; a non-matching device does not fire.
 
 ### Phase 4 — Documentation (the deliverable's whole point)
 

--- a/docs/EVENTS_PLAN.md
+++ b/docs/EVENTS_PLAN.md
@@ -1,0 +1,326 @@
+# Comprehensive Events & Automation Hooks
+
+**Status: planned.** This document specifies a full, consistent set of Home Assistant
+**bus events** for every meaningful thing that happens in Home Keeper — a task is
+created, edited, completed, deleted, becomes overdue or due-soon; a spare part runs low,
+runs out, or is restocked; an appliance is added, changed, or removed — plus the
+**automation-UI triggers** that let users wire those events up from the visual automation
+editor without knowing the raw event names.
+
+Events are the interoperability surface. The existing two events
+(`home_keeper_task_completed`, `home_keeper_part_low_stock`) are already the documented
+hook other integrations subscribe to (`docs/INTEGRATING.md`); this generalises that one
+pattern into a complete, well-documented catalog so **automations and other integrations
+can react to the full lifecycle**, not just completion and low-stock.
+
+> **Back-compatible by construction.** The two existing event names and their payload
+> fields are frozen — this plan only **adds** events and **adds** fields to existing
+> payloads. No automation built today breaks.
+
+---
+
+## 1. What already exists (and what doesn't)
+
+Already present (the pattern to generalise):
+
+- **Two events, fired at the store chokepoint.** `complete_task()` fires
+  `home_keeper_task_completed` (`store.py:353`); the low-stock crossing fires
+  `home_keeper_part_low_stock` from `_emit_low_stock()` (`store.py:404-408`), reached
+  both on wear-part consumption (`_stamp_part_replacement`, `store.py:400`) and manual
+  `adjust_part_stock()` (`store.py:427`).
+- **Pure payload builders.** `events.py` builds both payloads (`completion_event_data`,
+  `low_stock_event_data`) with **no Home Assistant imports**, so the test fake
+  (`testing.py`) and integrators test against the exact shipped contract and it can't
+  drift. This is the convention every new event must follow.
+- **Event-name convention.** `EVENT_* = f"{DOMAIN}_<noun>_<verb>"` in `const.py:38,45`.
+- **Edge-triggered stock crossing.** `assets.consume_part_stock()` /
+  `assets.adjust_part_stock()` return `True` *only* on the transition into low, so the
+  event fires once, never nags (`assets.py`).
+- **A 5-minute coordinator refresh** (`coordinator.py:29`) that keeps time-based state
+  current — but only *reads* the task map (`_async_update_data`, `coordinator.py:65`); it
+  detects no transitions and fires no events.
+
+Gaps to close:
+
+1. **Mutations are invisible.** Creating, editing, deleting, triggering (arming), and
+   un-completing a task fire nothing. Asset create/update/delete fire nothing.
+2. **Overdue is never announced.** `recurrence.is_overdue()` (`recurrence.py:289`) is a
+   stateless, on-demand check used by the overdue binary_sensor; nothing fires when a task
+   *crosses* into overdue. There is no "due soon" concept at all.
+3. **Stock has only one of three transitions.** Low-stock fires, but **out-of-stock**
+   (reaches 0) and **restocked** (recovers above the threshold) do not.
+4. **No automation-UI surface.** Users must know the raw event string and hand-write a
+   `platform: event` trigger; nothing appears in the visual automation editor or on a
+   device page.
+
+---
+
+## 2. The event catalog
+
+Naming stays `home_keeper_<noun>_<verb>`. Every event gets a `const.EVENT_*` constant and
+a **pure builder in `events.py`**. Payloads share a common spine so automations can
+template uniformly.
+
+### Task lifecycle — fired at the `store.py` mutation chokepoints
+
+| Event | Fires from | When |
+|---|---|---|
+| `home_keeper_task_created` | `add_task` | a task is created (any source: panel, service, contributing integration) |
+| `home_keeper_task_updated` | `update_task` | a task actually changes (no-op merges don't fire); payload carries `changed_fields` |
+| `home_keeper_task_deleted` | `delete_task` | a task is removed |
+| `home_keeper_task_completed` | `complete_task` | **(exists)** any completion surface |
+| `home_keeper_task_uncompleted` | `delete_completion` | a completion is undone (re-derives `next_due`) |
+| `home_keeper_task_triggered` | `trigger_task` | a condition-driven task is armed (dormant → due-now) |
+
+### Time-based transitions — fired from the coordinator, **edge-triggered**
+
+| Event | When |
+|---|---|
+| `home_keeper_task_overdue` | a task first crosses `next_due` (now ≥ next_due) while HA is running |
+| `home_keeper_task_due_soon` | a task enters the look-ahead window (default 24 h before `next_due`) |
+
+### Stock transitions — fired at the stock chokepoints, **edge-triggered**
+
+| Event | When |
+|---|---|
+| `home_keeper_part_low_stock` | **(exists)** stock crosses to ≤ `reorder_at` |
+| `home_keeper_part_out_of_stock` | stock reaches 0 |
+| `home_keeper_part_restocked` | stock recovers back above `reorder_at` |
+
+### Asset lifecycle — fired at the `store.py` asset chokepoints
+
+| Event | Fires from |
+|---|---|
+| `home_keeper_asset_created` | `add_asset` |
+| `home_keeper_asset_updated` | `update_asset` |
+| `home_keeper_asset_deleted` | `delete_asset` |
+
+### Payload spine
+
+Task events carry a common core, so one automation template works across all of them:
+
+```jsonc
+{
+  "task_id": "…",
+  "name": "…",
+  "device_id": "…",          // resolved registry device id, or null
+  "area_id": "…",            // null if none
+  "recurrence_type": "floating|fixed|triggered",
+  "next_due": "…ISO… | null",
+  "enabled": true,
+  "source": { … } | null,    // opaque, echoed verbatim (as today)
+  "managed_by": { … } | null // well-known ownership block (as today)
+}
+```
+
+- `task_completed` keeps its **exact current fields** (`task_id, name, source, managed_by,
+  completed_at, origin`) and *adds* the spine fields — additive only.
+- `task_updated` adds `changed_fields: ["name", "interval", …]`.
+- `task_overdue` adds `next_due` and `days_overdue`; `task_due_soon` adds `next_due` and
+  `due_in_hours`.
+- Stock events reuse the existing `low_stock_event_data` shape (`asset_id, asset_name,
+  device_id, part_id, part_name, part_number, vendor, stock, reorder_at`) so all three
+  stock events are interchangeable in a template.
+- Asset events carry `asset_id, asset_name, device_id` (+ `changed_fields` for update).
+
+---
+
+## 3. Key design decisions
+
+### Decision A — Where transition events are detected (overdue / due-soon)
+
+The coordinator already wakes every 5 min and holds the task map; it is the natural place.
+Keep the **detection logic pure and unit-testable** (matching the `recurrence.py` /
+`assets.py` convention) in a new `transitions.py` (no HA imports):
+
+```python
+detect_transitions(prev: dict[str, str], tasks, now) -> (events: list, next_state: dict)
+```
+
+The coordinator holds the small `prev` state map (task_id → the `next_due` value already
+announced) and fires what `detect_transitions` returns. Firing stays in the HA layer; the
+edge logic stays pure.
+
+### Decision B — Edge-triggering and idempotency (don't spam)
+
+Every transition event fires **once per crossing**, never on every 5-minute tick:
+
+- **Overdue / due-soon:** announce a task at most once per `next_due` value. Completing or
+  rescheduling advances `next_due`, which re-arms the next announcement naturally. The
+  state is keyed on `next_due`, so a task that is *still* overdue next cycle does **not**
+  refire.
+- **Restart semantics (recommended): baseline silently on first refresh.** On the first
+  coordinator run after startup, seed the `prev` map from current state **without firing**,
+  so HA restarting doesn't replay an "overdue" storm for tasks that were already overdue.
+  Events then fire only for transitions observed *while HA is running*. The overdue
+  binary_sensor still reflects the steady state regardless, so nothing is lost — this only
+  governs the one-shot *event*. (Alternative: persist a per-task `overdue_announced` marker
+  in the store for cross-restart firing — rejected for v1 as storage churn for little gain;
+  noted as a future option.)
+- **Stock:** out-of-stock and restocked are edge-triggered exactly like the existing
+  low-stock crossing — extend the pure `assets.py` helpers to return a richer **transition
+  descriptor** (`none | low | out | restocked`) instead of today's bare `crossed_low`
+  boolean, then `store.py` maps that to the right event. One chokepoint, three events, no
+  double-firing (a single decrement that goes low *and* to zero fires the most specific:
+  `out_of_stock`).
+
+### Decision C — Automation-UI surface: device triggers
+
+Per the chosen scope, expose the events in the **visual automation editor** via a
+`device_trigger.py` platform (Home Assistant's well-established device-automation API).
+This works broadly because nearly everything in Home Keeper already has a registry device:
+
+- **Device-attached tasks** merge onto an existing device page (`coordinator.device_info_for_task`).
+- **Standalone tasks** get a self-owned device `(DOMAIN, task_id)`.
+- **Appliances** are virtual devices `(DOMAIN, "asset_<id>")`.
+
+`async_get_triggers(hass, device_id)` offers, per device, the relevant subset: *Task
+completed / overdue / due-soon* (and created/updated) for task devices; *Low stock /
+Out of stock / Restocked* for appliance devices. `async_attach_trigger` delegates to HA's
+`event_trigger` with the event type and a `device_id` filter on the payload — so the device
+trigger is a thin, well-tested wrapper over the same bus event. Trigger labels live in
+`strings.json` under `device_automation`, with **translation parity** across all 16 locales
+(enforced by `test_translations_parity.py`).
+
+Global, non-device automations (e.g. "*any* part low" → one shopping-list automation)
+continue to use a raw `platform: event` trigger, documented with copy-paste YAML in
+`docs/EVENTS.md`. (A modern integration-level trigger platform — `triggers.yaml` +
+`async_get_triggers` for non-device triggers — is recorded as a **stretch**, not v1.)
+
+### Decision D — Services? Mostly no.
+
+These events are *observations of* state changes that already flow through services /
+store methods — they are not new data actions, so they need **no new `home_keeper.*`
+service** (the "every action is a service" rule governs *mutations*, which already exist).
+The one exception worth weighing: a `home_keeper.list_overdue` / report-style service is
+**out of scope** here (the overdue binary_sensors already expose that state). Firing happens
+inside existing store methods and the coordinator.
+
+---
+
+## 4. Phased implementation
+
+Each phase is an independently reviewable PR; request a Cue review after each push
+(`/q review …`), tailored to that phase (correctness/edge-cases for the transition logic,
+HA best-practices for the device triggers).
+
+### Phase 1 — Task & asset lifecycle + stock depletion events (backend, no UI)
+
+1. **`const.py`** — add the `EVENT_*` constants (task created/updated/deleted/uncompleted/
+   triggered; part out_of_stock/restocked; asset created/updated/deleted), each with a
+   doc-comment like the existing two.
+2. **`events.py`** — add a pure builder per event; reuse the spine. Extend
+   `completion_event_data` *additively* with the spine fields (keep existing keys).
+3. **`assets.py`** — change `consume_part_stock` / `adjust_part_stock` to return a
+   transition descriptor (`none|low|out|restocked`) instead of a bare boolean; pure, fully
+   unit-tested across boundary values (`stock == reorder_at`, `0`, recovery).
+4. **`store.py`** — fire events at the chokepoints: `add_task`/`update_task`/`delete_task`/
+   `trigger_task`/`delete_completion`, `add_asset`/`update_asset`/`delete_asset`, and map
+   the stock descriptor in `_emit_low_stock`'s sibling(s). `update_task` fires only when
+   `merged != existing`, with `changed_fields` computed from the diff.
+5. **`testing.py`** — extend the fake to expose the new events via the same builders, so
+   integrators can test reactions (mirrors the existing `fire_user_completion`).
+6. **Tests** — unit (`events.py` builders, `assets.py` transitions), integration (each
+   mutation fires exactly one event with the right payload; no double-fire on a single
+   decrement that goes low-and-zero).
+
+### Phase 2 — Time-based transitions (overdue / due-soon)
+
+1. **`transitions.py`** (new, pure) — `detect_transitions(prev, tasks, now)` returning the
+   events to fire and the next state map; `DUE_SOON_WINDOW` constant (default 24 h).
+2. **`coordinator.py`** — hold the `prev` map, baseline-on-first-refresh (Decision B), call
+   the detector each refresh, fire results on the bus. Fire on the **immediate** post-mutation
+   refresh too, so completing a task that re-arms a triggered one is observed promptly.
+3. **Tests** — unit: crossing fires once, still-overdue doesn't refire, completion re-arms,
+   startup baselines silently, DST/timezone-aware `now` (deterministic, injected `now`).
+
+### Phase 3 — Automation-UI device triggers
+
+1. **`device_trigger.py`** (new) — `async_get_triggers` (task vs appliance device subsets),
+   `async_attach_trigger` delegating to `event_trigger` with a `device_id` data filter,
+   `TRIGGER_SCHEMA`, and `async_get_trigger_capabilities` where useful.
+2. **`strings.json` + `translations/*.json`** — `device_automation.trigger_type` labels,
+   parity across all locales (enforced by the parity test).
+3. **`manifest.json`** — no change (device triggers need no extra dependency).
+4. **Tests** — `async_get_triggers` returns the right set per device kind;
+   `async_attach_trigger` fires the action when the matching bus event is emitted; a
+   non-matching `device_id` does not.
+
+### Phase 4 — Documentation (the deliverable's whole point)
+
+1. **`docs/EVENTS.md`** (new) — the canonical catalog: every event, exactly when it fires,
+   a payload table, the **edge-trigger / idempotency / restart semantics**, and copy-paste
+   automation examples (both device-trigger and raw `platform: event` YAML). This is the
+   "documented well" core.
+2. **`docs/INTEGRATING.md`** — extend §3's event references and the at-a-glance table to
+   list the new events; cross-link `EVENTS.md` as the full catalog.
+3. **`README.md`** — expand the events/automation section with **use cases** (overdue →
+   notify; out-of-stock → shopping list; task created → log) and a couple of example
+   automations, per the "document new major features in README" rule.
+4. **`CHANGELOG.md`** — an **Added** entry under the next beta describing the new events and
+   the device-trigger UI, with one automation example.
+5. **`.amazonq/rules/architecture-and-code.md`** + **`AGENTS.md`** — record the convention:
+   *every observable state change fires a documented bus event built by a pure `events.py`
+   function; edge-triggered transitions are detected in `transitions.py`/coordinator; the
+   event catalog in `docs/EVENTS.md` is kept in sync in the same change.* (A new convention
+   isn't real until it's written into the rules.)
+
+> **Screenshot gate:** this feature touches **no panel UI** (`frontend/src/`), so the hard
+> screenshot gate does not apply. Optionally capture the device-trigger picker in HA's
+> automation editor for the README — nice-to-have, not gated.
+
+---
+
+## 5. Files touched (by phase)
+
+**Phase 1 (lifecycle + stock):**
+- `custom_components/home_keeper/const.py` — `EVENT_*` constants
+- `custom_components/home_keeper/events.py` — pure builders (+ additive completion fields)
+- `custom_components/home_keeper/assets.py` — stock transition descriptor
+- `custom_components/home_keeper/store.py` — fire at mutation/stock chokepoints
+- `custom_components/home_keeper/testing.py` — fake exposes new events
+- `tests/unit/*`, `tests/integration/*`
+
+**Phase 2 (transitions):**
+- `custom_components/home_keeper/transitions.py` — new, pure detector + window const
+- `custom_components/home_keeper/coordinator.py` — state, baseline, fire
+- `tests/unit/test_transitions.py`
+
+**Phase 3 (device triggers):**
+- `custom_components/home_keeper/device_trigger.py` — new
+- `custom_components/home_keeper/strings.json` + `translations/*.json`
+- `tests/integration/test_device_trigger.py`
+
+**Phase 4 (docs):**
+- `docs/EVENTS.md` (new), `docs/INTEGRATING.md`, `README.md`, `CHANGELOG.md`
+- `.amazonq/rules/architecture-and-code.md`, `AGENTS.md`
+
+---
+
+## 6. Testing strategy
+
+- **Unit (pytest, pure):** `events.py` builders produce the exact documented payloads;
+  `assets.py` stock transitions across all boundaries (low / out / restock / no-op);
+  `transitions.py` overdue/due-soon crossing, no-refire, re-arm on completion, silent
+  startup baseline — all with an injected, timezone-aware `now` for determinism (incl. a
+  DST boundary case).
+- **Integration (Docker HA):** each store mutation fires exactly one correctly-shaped
+  event; a single decrement to zero fires `out_of_stock` once (not also `low_stock`); the
+  device trigger fires its action for the matching `device_id` and not for others.
+- **Contract (the fake):** the fake fires the new events via the same `events.py` builders,
+  proving the integrator-facing contract can't drift from production.
+- **Parity:** `test_translations_parity.py` covers the new device-trigger strings.
+
+Run locally before pushing (per AGENTS.md): `pytest tests/unit -v`, the full unit suite,
+and the Docker integration suite — never use CI as the test runner.
+
+---
+
+## 7. Recommended first step
+
+Ship **Phase 1** end-to-end: it generalises the already-proven "fire at the store
+chokepoint via a pure `events.py` builder" pattern to the full mutation + stock surface,
+needs no new infrastructure, and is immediately useful (task-created / out-of-stock
+automations). Phases 2–3 then add the genuinely new machinery (runtime transition
+detection, the automation-UI surface) on top, and Phase 4 documents the lot in
+`docs/EVENTS.md` as the single catalog automations and integrations build against.

--- a/docs/EVENTS_PLAN.md
+++ b/docs/EVENTS_PLAN.md
@@ -1,6 +1,11 @@
 # Comprehensive Events & Automation Hooks
 
-**Status: planned.** This document specifies a full, consistent set of Home Assistant
+**Status: implemented.** The event catalog, the pure `transitions.py` detector, the
+coordinator wiring, the `device_trigger.py` automation-editor surface, and the docs
+below all shipped. The canonical user/integrator reference is
+[`docs/EVENTS.md`](EVENTS.md); this document is kept as the design rationale.
+
+This document specifies a full, consistent set of Home Assistant
 **bus events** for every meaningful thing that happens in Home Keeper — a task is
 created, edited, completed, deleted, becomes overdue or due-soon; a spare part runs low,
 runs out, or is restocked; an appliance is added, changed, or removed — plus the

--- a/docs/EVENTS_PLAN.md
+++ b/docs/EVENTS_PLAN.md
@@ -13,9 +13,14 @@ hook other integrations subscribe to (`docs/INTEGRATING.md`); this generalises t
 pattern into a complete, well-documented catalog so **automations and other integrations
 can react to the full lifecycle**, not just completion and low-stock.
 
-> **Back-compatible by construction.** The two existing event names and their payload
-> fields are frozen — this plan only **adds** events and **adds** fields to existing
-> payloads. No automation built today breaks.
+> **Pre-1.0 — free to normalise.** Home Keeper is still a beta (panel `0.3.0bN`), so this
+> plan is **not** bound by back-compatibility. It keeps the existing field names because
+> they're already good (changing them would be churn for its own sake), but it is free to
+> reshape a payload where that yields a cleaner, uniform spine. The one external consumer
+> of the current `home_keeper_task_completed` contract is **Pawsistant** (same owner); any
+> breaking change to that payload is made **in lockstep** with Pawsistant and
+> `docs/INTEGRATING.md`, and lands as a **breaking** CHANGELOG entry rather than an additive
+> one.
 
 ---
 
@@ -113,8 +118,10 @@ Task events carry a common core, so one automation template works across all of 
 }
 ```
 
-- `task_completed` keeps its **exact current fields** (`task_id, name, source, managed_by,
-  completed_at, origin`) and *adds* the spine fields — additive only.
+- `task_completed` adopts the common spine and carries its completion-specific extras
+  (`completed_at`, `origin`) on top. (Its current fields are a subset of the spine plus
+  these two, so in practice this is the spine + 2 — but we're no longer *constrained* to
+  preserve the exact legacy shape; see the pre-1.0 note above.)
 - `task_updated` adds `changed_fields: ["name", "interval", …]`.
 - `task_overdue` adds `next_due` and `days_overdue`; `task_due_soon` adds `next_due` and
   `due_in_hours`.
@@ -209,8 +216,9 @@ HA best-practices for the device triggers).
 1. **`const.py`** — add the `EVENT_*` constants (task created/updated/deleted/uncompleted/
    triggered; part out_of_stock/restocked; asset created/updated/deleted), each with a
    doc-comment like the existing two.
-2. **`events.py`** — add a pure builder per event; reuse the spine. Extend
-   `completion_event_data` *additively* with the spine fields (keep existing keys).
+2. **`events.py`** — add a pure builder per event; reuse the spine. Bring
+   `completion_event_data` onto the spine too (no longer constrained to the legacy shape —
+   if Pawsistant relies on a field, change both repos in lockstep).
 3. **`assets.py`** — change `consume_part_stock` / `adjust_part_stock` to return a
    transition descriptor (`none|low|out|restocked`) instead of a bare boolean; pure, fully
    unit-tested across boundary values (`stock == reorder_at`, `0`, recovery).
@@ -253,12 +261,15 @@ HA best-practices for the device triggers).
    automation examples (both device-trigger and raw `platform: event` YAML). This is the
    "documented well" core.
 2. **`docs/INTEGRATING.md`** — extend §3's event references and the at-a-glance table to
-   list the new events; cross-link `EVENTS.md` as the full catalog.
+   list the new events; cross-link `EVENTS.md` as the full catalog. If the
+   `task_completed` payload shape changed, update its field table here and ship the matching
+   Pawsistant change in lockstep.
 3. **`README.md`** — expand the events/automation section with **use cases** (overdue →
    notify; out-of-stock → shopping list; task created → log) and a couple of example
    automations, per the "document new major features in README" rule.
-4. **`CHANGELOG.md`** — an **Added** entry under the next beta describing the new events and
-   the device-trigger UI, with one automation example.
+4. **`CHANGELOG.md`** — an **Added** entry under the next beta for the new events and the
+   device-trigger UI, with one automation example. If the `task_completed` payload shape
+   changed, add a **Changed/Breaking** note too (and call out the Pawsistant bump).
 5. **`.amazonq/rules/architecture-and-code.md`** + **`AGENTS.md`** — record the convention:
    *every observable state change fires a documented bus event built by a pure `events.py`
    function; edge-triggered transitions are detected in `transitions.py`/coordinator; the

--- a/docs/INTEGRATING.md
+++ b/docs/INTEGRATING.md
@@ -149,6 +149,18 @@ Event payload:
 | `completed_at` | `str` (ISO) | When it was completed. |
 | `origin` | `str \| None` | Whatever the completer passed; `None` for a manual/Home-Keeper-UI completion. |
 
+The payload also carries the common task **spine** (`device_id`, `area_id`,
+`recurrence_type`, `next_due`, `enabled`, `managed_by`) — see
+[EVENTS.md](EVENTS.md#task-event-spine). If you only read the fields above, nothing
+changes for you.
+
+> **`home_keeper_task_completed` is one of a full catalog.** Home Keeper fires events
+> for the entire lifecycle — tasks created/updated/deleted/uncompleted/triggered,
+> overdue/due-soon, spare parts low/out/restocked, and appliances created/updated/
+> deleted — all built by the same pure payload builders in `events.py`. If your
+> integration needs to react to more than completion, see [EVENTS.md](EVENTS.md) for the
+> catalog. Everything below stays focused on the completion contract.
+
 ## 4. Two-way sync and loop prevention
 
 To make the task behave like "the same button" on both sides you complete it from your

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,7 @@ def _load_pure_modules() -> None:
         "models",
         "assets",
         "events",
+        "transitions",
         "reconcile",
         "inventory",
     ):
@@ -50,6 +51,7 @@ def _load_pure_modules() -> None:
     sys.modules["hk_models"] = sys.modules["hk.models"]
     sys.modules["hk_assets"] = sys.modules["hk.assets"]
     sys.modules["hk_events"] = sys.modules["hk.events"]
+    sys.modules["hk_transitions"] = sys.modules["hk.transitions"]
     sys.modules["hk_reconcile"] = sys.modules["hk.reconcile"]
     sys.modules["hk_inventory"] = sys.modules["hk.inventory"]
 

--- a/tests/integration/test_assets.py
+++ b/tests/integration/test_assets.py
@@ -530,9 +530,13 @@ def test_low_stock_event_fires_on_crossing_not_on_restock(ha):
     call_service(ha, "home_keeper", "adjust_part_stock",
                  {"asset_id": wh["id"], "part_id": pid, "delta": 10})
     _reset()
-    # Drop across the threshold to zero -> exactly one low-stock event for this part.
+    # Drop across the threshold but stay above zero -> a *low-stock* crossing (a drop
+    # all the way to zero is the more specific `part_out_of_stock` event instead). Land
+    # at the threshold so the part reads low without being out.
+    part = next(p for p in _water_heater(ha)["parts"] if p["id"] == pid)
+    target = max(1, part["reorder_at"])
     call_service(ha, "home_keeper", "adjust_part_stock",
-                 {"asset_id": wh["id"], "part_id": pid, "delta": -100})
+                 {"asset_id": wh["id"], "part_id": pid, "delta": target - part["stock"]})
     deadline = time.monotonic() + 10
     captured = None
     while time.monotonic() < deadline:
@@ -540,7 +544,9 @@ def test_low_stock_event_fires_on_crossing_not_on_restock(ha):
         if captured and captured != "none":
             break
         time.sleep(0.5)
-    assert captured == f"{pid}@0", f"expected a low-stock event for {pid}, got {captured!r}"
+    assert captured == f"{pid}@{target}", (
+        f"expected a low-stock event for {pid}, got {captured!r}"
+    )
 
     # A restock that leaves the part not-low must NOT re-fire the event.
     _reset()

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -1,0 +1,255 @@
+"""Integration tests for Home Keeper's bus events against a real HA container.
+
+Subscribes over the Home Assistant websocket API and asserts the lifecycle and stock
+events fire with the right payloads when the corresponding services are called. The
+time-based transition events (overdue / due-soon) are covered by the pure unit tests
+(``tests/unit/test_transitions.py``) since they depend on the coordinator's periodic
+refresh; here we cover the deterministic, mutation-driven events.
+"""
+
+import asyncio
+import json
+
+import pytest
+import websockets
+from conftest import HA_URL, call_service
+
+WS_URL = "ws://localhost:8123/api/websocket"
+
+
+async def _capture(token, event_types, action, *, expected, timeout=20):
+    """Subscribe to *event_types*, run *action* (sync), return captured events.
+
+    Returns a list of ``(event_type, data)`` in arrival order, stopping once
+    *expected* events are seen or *timeout* elapses.
+    """
+    captured = []
+    async with websockets.connect(WS_URL, max_size=None) as ws:
+        assert json.loads(await ws.recv())["type"] == "auth_required"
+        await ws.send(json.dumps({"type": "auth", "access_token": token}))
+        assert json.loads(await ws.recv())["type"] == "auth_ok"
+
+        msg_id = 0
+        for event_type in event_types:
+            msg_id += 1
+            await ws.send(
+                json.dumps(
+                    {"id": msg_id, "type": "subscribe_events", "event_type": event_type}
+                )
+            )
+            result = json.loads(await ws.recv())
+            assert result["success"], result
+
+        # Run the blocking REST action off the event loop, then drain events.
+        await asyncio.get_event_loop().run_in_executor(None, action)
+
+        async def _drain():
+            while len(captured) < expected:
+                msg = json.loads(await ws.recv())
+                if msg.get("type") == "event":
+                    ev = msg["event"]
+                    captured.append((ev["event_type"], ev["data"]))
+
+        try:
+            await asyncio.wait_for(_drain(), timeout=timeout)
+        except asyncio.TimeoutError:
+            pass
+    return captured
+
+
+def _run(token, event_types, action, *, expected, timeout=20):
+    return asyncio.run(
+        _capture(token, event_types, action, expected=expected, timeout=timeout)
+    )
+
+
+def _by_type(captured):
+    out = {}
+    for event_type, data in captured:
+        out.setdefault(event_type, []).append(data)
+    return out
+
+
+def test_task_lifecycle_events(ha, ha_token):
+    created_id = {}
+
+    def action():
+        resp = call_service(
+            ha,
+            "home_keeper",
+            "add_task",
+            {"name": "Event test task", "recurrence_type": "floating",
+             "interval": 7, "unit": "days"},
+            return_response=True,
+        )
+        body = resp.get("service_response", resp)
+        created_id["id"] = body["task_id"]
+        call_service(ha, "home_keeper", "update_task",
+                     {"task_id": body["task_id"], "name": "Renamed task"})
+        call_service(ha, "home_keeper", "complete_task", {"task_id": body["task_id"]})
+        call_service(ha, "home_keeper", "delete_task", {"task_id": body["task_id"]})
+
+    events = _by_type(
+        _run(
+            ha_token,
+            [
+                "home_keeper_task_created",
+                "home_keeper_task_updated",
+                "home_keeper_task_completed",
+                "home_keeper_task_deleted",
+            ],
+            action,
+            expected=4,
+        )
+    )
+
+    assert "home_keeper_task_created" in events
+    assert events["home_keeper_task_created"][0]["name"] == "Event test task"
+    # Spine fields are present on the lifecycle payload.
+    created = events["home_keeper_task_created"][0]
+    assert created["recurrence_type"] == "floating"
+    assert "next_due" in created and "enabled" in created
+
+    assert events["home_keeper_task_updated"][0]["changed_fields"] == ["name"]
+    assert events["home_keeper_task_completed"][0]["task_id"] == created_id["id"]
+    assert "completed_at" in events["home_keeper_task_completed"][0]
+    assert events["home_keeper_task_deleted"][0]["task_id"] == created_id["id"]
+
+
+def test_stock_transition_events(ha, ha_token):
+    """A part driven low -> out -> restocked fires one event per crossing."""
+    ids = {}
+
+    def setup_asset():
+        call_service(
+            ha,
+            "home_keeper",
+            "add_asset",
+            {
+                "name": "Event test appliance",
+                "parts": [
+                    {"name": "Widget", "type": "consumable", "stock": 2, "reorder_at": 1}
+                ],
+            },
+        )
+        assets = call_service(
+            ha, "home_keeper", "list_assets", {}, return_response=True
+        )
+        body = assets.get("service_response", assets)
+        asset = next(a for a in body["assets"] if a["name"] == "Event test appliance")
+        ids["asset_id"] = asset["id"]
+        ids["part_id"] = asset["parts"][0]["id"]
+
+    setup_asset()
+
+    def action():
+        # 2 -> 1 (low), 1 -> 0 (out), 0 -> 5 (restocked).
+        for delta in (-1, -1, 5):
+            call_service(
+                ha,
+                "home_keeper",
+                "adjust_part_stock",
+                {"asset_id": ids["asset_id"], "part_id": ids["part_id"], "delta": delta},
+            )
+
+    events = _by_type(
+        _run(
+            ha_token,
+            [
+                "home_keeper_part_low_stock",
+                "home_keeper_part_out_of_stock",
+                "home_keeper_part_restocked",
+            ],
+            action,
+            expected=3,
+        )
+    )
+
+    assert events["home_keeper_part_low_stock"][0]["part_name"] == "Widget"
+    assert events["home_keeper_part_out_of_stock"][0]["stock"] == 0
+    assert "home_keeper_part_restocked" in events
+
+    # Clean up the asset we created.
+    call_service(ha, "home_keeper", "delete_asset", {"asset_id": ids["asset_id"]})
+
+
+async def _ws_commands(token, commands):
+    """Open one authed websocket, send each command dict (id auto-assigned), return results."""
+    results = []
+    async with websockets.connect(WS_URL, max_size=None) as ws:
+        assert json.loads(await ws.recv())["type"] == "auth_required"
+        await ws.send(json.dumps({"type": "auth", "access_token": token}))
+        assert json.loads(await ws.recv())["type"] == "auth_ok"
+        msg_id = 0
+        for command in commands:
+            msg_id += 1
+            await ws.send(json.dumps({"id": msg_id, **command}))
+            reply = json.loads(await ws.recv())
+            results.append(reply)
+    return results
+
+
+def test_device_triggers_offered_for_appliance_and_task_devices(ha, ha_token):
+    """async_get_triggers offers Home Keeper triggers on the right devices."""
+    (devices_reply,) = _run_ws(
+        ha_token, [{"type": "config/device_registry/list"}]
+    )
+    devices = devices_reply["result"]
+
+    def _is_hk(device):
+        return any(
+            (pair[0] if isinstance(pair, (list, tuple)) else None) == "home_keeper"
+            for pair in device.get("identifiers", [])
+        )
+
+    hk_devices = [d for d in devices if _is_hk(d)]
+    assert hk_devices, "expected at least one Home Keeper registry device"
+
+    # Fetch the triggers for every HK device and collect the trigger types per device.
+    replies = _run_ws(
+        ha_token,
+        [
+            {"type": "device_automation/trigger/list", "device_id": d["id"]}
+            for d in hk_devices
+        ],
+    )
+    all_types = set()
+    for reply in replies:
+        for trig in reply["result"]:
+            if trig.get("domain") == "home_keeper":
+                all_types.add(trig["type"])
+
+    # The seeded config has both a virtual appliance (with stocked wear parts) and
+    # task devices, so across all HK devices we expect both task and stock triggers.
+    assert "task_overdue" in all_types
+    assert "part_low_stock" in all_types
+    assert "part_out_of_stock" in all_types
+
+
+def _run_ws(token, commands):
+    return asyncio.run(_ws_commands(token, commands))
+
+
+def test_asset_lifecycle_events(ha, ha_token):
+    def action():
+        call_service(ha, "home_keeper", "add_asset", {"name": "Asset event appliance"})
+
+    events = _by_type(
+        _run(ha_token, ["home_keeper_asset_created"], action, expected=1)
+    )
+    assert events["home_keeper_asset_created"][0]["asset_name"] == "Asset event appliance"
+
+    # Find and delete it, asserting the deletion event.
+    assets = call_service(ha, "home_keeper", "list_assets", {}, return_response=True)
+    body = assets.get("service_response", assets)
+    asset_id = next(
+        a["id"] for a in body["assets"] if a["name"] == "Asset event appliance"
+    )
+
+    def delete():
+        call_service(ha, "home_keeper", "delete_asset", {"asset_id": asset_id})
+
+    events = _by_type(
+        _run(ha_token, ["home_keeper_asset_deleted"], delete, expected=1)
+    )
+    assert events["home_keeper_asset_deleted"][0]["asset_id"] == asset_id

--- a/tests/unit/test_assets.py
+++ b/tests/unit/test_assets.py
@@ -402,39 +402,57 @@ def test_part_is_low():
     assert a.part_is_low({"stock": 0, "reorder_at": None}) is False
 
 
+def test_stock_transition_classifies_crossings():
+    # No threshold -> untracked, never transitions.
+    assert a.stock_transition(5, 4, None) == a.STOCK_NONE
+    # Crossing into low.
+    assert a.stock_transition(2, 1, 1) == a.STOCK_LOW
+    # Reaching zero wins over "low" (more specific) even from an already-low part.
+    assert a.stock_transition(1, 0, 1) == a.STOCK_OUT
+    assert a.stock_transition(3, 0, 5) == a.STOCK_OUT
+    # Restock lifts back above the threshold.
+    assert a.stock_transition(1, 4, 1) == a.STOCK_RESTOCKED
+    # Restock that's still at/below threshold is not a recovery.
+    assert a.stock_transition(0, 2, 2) == a.STOCK_NONE
+    # No crossing while comfortably above, or already low without reaching zero.
+    assert a.stock_transition(3, 2, 1) == a.STOCK_NONE
+    assert a.stock_transition(2, 1, 3) == a.STOCK_NONE
+
+
 def test_consume_part_stock_flags_low_only_on_crossing():
     part = {"stock": 3, "reorder_at": 1}
     # 3 -> 2, still above the threshold of 1.
-    assert a.consume_part_stock(part) is False
+    assert a.consume_part_stock(part) == a.STOCK_NONE
     assert part["stock"] == 2
     # 2 -> 1 crosses from not-low into low.
-    assert a.consume_part_stock(part) is True
+    assert a.consume_part_stock(part) == a.STOCK_LOW
     assert part["stock"] == 1
-    # 1 -> 0, already low: edge-triggered, so no repeat signal.
-    assert a.consume_part_stock(part) is False
+    # 1 -> 0, already low: reaching zero is now reported as out-of-stock (the old
+    # bare boolean stayed silent here).
+    assert a.consume_part_stock(part) == a.STOCK_OUT
     assert part["stock"] == 0
 
 
 def test_consume_part_stock_floors_at_zero_without_refiring():
-    # Already low (and at zero): consuming again clamps at zero and does not re-fire.
+    # Already at zero: consuming again clamps at zero and does not re-fire.
     part = {"stock": 0, "reorder_at": 0}
-    assert a.consume_part_stock(part) is False
+    assert a.consume_part_stock(part) == a.STOCK_NONE
     assert part["stock"] == 0
 
 
 def test_consume_part_stock_noop_when_untracked():
     part = {"stock": None, "reorder_at": 2}
-    assert a.consume_part_stock(part) is False
+    assert a.consume_part_stock(part) == a.STOCK_NONE
     assert part["stock"] is None
 
 
 def test_adjust_part_stock_restock_and_clamp():
     part = {"stock": 1, "reorder_at": 1}
-    # Restock by 3 -> 4, no longer low.
-    assert a.adjust_part_stock(part, 3) is False
+    # Restock by 3 -> 4, recovers above the threshold.
+    assert a.adjust_part_stock(part, 3) == a.STOCK_RESTOCKED
     assert part["stock"] == 4
-    # Consume 5 -> clamps at 0, now low.
-    assert a.adjust_part_stock(part, -5) is True
+    # Consume 5 -> clamps at 0: out of stock.
+    assert a.adjust_part_stock(part, -5) == a.STOCK_OUT
     assert part["stock"] == 0
 
 
@@ -444,13 +462,13 @@ def test_adjust_part_stock_begins_tracking_from_zero():
     assert part["stock"] == 2
 
 
-def test_adjust_part_stock_no_refire_while_already_low():
-    # Decreasing while already low must not re-signal (edge-triggered).
+def test_adjust_part_stock_to_zero_reports_out():
+    # Decreasing while already low to exactly zero reports out-of-stock.
     part = {"stock": 1, "reorder_at": 2}
-    assert a.adjust_part_stock(part, -1) is False
+    assert a.adjust_part_stock(part, -1) == a.STOCK_OUT
     assert part["stock"] == 0
-    # Restocking back up to/below the threshold also doesn't signal.
-    assert a.adjust_part_stock(part, 2) is False
+    # Restocking back up to (still <=) the threshold is not a recovery.
+    assert a.adjust_part_stock(part, 2) == a.STOCK_NONE
     assert part["stock"] == 2
 
 

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -16,17 +16,58 @@ def test_payload_has_contract_fields():
     task = {
         "id": "t1",
         "name": "Medicine",
+        "device_id": "dev1",
+        "area_id": "kitchen",
+        "recurrence_type": "floating",
+        "next_due": "2026-07-01T10:00:00-04:00",
+        "enabled": True,
         "source": {"pawsistant": {"schedule_id": "s1"}},
     }
     data = ev.completion_event_data(task, WHEN, origin="pawsistant")
     assert data == {
         "task_id": "t1",
         "name": "Medicine",
+        "device_id": "dev1",
+        "area_id": "kitchen",
+        "recurrence_type": "floating",
+        "next_due": "2026-07-01T10:00:00-04:00",
+        "enabled": True,
         "source": {"pawsistant": {"schedule_id": "s1"}},
         "managed_by": None,
         "completed_at": WHEN.isoformat(),
         "origin": "pawsistant",
     }
+
+
+def test_task_event_spine_defaults_and_extra():
+    data = ev.task_event_data({"id": "t9"}, extra={"changed_fields": ["name"]})
+    assert data["task_id"] == "t9"
+    # Sensible defaults for a sparse task dict.
+    assert data["device_id"] is None and data["area_id"] is None
+    assert data["enabled"] is True and data["next_due"] is None
+    assert data["source"] is None and data["managed_by"] is None
+    assert data["changed_fields"] == ["name"]
+
+
+def test_asset_event_data_shape():
+    data = ev.asset_event_data(
+        {"id": "a1", "name": "Furnace", "device_id": "dev1"},
+        extra={"changed_fields": ["model"]},
+    )
+    assert data == {
+        "asset_id": "a1",
+        "asset_name": "Furnace",
+        "device_id": "dev1",
+        "changed_fields": ["model"],
+    }
+    # Tolerates a missing name.
+    assert ev.asset_event_data({"id": "a2"})["asset_name"] == ""
+
+
+def test_stock_event_data_alias_matches_low_stock():
+    asset = {"id": "a1", "name": "Furnace", "device_id": "dev1"}
+    part = {"id": "p1", "name": "Filter", "stock": 0, "reorder_at": 1}
+    assert ev.stock_event_data(asset, part) == ev.low_stock_event_data(asset, part)
 
 
 def test_payload_carries_managed_by():

--- a/tests/unit/test_transitions.py
+++ b/tests/unit/test_transitions.py
@@ -1,0 +1,101 @@
+"""Unit tests for the pure overdue / due-soon edge detector.
+
+These exercise the fire-once-per-crossing semantics with an injected ``now`` (no HA
+runtime): a task announces due-soon then overdue against the same ``next_due`` exactly
+once each, re-arms when its schedule moves, and never fires while dormant or disabled.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import hk_transitions as t
+from hk_const import EVENT_TASK_DUE_SOON, EVENT_TASK_OVERDUE
+
+TZ = timezone.utc
+NOW = datetime(2026, 6, 18, 12, 0, tzinfo=TZ)
+
+
+def _task(tid="t1", *, next_due, enabled=True, recurrence_type="floating"):
+    return {
+        "id": tid,
+        "name": "Task",
+        "next_due": next_due.isoformat() if next_due else None,
+        "enabled": enabled,
+        "recurrence_type": recurrence_type,
+    }
+
+
+def _names(fired):
+    return [name for name, _ in fired]
+
+
+def test_overdue_fires_once_and_not_again():
+    task = _task(next_due=NOW - timedelta(days=2))
+    tasks = {"t1": task}
+
+    fired, state = t.detect_transitions({}, tasks, now=NOW)
+    assert _names(fired) == [EVENT_TASK_OVERDUE]
+    assert fired[0][1]["days_overdue"] == 2
+    assert state["t1"]["overdue_fired"] is True
+
+    # Still overdue next cycle, same next_due -> no repeat.
+    fired2, state2 = t.detect_transitions(state, tasks, now=NOW + timedelta(hours=1))
+    assert fired2 == []
+    assert state2["t1"]["overdue_fired"] is True
+
+
+def test_due_soon_then_overdue_both_fire_once_for_one_next_due():
+    next_due = NOW + timedelta(days=1)  # within the 3-day window, not yet overdue
+    tasks = {"t1": _task(next_due=next_due)}
+
+    fired, state = t.detect_transitions({}, tasks, now=NOW)
+    assert _names(fired) == [EVENT_TASK_DUE_SOON]
+    assert fired[0][1]["due_in_hours"] == 24.0
+
+    # Time passes to just after the due date — overdue fires, due-soon does not repeat.
+    later = next_due + timedelta(minutes=5)
+    fired2, state2 = t.detect_transitions(state, tasks, now=later)
+    assert _names(fired2) == [EVENT_TASK_OVERDUE]
+    assert state2["t1"] == {
+        "next_due": tasks["t1"]["next_due"],
+        "due_soon_fired": True,
+        "overdue_fired": True,
+    }
+
+
+def test_reschedule_rearms_announcements():
+    task = _task(next_due=NOW - timedelta(days=1))
+    fired, state = t.detect_transitions({}, {"t1": task}, now=NOW)
+    assert _names(fired) == [EVENT_TASK_OVERDUE]
+
+    # Completed/rescheduled: next_due moves into the future -> flags reset, nothing
+    # fires now, and a later crossing fires again.
+    rescheduled = _task(next_due=NOW + timedelta(days=30))
+    fired2, state2 = t.detect_transitions(state, {"t1": rescheduled}, now=NOW)
+    assert fired2 == []
+    assert state2["t1"]["overdue_fired"] is False
+
+
+def test_dormant_and_disabled_never_fire():
+    dormant = _task("d", next_due=None, recurrence_type="triggered")
+    disabled = _task("x", next_due=NOW - timedelta(days=5), enabled=False)
+    fired, state = t.detect_transitions({}, {"d": dormant, "x": disabled}, now=NOW)
+    assert fired == []
+    # Tracked but quiet: both carry state so re-arm/re-enable starts fresh.
+    assert set(state) == {"d", "x"}
+
+
+def test_triggered_task_fires_overdue_on_arm():
+    dormant = _task("d", next_due=None, recurrence_type="triggered")
+    _, state = t.detect_transitions({}, {"d": dormant}, now=NOW)
+
+    armed = _task("d", next_due=NOW, recurrence_type="triggered")
+    fired, state2 = t.detect_transitions(state, {"d": armed}, now=NOW)
+    assert _names(fired) == [EVENT_TASK_OVERDUE]
+
+
+def test_deleted_task_drops_out_of_state():
+    task = _task(next_due=NOW - timedelta(days=1))
+    _, state = t.detect_transitions({}, {"t1": task}, now=NOW)
+    assert "t1" in state
+    fired, state2 = t.detect_transitions(state, {}, now=NOW)
+    assert fired == [] and state2 == {}


### PR DESCRIPTION
## Summary

Generalises Home Keeper's two existing bus events into a **full event catalog** so automations and other integrations can react to the whole lifecycle — plus **device triggers** so the events show up in the visual automation editor. Started as a design doc (`docs/EVENTS_PLAN.md`, now marked implemented) and is now fully built, tested, and documented.

### Events added
- **Task lifecycle:** `task_created` · `task_updated` (with `changed_fields`) · `task_deleted` · `task_uncompleted` · `task_triggered` — fired at **every** `store.py` chokepoint, including the non-CRUD paths (`reconcile_part_tasks`, `detach_tasks_from_device`, `delete_asset` cascade) that previously mutated tasks silently.
- **Time transitions (edge-triggered):** `task_overdue` (`days_overdue`) · `task_due_soon` (`due_in_hours`) — detected by a new pure `transitions.py` and fired from the coordinator. Fire **once per `next_due`** (independent due-soon/overdue flags) and **baseline silently on startup** (no overdue storm after a reboot).
- **Stock (edge-triggered):** `part_out_of_stock` · `part_restocked` join `part_low_stock`, driven by a new pure `assets.stock_transition` (`out` wins over `low`; untracked parts never fire). Replaces the old `crossed_low` boolean.
- **Asset lifecycle:** `asset_created` · `asset_updated` · `asset_deleted`.
- `home_keeper_task_completed` gains the common task spine (additive).

### Automation-editor surface
`device_trigger.py` exposes the events in the visual editor, filtering on **`task_id`** for self-owned task devices (their events carry `device_id: null`) and **`device_id`** for shared/appliance devices. Labels added to `strings.json` + all 16 locales (parity).

### Architecture
Every event is built by a **pure function in `events.py`** (shared with the test fake, so the contract can't drift) and fired at the store chokepoint; transition detection is pure (`transitions.py`) and unit-tested with an injected `now`. No new services (events observe changes that already flow through existing services).

### Docs
New canonical [`docs/EVENTS.md`](docs/EVENTS.md) catalog (events, payloads, semantics, example automations); README "Events & automations" section; CHANGELOG; INTEGRATING.md; and the `.amazonq` rules + AGENTS.md conventions.

### Behaviour change (CHANGELOG-noted)
A part dropping **straight to zero** now fires `part_out_of_stock` (more specific) rather than `part_low_stock`. Crossing into low *without* hitting zero still fires `part_low_stock`.

### Testing
- **Unit:** builders, `stock_transition` (all boundaries), and `transitions` (fire-once, re-arm, dormant/disabled skip, baseline). **193 pass** locally.
- **Integration (Docker HA, websocket):** lifecycle + stock events fire with correct payloads; a single drop-to-zero fires `out_of_stock` only; device-trigger listing. **37 pass** locally.

No panel UI (`frontend/src/`) touched, so the screenshot gate doesn't apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)