### PR TITLE
Add ruff lint/format + dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels: ["dependencies"]
+
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels: ["dependencies"]
+
+  - package-ecosystem: npm
+    directory: "/custom_components/home_keeper/frontend"
+    schedule:
+      interval: weekly
+    labels: ["dependencies"]
+
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels: ["dependencies"]
+
+  - package-ecosystem: npm
+    directory: "/tests/e2e"
+    schedule:
+      interval: weekly
+    labels: ["dependencies"]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install ruff
+        run: pip install ruff
+      - name: Ruff lint
+        run: ruff check custom_components tests ci
+      - name: Ruff format check
+        run: ruff format --check custom_components tests ci

--- a/custom_components/home_keeper/__init__.py
+++ b/custom_components/home_keeper/__init__.py
@@ -137,9 +137,7 @@ _ASSET_FIELDS = {
     vol.Optional("related_device_ids"): [cv.string],
 }
 ADD_ASSET_SCHEMA = vol.Schema(_ASSET_FIELDS)
-UPDATE_ASSET_SCHEMA = vol.Schema(
-    {vol.Required("asset_id"): cv.string, **_ASSET_FIELDS}
-)
+UPDATE_ASSET_SCHEMA = vol.Schema({vol.Required("asset_id"): cv.string, **_ASSET_FIELDS})
 ASSET_ID_SCHEMA = vol.Schema({vol.Required("asset_id"): cv.string})
 
 # Adjust a part's on-hand spare count by a (signed) delta; clamped at zero.

--- a/custom_components/home_keeper/assets.py
+++ b/custom_components/home_keeper/assets.py
@@ -261,7 +261,10 @@ def _normalize_part(raw: Any) -> dict:
         part["replace_unit"] = unit
     # A future "last replaced" would push the derived maintenance task far out and
     # silently hide it; it can only be a past (or today's) date.
-    if part["last_replaced"] and date.fromisoformat(part["last_replaced"]) > date.today():
+    if (
+        part["last_replaced"]
+        and date.fromisoformat(part["last_replaced"]) > date.today()
+    ):
         raise AssetValidationError("last_replaced must not be in the future")
     return part
 
@@ -361,7 +364,7 @@ def adjust_part_stock(part: dict, delta: int) -> str:
 
     Begins tracking from zero for a previously untracked part. Returns the edge
     transition (``stock_transition``) the adjustment caused — ``"low"`` / ``"out"`` on a
-    decrease that crosses a threshold, ``"restocked"`` when a restock lifts it back above
+    decrease that crosses a threshold, ``"restocked"`` when a restock lifts it above
     the reorder point, else ``"none"``.
     """
     old = int(part.get("stock") or 0)
@@ -547,9 +550,7 @@ def tasks_for_asset(asset: dict, tasks: list[dict]) -> list[dict]:
     return [task for task in tasks if task_relates_to_asset(task, asset)]
 
 
-def find_archiving_asset(
-    assets_by_id: dict[str, dict], task: dict
-) -> dict | None:
+def find_archiving_asset(assets_by_id: dict[str, dict], task: dict) -> dict | None:
     """The asset a deleted *task*'s history should be preserved on, or None.
 
     Precedence: the part-source appliance (the strong, explicit link) first, then

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -27,7 +27,8 @@ STORAGE_VERSION = 1
 # How many completion timestamps to retain per task. Generous so the panel's task
 # history shows years of cadence (e.g. 500 monthly completions ≈ 40 years) while
 # still bounding the stored list. When a task that belongs to an appliance is
-# deleted, this history is archived onto the appliance (see ``assets.append_task_history``).
+# deleted, this history is archived onto the appliance
+# (see ``assets.append_task_history``).
 MAX_COMPLETION_HISTORY = 500
 
 # Event fired on the HA event bus whenever a task is completed (from any surface:
@@ -127,7 +128,7 @@ MAX_INTERVAL = 10_000
 # interface so integrations like Battery Notes can push maintenance tasks without
 # this integration knowing anything about them. The intended hook is a dispatcher
 # signal plus a `home_keeper.contribute_task` service. See docs/DESIGN.md.
-SIGNAL_TASK_CONTRIBUTION = f"{DOMAIN}_task_contribution"  # noqa: F841  (reserved)
+SIGNAL_TASK_CONTRIBUTION = f"{DOMAIN}_task_contribution"
 
 # Well-known field on a task dict that Home Keeper inspects (unlike the opaque
 # ``source`` field). Declares the integration that owns the task: which fields

--- a/custom_components/home_keeper/device_trigger.py
+++ b/custom_components/home_keeper/device_trigger.py
@@ -151,7 +151,9 @@ async def async_attach_trigger(
         {
             event_trigger.CONF_PLATFORM: "event",
             event_trigger.CONF_EVENT_TYPE: _EVENT_BY_TYPE[trigger_type],
-            event_trigger.CONF_EVENT_DATA: event_data if event_data is not None else _NO_MATCH,
+            event_trigger.CONF_EVENT_DATA: event_data
+            if event_data is not None
+            else _NO_MATCH,
         }
     )
     return await event_trigger.async_attach_trigger(

--- a/custom_components/home_keeper/diagnostics.py
+++ b/custom_components/home_keeper/diagnostics.py
@@ -28,9 +28,7 @@ async def async_get_config_entry_diagnostics(
             "tasks": len(tasks),
             "assets": len(assets),
             "parts": sum(len(a.get("parts", [])) for a in assets),
-            "virtual_devices": sum(
-                1 for a in assets if a.get("kind") == "virtual"
-            ),
+            "virtual_devices": sum(1 for a in assets if a.get("kind") == "virtual"),
         },
         "tasks": tasks,
         "assets": assets,

--- a/custom_components/home_keeper/events.py
+++ b/custom_components/home_keeper/events.py
@@ -80,9 +80,7 @@ def asset_event_data(
     return data
 
 
-def stock_event_data(
-    asset: dict[str, Any], part: dict[str, Any]
-) -> dict[str, Any]:
+def stock_event_data(asset: dict[str, Any], part: dict[str, Any]) -> dict[str, Any]:
     """Return the shared payload for the three `home_keeper_part_*` stock events.
 
     Low-stock, out-of-stock and restocked all carry the same shape so an automation

--- a/custom_components/home_keeper/inventory.py
+++ b/custom_components/home_keeper/inventory.py
@@ -26,7 +26,7 @@ def _num(value: Any) -> float:
 
 
 def _spares_value(part: dict[str, Any]) -> float:
-    """On-hand value of a part: unit cost × stock (0 when either is unknown)."""
+    """On-hand value of a part: unit cost * stock (0 when either is unknown)."""
     cost = part.get("cost")
     stock = part.get("stock")
     if cost is None or stock is None:

--- a/custom_components/home_keeper/models.py
+++ b/custom_components/home_keeper/models.py
@@ -102,7 +102,8 @@ def normalize_fields(data: dict, *, tz: Any = None) -> dict:
         # reading (correct for zoneinfo/DST) rather than shifting it.
         if parsed_anchor.tzinfo is None:
             parsed_anchor = (
-                parsed_anchor.replace(tzinfo=tz) if tz is not None
+                parsed_anchor.replace(tzinfo=tz)
+                if tz is not None
                 else parsed_anchor.astimezone()
             )
         fields["freq"] = freq
@@ -246,6 +247,8 @@ def merge_update(existing: dict, updates: dict, *, now: datetime) -> dict:
     # complete_task (armed timestamp vs dormant None), so editing name/notes/device
     # must never recompute it (that would re-arm a dormant "monitored" task).
     recurrence_keys = {"recurrence_type", "interval", "unit", "freq", "anchor"}
-    if merged.get("recurrence_type") != REC_TRIGGERED and (recurrence_keys & set(updates)):
+    if merged.get("recurrence_type") != REC_TRIGGERED and (
+        recurrence_keys & set(updates)
+    ):
         merged["next_due"] = recurrence.compute_next_due(merged, now=now).isoformat()
     return merged

--- a/custom_components/home_keeper/reconcile.py
+++ b/custom_components/home_keeper/reconcile.py
@@ -99,7 +99,9 @@ def reconcile_part_tasks(
                     "unit": part["replace_unit"],
                     "device_id": asset.get("device_id"),
                     "area_id": asset.get("area_id"),
-                    "source": {"part": {"asset_id": asset["id"], "part_id": part["id"]}},
+                    "source": {
+                        "part": {"asset_id": asset["id"], "part_id": part["id"]}
+                    },
                 },
                 now=now,
             )
@@ -111,7 +113,9 @@ def reconcile_part_tasks(
             # silently hidden for a cycle.
             if anchored:
                 task["last_completed"] = anchored
-                task["next_due"] = recurrence.compute_next_due(task, now=now).isoformat()
+                task["next_due"] = recurrence.compute_next_due(
+                    task, now=now
+                ).isoformat()
             result[task["id"]] = task
             changed = True
         else:
@@ -130,7 +134,9 @@ def reconcile_part_tasks(
                 updates["device_id"] = asset.get("device_id")
             if before.get("area_id") != asset.get("area_id"):
                 updates["area_id"] = asset.get("area_id")
-            merged = models.merge_update(before, updates, now=now) if updates else before
+            merged = (
+                models.merge_update(before, updates, now=now) if updates else before
+            )
             # Heal a legacy timezone-naive last_completed (older builds stored a
             # date-only last_replaced verbatim, yielding a naive next_due that crashed
             # the sensors/calendar). Only re-qualify a naive value — never overwrite a
@@ -140,7 +146,9 @@ def reconcile_part_tasks(
             if healed and healed != lc:
                 merged = dict(merged)
                 merged["last_completed"] = healed
-                merged["next_due"] = recurrence.compute_next_due(merged, now=now).isoformat()
+                merged["next_due"] = recurrence.compute_next_due(
+                    merged, now=now
+                ).isoformat()
             if merged is not before:
                 result[tid] = merged
                 changed = True

--- a/custom_components/home_keeper/recurrence.py
+++ b/custom_components/home_keeper/recurrence.py
@@ -104,7 +104,9 @@ def _step(dt: datetime, freq: str, interval: int) -> datetime:
     raise ValueError(f"unknown freq: {freq!r}")
 
 
-def _fast_forward(anchor: datetime, freq: str, interval: int, target: datetime) -> datetime:
+def _fast_forward(
+    anchor: datetime, freq: str, interval: int, target: datetime
+) -> datetime:
     """An occurrence at or just before *target*, jumped to in O(1).
 
     A long-dormant fixed schedule can be thousands of steps past its anchor;

--- a/custom_components/home_keeper/sensor.py
+++ b/custom_components/home_keeper/sensor.py
@@ -92,9 +92,7 @@ class HomeKeeperNextDueSensor(HomeKeeperTaskEntity, SensorEntity):
         }
 
 
-class HomeKeeperAssetDateSensor(
-    CoordinatorEntity[HomeKeeperCoordinator], SensorEntity
-):
+class HomeKeeperAssetDateSensor(CoordinatorEntity[HomeKeeperCoordinator], SensorEntity):
     """A single tracked ``date`` metadata entry for an asset, on its device page.
 
     The value lives in the asset's free-form ``metadata`` list (not the task map);

--- a/custom_components/home_keeper/store.py
+++ b/custom_components/home_keeper/store.py
@@ -42,8 +42,8 @@ _STOCK_EVENT = {
     STOCK_OUT: EVENT_PART_OUT_OF_STOCK,
     STOCK_RESTOCKED: EVENT_PART_RESTOCKED,
 }
-from .reconcile import part_source as _part_source
-from .reconcile import reconcile_part_tasks as _reconcile_part_tasks
+from .reconcile import part_source as _part_source  # noqa: E402
+from .reconcile import reconcile_part_tasks as _reconcile_part_tasks  # noqa: E402
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -136,7 +136,9 @@ class HomeKeeperStore:
         self._hass.bus.async_fire(EVENT_TASK_CREATED, events.task_event_data(task))
         return task
 
-    async def update_task(self, task_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+    async def update_task(
+        self, task_id: str, updates: dict[str, Any]
+    ) -> dict[str, Any]:
         existing = self._tasks.get(task_id)
         if existing is None:
             raise KeyError(task_id)
@@ -174,7 +176,9 @@ class HomeKeeperStore:
         existing["next_due"] = dt_util.now().isoformat()
         await self._save()
         _LOGGER.debug("Triggered task %s (armed, due now)", task_id)
-        self._hass.bus.async_fire(EVENT_TASK_TRIGGERED, events.task_event_data(existing))
+        self._hass.bus.async_fire(
+            EVENT_TASK_TRIGGERED, events.task_event_data(existing)
+        )
         return existing
 
     async def delete_task(self, task_id: str, *, force: bool = False) -> None:
@@ -190,7 +194,9 @@ class HomeKeeperStore:
             managed_by = task.get("managed_by")
             orphaned = self.managed_task_orphaned(task)
             if models.deletion_blocked(task, orphaned=orphaned, force=force):
-                display_name = (managed_by or {}).get("display_name") or "an integration"
+                display_name = (managed_by or {}).get(
+                    "display_name"
+                ) or "an integration"
                 raise models.TaskValidationError(
                     f"This task is managed by {display_name}. "
                     f"Delete it from {display_name} instead."
@@ -200,7 +206,9 @@ class HomeKeeperStore:
             self._archive_task_history(removed)
             del self._tasks[task_id]
             await self._save()
-            self._hass.bus.async_fire(EVENT_TASK_DELETED, events.task_event_data(removed))
+            self._hass.bus.async_fire(
+                EVENT_TASK_DELETED, events.task_event_data(removed)
+            )
 
     def managed_task_orphaned(self, task: dict[str, Any]) -> bool:
         """Whether a managed task's owning integration is no longer present.
@@ -349,7 +357,8 @@ class HomeKeeperStore:
         dropped_ids = {
             tid
             for tid, t in self._tasks.items()
-            if _part_source(t) is not None and _part_source(t).get("asset_id") == asset_id
+            if _part_source(t) is not None
+            and _part_source(t).get("asset_id") == asset_id
         }
         dropped = [self._tasks[tid] for tid in dropped_ids]
         self._tasks = {
@@ -380,9 +389,7 @@ class HomeKeeperStore:
             # the appliance remains; preserve its history on the appliance. (Deleting
             # the whole appliance drops its derived tasks via delete_asset, before any
             # reconcile, so this only archives part removals — not appliance deletes.)
-            removed = [
-                task for tid, task in old_tasks.items() if tid not in new_tasks
-            ]
+            removed = [task for tid, task in old_tasks.items() if tid not in new_tasks]
             for task in removed:
                 if _part_source(task):
                     self._archive_task_history(task)
@@ -405,7 +412,11 @@ class HomeKeeperStore:
         return changed
 
     async def complete_task(
-        self, task_id: str, completed_at: Any | None = None, *, origin: str | None = None
+        self,
+        task_id: str,
+        completed_at: Any | None = None,
+        *,
+        origin: str | None = None,
     ) -> dict[str, Any]:
         """Mark a task completed and advance its recurrence.
 
@@ -451,7 +462,9 @@ class HomeKeeperStore:
         updated = recurrence.remove_completion(dict(existing), ts, now=dt_util.now())
         self._tasks[task_id] = updated
         await self._save()
-        self._hass.bus.async_fire(EVENT_TASK_UNCOMPLETED, events.task_event_data(updated))
+        self._hass.bus.async_fire(
+            EVENT_TASK_UNCOMPLETED, events.task_event_data(updated)
+        )
         return updated
 
     async def delete_archived_completion(

--- a/custom_components/home_keeper/testing.py
+++ b/custom_components/home_keeper/testing.py
@@ -136,7 +136,7 @@ class FakeHomeKeeper:
     def fire_user_completion(
         self, task_id: str, completed_at: Any | None = None
     ) -> dict[str, Any]:
-        """Simulate a user checking the task off in Home Keeper's UI (``origin`` None)."""
+        """Simulate a user checking the task off in the UI (``origin`` None)."""
         return self._complete(task_id, completed_at, None)
 
     def get_task_by_source(self, namespace: str, **match: Any) -> dict[str, Any] | None:

--- a/custom_components/home_keeper/todo.py
+++ b/custom_components/home_keeper/todo.py
@@ -35,7 +35,9 @@ async def async_setup_entry(
     async_add_entities([HomeKeeperTodoListEntity(coordinator)])
 
 
-class HomeKeeperTodoListEntity(CoordinatorEntity[HomeKeeperCoordinator], TodoListEntity):
+class HomeKeeperTodoListEntity(
+    CoordinatorEntity[HomeKeeperCoordinator], TodoListEntity
+):
     """A single to-do list backed by the Home Keeper task store."""
 
     # No device for this hub entity, so anchor the entity_id explicitly via the

--- a/custom_components/home_keeper/transitions.py
+++ b/custom_components/home_keeper/transitions.py
@@ -74,7 +74,9 @@ def detect_transitions(
                 fired.append(
                     (
                         EVENT_TASK_DUE_SOON,
-                        events.task_event_data(task, extra={"due_in_hours": due_in_hours}),
+                        events.task_event_data(
+                            task, extra={"due_in_hours": due_in_hours}
+                        ),
                     )
                 )
                 due_soon_fired = True
@@ -83,7 +85,9 @@ def detect_transitions(
                 fired.append(
                     (
                         EVENT_TASK_OVERDUE,
-                        events.task_event_data(task, extra={"days_overdue": days_overdue}),
+                        events.task_event_data(
+                            task, extra={"days_overdue": days_overdue}
+                        ),
                     )
                 )
                 overdue_fired = True

--- a/custom_components/home_keeper/websocket_api.py
+++ b/custom_components/home_keeper/websocket_api.py
@@ -347,9 +347,7 @@ async def ws_adjust_part_stock(
     connection.send_result(msg["id"], {"asset": asset})
 
 
-@websocket_api.websocket_command(
-    {vol.Required("type"): "home_keeper/export_inventory"}
-)
+@websocket_api.websocket_command({vol.Required("type"): "home_keeper/export_inventory"})
 @websocket_api.async_response
 async def ws_export_inventory(
     hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,19 @@ omit = ["custom_components/home_keeper/testing.py"]
 
 [tool.coverage.report]
 show_missing = true
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+# Pragmatic-but-meaningful set: pyflakes/pycodestyle, import sorting, pyupgrade,
+# bugbear, comprehensions, simplify, and Ruff's own rules.
+select = ["E", "F", "W", "I", "UP", "B", "C4", "SIM", "RUF"]
+
+[tool.ruff.lint.isort]
+known-third-party = ["homeassistant"]
+
+[tool.ruff.lint.per-file-ignores]
+# Tests favour explicit loops / try-except over these "simplify" suggestions.
+"tests/**" = ["SIM105", "SIM113"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,9 @@ import sys
 import types
 from pathlib import Path
 
-_COMPONENT_DIR = Path(__file__).resolve().parent.parent / "custom_components" / "home_keeper"
+_COMPONENT_DIR = (
+    Path(__file__).resolve().parent.parent / "custom_components" / "home_keeper"
+)
 
 
 def _load_pure_modules() -> None:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -44,7 +44,9 @@ def _complete_onboarding():
     elif r.status_code == 403:
         return _login("test", "testtest1")
     else:
-        raise RuntimeError(f"Failed to create onboarding user: {r.status_code} {r.text}")
+        raise RuntimeError(
+            f"Failed to create onboarding user: {r.status_code} {r.text}"
+        )
 
     r = requests.post(
         f"{HA_URL}/auth/token",
@@ -62,10 +64,16 @@ def _complete_onboarding():
     for endpoint, payload in [
         ("core_config", {}),
         ("analytics", {}),
-        ("integration", {"client_id": f"{HA_URL}/", "redirect_uri": f"{HA_URL}/?auth_callback=1"}),
+        (
+            "integration",
+            {"client_id": f"{HA_URL}/", "redirect_uri": f"{HA_URL}/?auth_callback=1"},
+        ),
     ]:
         requests.post(
-            f"{HA_URL}/api/onboarding/{endpoint}", headers=headers, json=payload, timeout=10
+            f"{HA_URL}/api/onboarding/{endpoint}",
+            headers=headers,
+            json=payload,
+            timeout=10,
         )
 
     return access_token
@@ -171,6 +179,4 @@ def poll_state(ha, entity_id, condition, timeout=20):
         time.sleep(1)
     state_obj = get_state(ha, entity_id)
     state_val = state_obj["state"] if state_obj else "<entity not found>"
-    raise TimeoutError(
-        f"Timed out waiting for {entity_id}. Last state: {state_val}"
-    )
+    raise TimeoutError(f"Timed out waiting for {entity_id}. Last state: {state_val}")

--- a/tests/integration/test_assets.py
+++ b/tests/integration/test_assets.py
@@ -18,8 +18,7 @@ def test_seeded_virtual_asset_has_warranty_date_sensor(ha):
     # entry, which is surfaced as a date sensor on its (virtual) device page.
     warranty = _find_state(
         ha,
-        lambda s: s["entity_id"].startswith("sensor.")
-        and "warranty" in s["entity_id"],
+        lambda s: s["entity_id"].startswith("sensor.") and "warranty" in s["entity_id"],
     )
     assert warranty, "expected a warranty-expiry date sensor for the virtual asset"
     assert any(s["state"] == "2032-05-01" for s in warranty)
@@ -56,9 +55,7 @@ def test_add_asset_then_attach_task_creates_device_entities(ha):
     )
 
     def _find_new_asset():
-        resp = call_service(
-            ha, "home_keeper", "list_assets", {}, return_response=True
-        )
+        resp = call_service(ha, "home_keeper", "list_assets", {}, return_response=True)
         payload = resp.get("service_response", resp)
         for a in payload["assets"]:
             if a["name"] == "Test dehumidifier" and a.get("device_id"):
@@ -136,7 +133,9 @@ def test_existing_device_asset_persists_identifier_snapshot(ha):
         {
             "kind": "existing",
             "device_id": device_id,
-            "metadata": [{"type": "text", "label": "Warranty provider", "value": "ACME"}],
+            "metadata": [
+                {"type": "text", "label": "Warranty provider", "value": "ACME"}
+            ],
         },
     )
 
@@ -180,7 +179,9 @@ def test_wear_part_creates_maintenance_task_with_device_entities(ha):
     assert anode_tasks[0].get("source", {}).get("part"), "task should carry part source"
     # Its per-task entities appear; the button merges onto the appliance device, so
     # its entity_id derives from the device name ("Garage water heater").
-    mark_done = [s["entity_id"] for s in list_states(ha) if "mark_done" in s["entity_id"]]
+    mark_done = [
+        s["entity_id"] for s in list_states(ha) if "mark_done" in s["entity_id"]
+    ]
     assert any("garage_water_heater" in eid for eid in mark_done), mark_done
 
 
@@ -199,8 +200,12 @@ def test_cannot_delete_derived_part_task(ha):
     from conftest import HA_URL
 
     anode = _anode_task(ha)
-    r = ha.post(f"{HA_URL}/api/services/home_keeper/delete_task", json={"task_id": anode["id"]})
-    assert r.status_code >= 400, f"deleting a derived task should be rejected, got {r.status_code}"
+    r = ha.post(
+        f"{HA_URL}/api/services/home_keeper/delete_task", json={"task_id": anode["id"]}
+    )
+    assert r.status_code >= 400, (
+        f"deleting a derived task should be rejected, got {r.status_code}"
+    )
     resp = call_service(ha, "home_keeper", "list_tasks", {}, return_response=True)
     assert any(
         t["id"] == anode["id"] for t in resp.get("service_response", resp)["tasks"]
@@ -219,10 +224,17 @@ def test_completing_derived_part_task_survives_reconcile(ha):
     lc, nd = after_complete["last_completed"], after_complete["next_due"]
     assert lc, "completion should set last_completed"
     # Editing the asset triggers a reconcile of its part tasks.
-    call_service(ha, "home_keeper", "update_asset", {"asset_id": asset_id, "manufacturer": "poke"})
+    call_service(
+        ha,
+        "home_keeper",
+        "update_asset",
+        {"asset_id": asset_id, "manufacturer": "poke"},
+    )
     time.sleep(1)
     after_reconcile = next(t for t in _all_tasks(ha) if t["id"] == anode["id"])
-    assert after_reconcile["last_completed"] == lc, "reconcile must not revert the completion"
+    assert after_reconcile["last_completed"] == lc, (
+        "reconcile must not revert the completion"
+    )
     assert after_reconcile["next_due"] == nd
 
 
@@ -238,7 +250,9 @@ def _part_tasks_for(ha, asset_id):
 
 def _newest_asset_named(ha, name):
     resp = call_service(ha, "home_keeper", "list_assets", {}, return_response=True)
-    matches = [a for a in resp.get("service_response", resp)["assets"] if a["name"] == name]
+    matches = [
+        a for a in resp.get("service_response", resp)["assets"] if a["name"] == name
+    ]
     return matches[-1] if matches else None
 
 
@@ -257,7 +271,12 @@ def test_removing_wear_part_deletes_its_derived_task(ha):
         {
             "name": name,
             "parts": [
-                {"name": "Belt", "type": "wear", "replace_interval": 6, "replace_unit": "months"}
+                {
+                    "name": "Belt",
+                    "type": "wear",
+                    "replace_interval": 6,
+                    "replace_unit": "months",
+                }
             ],
         },
     )
@@ -267,15 +286,21 @@ def test_removing_wear_part_deletes_its_derived_task(ha):
         if asset and _part_tasks_for(ha, asset["id"]):
             break
         time.sleep(1)
-    assert asset and _part_tasks_for(ha, asset["id"]), "wear part should have created a task"
+    assert asset and _part_tasks_for(ha, asset["id"]), (
+        "wear part should have created a task"
+    )
 
-    call_service(ha, "home_keeper", "update_asset", {"asset_id": asset["id"], "parts": []})
+    call_service(
+        ha, "home_keeper", "update_asset", {"asset_id": asset["id"], "parts": []}
+    )
 
     for _ in range(20):
         if not _part_tasks_for(ha, asset["id"]):
             break
         time.sleep(1)
-    assert not _part_tasks_for(ha, asset["id"]), "derived task should be removed with its part"
+    assert not _part_tasks_for(ha, asset["id"]), (
+        "derived task should be removed with its part"
+    )
     call_service(ha, "home_keeper", "delete_asset", {"asset_id": asset["id"]})
 
 
@@ -293,7 +318,14 @@ def test_wear_part_next_due_does_not_drift_on_asset_edit(ha):
         "add_asset",
         {
             "name": name,
-            "parts": [{"name": "Filter", "type": "wear", "replace_interval": 3, "replace_unit": "months"}],
+            "parts": [
+                {
+                    "name": "Filter",
+                    "type": "wear",
+                    "replace_interval": 3,
+                    "replace_unit": "months",
+                }
+            ],
         },
     )
     asset = None
@@ -302,10 +334,17 @@ def test_wear_part_next_due_does_not_drift_on_asset_edit(ha):
         if asset and _part_tasks_for(ha, asset["id"]):
             break
         time.sleep(1)
-    assert asset and _part_tasks_for(ha, asset["id"]), "wear part should have created a task"
+    assert asset and _part_tasks_for(ha, asset["id"]), (
+        "wear part should have created a task"
+    )
     due_before = _part_tasks_for(ha, asset["id"])[0]["next_due"]
 
-    call_service(ha, "home_keeper", "update_asset", {"asset_id": asset["id"], "name": name + " v2"})
+    call_service(
+        ha,
+        "home_keeper",
+        "update_asset",
+        {"asset_id": asset["id"], "name": name + " v2"},
+    )
 
     due_after = _part_tasks_for(ha, asset["id"])[0]["next_due"]
     call_service(ha, "home_keeper", "delete_asset", {"asset_id": asset["id"]})
@@ -326,11 +365,16 @@ def test_subdevice_has_warranty_independent_and_parent_seeded(ha):
 def test_related_device_can_be_attached(ha):
     # Create a virtual appliance, then relate it to an existing device id and confirm
     # the relationship round-trips (panel-only association for foreign devices).
-    call_service(ha, "home_keeper", "add_asset", {"name": "Living room piano", "icon": "mdi:piano"})
+    call_service(
+        ha,
+        "home_keeper",
+        "add_asset",
+        {"name": "Living room piano", "icon": "mdi:piano"},
+    )
     resp = call_service(ha, "home_keeper", "list_assets", {}, return_response=True)
     assets = resp.get("service_response", resp)["assets"]
     piano = next(a for a in assets if a["name"] == "Living room piano")
-    # Relate it to the seeded water heater's (virtual) device as a stand-in foreign device.
+    # Relate it to the seeded water heater's (virtual) device as a foreign device.
     wh = next(a for a in assets if a["id"] == "asset_water_heater")
     call_service(
         ha,
@@ -408,7 +452,9 @@ def test_deleting_a_task_assigned_to_an_appliance_archives_its_history(ha):
     asset = next(a for a in _assets(ha) if a["name"] == "Archive test heater")
     history = asset.get("task_history", [])
     entry = next((h for h in history if h["task_id"] == task_id), None)
-    assert entry is not None, "deleted task's history should be archived on the appliance"
+    assert entry is not None, (
+        "deleted task's history should be archived on the appliance"
+    )
     assert entry["task_name"] == "Archive test flush"
     assert len(entry["completions"]) == 1
 
@@ -421,8 +467,12 @@ def test_deleting_a_standalone_task_does_not_archive(ha):
         ha,
         "home_keeper",
         "add_task",
-        {"name": "Standalone no-archive", "recurrence_type": "floating",
-         "interval": 1, "unit": "weeks"},
+        {
+            "name": "Standalone no-archive",
+            "recurrence_type": "floating",
+            "interval": 1,
+            "unit": "weeks",
+        },
         return_response=True,
     )
     task_id = add.get("service_response", add)["task_id"]
@@ -430,9 +480,9 @@ def test_deleting_a_standalone_task_does_not_archive(ha):
     call_service(ha, "home_keeper", "delete_task", {"task_id": task_id})
 
     for asset in _assets(ha):
-        assert all(
-            h["task_id"] != task_id for h in asset.get("task_history", [])
-        ), "a standalone task's history must not be archived anywhere"
+        assert all(h["task_id"] != task_id for h in asset.get("task_history", [])), (
+            "a standalone task's history must not be archived anywhere"
+        )
 
 
 def _water_heater(ha):
@@ -462,13 +512,17 @@ def test_adjust_part_stock_service_clamps_and_restocks(ha):
     part = next(p for p in wh["parts"] if p["name"] == "Anode rod")
     # Force to zero (clamped at zero) regardless of prior state, then restock by 2.
     call_service(
-        ha, "home_keeper", "adjust_part_stock",
+        ha,
+        "home_keeper",
+        "adjust_part_stock",
         {"asset_id": wh["id"], "part_id": part["id"], "delta": -100},
     )
     part = next(p for p in _water_heater(ha)["parts"] if p["name"] == "Anode rod")
     assert part["stock"] == 0
     call_service(
-        ha, "home_keeper", "adjust_part_stock",
+        ha,
+        "home_keeper",
+        "adjust_part_stock",
         {"asset_id": wh["id"], "part_id": part["id"], "delta": 2},
     )
     part = next(p for p in _water_heater(ha)["parts"] if p["name"] == "Anode rod")
@@ -519,24 +573,33 @@ def test_low_stock_event_fires_on_crossing_not_on_restock(ha):
     sentinel = "input_text.hk_last_low_stock_part"
 
     def _reset():
-        call_service(ha, "input_text", "set_value",
-                     {"entity_id": sentinel, "value": "none"})
+        call_service(
+            ha, "input_text", "set_value", {"entity_id": sentinel, "value": "none"}
+        )
 
     def _captured():
         st = get_state(ha, sentinel)
         return st["state"] if st else None
 
     # Restock well above the threshold (reorder_at=2) so the next drop is a crossing.
-    call_service(ha, "home_keeper", "adjust_part_stock",
-                 {"asset_id": wh["id"], "part_id": pid, "delta": 10})
+    call_service(
+        ha,
+        "home_keeper",
+        "adjust_part_stock",
+        {"asset_id": wh["id"], "part_id": pid, "delta": 10},
+    )
     _reset()
     # Drop across the threshold but stay above zero -> a *low-stock* crossing (a drop
     # all the way to zero is the more specific `part_out_of_stock` event instead). Land
     # at the threshold so the part reads low without being out.
     part = next(p for p in _water_heater(ha)["parts"] if p["id"] == pid)
     target = max(1, part["reorder_at"])
-    call_service(ha, "home_keeper", "adjust_part_stock",
-                 {"asset_id": wh["id"], "part_id": pid, "delta": target - part["stock"]})
+    call_service(
+        ha,
+        "home_keeper",
+        "adjust_part_stock",
+        {"asset_id": wh["id"], "part_id": pid, "delta": target - part["stock"]},
+    )
     deadline = time.monotonic() + 10
     captured = None
     while time.monotonic() < deadline:
@@ -550,7 +613,11 @@ def test_low_stock_event_fires_on_crossing_not_on_restock(ha):
 
     # A restock that leaves the part not-low must NOT re-fire the event.
     _reset()
-    call_service(ha, "home_keeper", "adjust_part_stock",
-                 {"asset_id": wh["id"], "part_id": pid, "delta": 10})
+    call_service(
+        ha,
+        "home_keeper",
+        "adjust_part_stock",
+        {"asset_id": wh["id"], "part_id": pid, "delta": 10},
+    )
     time.sleep(2)
     assert _captured() == "none", "a restock must not fire a low-stock event"

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -10,9 +10,8 @@ refresh; here we cover the deterministic, mutation-driven events.
 import asyncio
 import json
 
-import pytest
 import websockets
-from conftest import HA_URL, call_service
+from conftest import call_service
 
 WS_URL = "ws://localhost:8123/api/websocket"
 
@@ -52,7 +51,7 @@ async def _capture(token, event_types, action, *, expected, timeout=20):
 
         try:
             await asyncio.wait_for(_drain(), timeout=timeout)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pass
     return captured
 
@@ -78,14 +77,22 @@ def test_task_lifecycle_events(ha, ha_token):
             ha,
             "home_keeper",
             "add_task",
-            {"name": "Event test task", "recurrence_type": "floating",
-             "interval": 7, "unit": "days"},
+            {
+                "name": "Event test task",
+                "recurrence_type": "floating",
+                "interval": 7,
+                "unit": "days",
+            },
             return_response=True,
         )
         body = resp.get("service_response", resp)
         created_id["id"] = body["task_id"]
-        call_service(ha, "home_keeper", "update_task",
-                     {"task_id": body["task_id"], "name": "Renamed task"})
+        call_service(
+            ha,
+            "home_keeper",
+            "update_task",
+            {"task_id": body["task_id"], "name": "Renamed task"},
+        )
         call_service(ha, "home_keeper", "complete_task", {"task_id": body["task_id"]})
         call_service(ha, "home_keeper", "delete_task", {"task_id": body["task_id"]})
 
@@ -128,7 +135,12 @@ def test_stock_transition_events(ha, ha_token):
             {
                 "name": "Event test appliance",
                 "parts": [
-                    {"name": "Widget", "type": "consumable", "stock": 2, "reorder_at": 1}
+                    {
+                        "name": "Widget",
+                        "type": "consumable",
+                        "stock": 2,
+                        "reorder_at": 1,
+                    }
                 ],
             },
         )
@@ -149,7 +161,11 @@ def test_stock_transition_events(ha, ha_token):
                 ha,
                 "home_keeper",
                 "adjust_part_stock",
-                {"asset_id": ids["asset_id"], "part_id": ids["part_id"], "delta": delta},
+                {
+                    "asset_id": ids["asset_id"],
+                    "part_id": ids["part_id"],
+                    "delta": delta,
+                },
             )
 
     events = _by_type(
@@ -174,7 +190,7 @@ def test_stock_transition_events(ha, ha_token):
 
 
 async def _ws_commands(token, commands):
-    """Open one authed websocket, send each command dict (id auto-assigned), return results."""
+    """Open one authed websocket; send each command; return the replies."""
     results = []
     async with websockets.connect(WS_URL, max_size=None) as ws:
         assert json.loads(await ws.recv())["type"] == "auth_required"
@@ -191,9 +207,7 @@ async def _ws_commands(token, commands):
 
 def test_device_triggers_offered_for_appliance_and_task_devices(ha, ha_token):
     """async_get_triggers offers Home Keeper triggers on the right devices."""
-    (devices_reply,) = _run_ws(
-        ha_token, [{"type": "config/device_registry/list"}]
-    )
+    (devices_reply,) = _run_ws(ha_token, [{"type": "config/device_registry/list"}])
     devices = devices_reply["result"]
 
     def _is_hk(device):
@@ -234,10 +248,10 @@ def test_asset_lifecycle_events(ha, ha_token):
     def action():
         call_service(ha, "home_keeper", "add_asset", {"name": "Asset event appliance"})
 
-    events = _by_type(
-        _run(ha_token, ["home_keeper_asset_created"], action, expected=1)
+    events = _by_type(_run(ha_token, ["home_keeper_asset_created"], action, expected=1))
+    assert (
+        events["home_keeper_asset_created"][0]["asset_name"] == "Asset event appliance"
     )
-    assert events["home_keeper_asset_created"][0]["asset_name"] == "Asset event appliance"
 
     # Find and delete it, asserting the deletion event.
     assets = call_service(ha, "home_keeper", "list_assets", {}, return_response=True)
@@ -249,7 +263,5 @@ def test_asset_lifecycle_events(ha, ha_token):
     def delete():
         call_service(ha, "home_keeper", "delete_asset", {"asset_id": asset_id})
 
-    events = _by_type(
-        _run(ha_token, ["home_keeper_asset_deleted"], delete, expected=1)
-    )
+    events = _by_type(_run(ha_token, ["home_keeper_asset_deleted"], delete, expected=1))
     assert events["home_keeper_asset_deleted"][0]["asset_id"] == asset_id

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -57,16 +57,22 @@ def test_device_attached_task_creates_per_task_entities(ha):
     ids = [s["entity_id"] for s in states]
     # The seeded "water filter" task has a device_id, so it gets button + sensor +
     # binary_sensor entities.
-    assert any(eid.startswith("button.") and "water_filter" in eid or
-               eid == "button.replace_water_filter_mark_done" for eid in ids) or \
-        any("mark_done" in eid for eid in ids)
+    assert any(
+        (eid.startswith("button.") and "water_filter" in eid)
+        or eid == "button.replace_water_filter_mark_done"
+        for eid in ids
+    ) or any("mark_done" in eid for eid in ids)
     assert any("next_due" in eid for eid in ids)
     assert any("overdue" in eid for eid in ids)
 
 
 def test_overdue_binary_sensor_is_on_for_overdue_task(ha):
     states = list_states(ha)
-    overdue = [s for s in states if s["entity_id"].endswith("_overdue") or "overdue" in s["entity_id"]]
+    overdue = [
+        s
+        for s in states
+        if s["entity_id"].endswith("_overdue") or "overdue" in s["entity_id"]
+    ]
     assert overdue, "expected at least one overdue binary_sensor"
     # The seeded water filter is overdue.
     assert any(s["state"] == "on" for s in overdue)
@@ -125,7 +131,13 @@ def test_add_task_accepts_and_round_trips_opaque_source(ha):
     # A contributing integration tags its task with a domain-namespaced source dict;
     # Home Keeper must accept it on the service and store it verbatim (see
     # docs/INTEGRATING.md).
-    source = {"pawsistant": {"dog_id": "buddy", "event_type": "medicine", "schedule_id": "sched-1"}}
+    source = {
+        "pawsistant": {
+            "dog_id": "buddy",
+            "event_type": "medicine",
+            "schedule_id": "sched-1",
+        }
+    }
     call_service(
         ha,
         "home_keeper",
@@ -168,7 +180,9 @@ def test_complete_task_fires_event_with_source_and_origin(ha):
         t["id"] for t in _list_tasks(ha) if t["name"] == "Event payload probe"
     )
 
-    call_service(ha, "home_keeper", "complete_task", {"task_id": task_id, "origin": origin})
+    call_service(
+        ha, "home_keeper", "complete_task", {"task_id": task_id, "origin": origin}
+    )
 
     # The capture automation records the last completion's origin/source.
     poll_state(
@@ -222,7 +236,7 @@ def test_renaming_task_updates_device_entity_name(ha):
     try:
         eid = None
         for _ in range(20):
-            eid, before = _find_button_by_name(ha, "Rename probe original")
+            eid, _before = _find_button_by_name(ha, "Rename probe original")
             if eid:
                 break
             time.sleep(1)

--- a/tests/unit/test_assets.py
+++ b/tests/unit/test_assets.py
@@ -50,7 +50,9 @@ def test_build_existing_asset_keeps_device_id_no_identifier():
         {
             "kind": "existing",
             "device_id": "dev_xyz",
-            "metadata": [{"type": "date", "label": "Warranty expiry", "value": "2030-01-01"}],
+            "metadata": [
+                {"type": "date", "label": "Warranty expiry", "value": "2030-01-01"}
+            ],
         },
         now=NOW,
     )
@@ -73,8 +75,17 @@ def test_metadata_entries_normalized():
             "metadata": [
                 {"type": "date", "label": "Purchase date", "value": "2024-03-15"},
                 # A full datetime should be truncated to its date.
-                {"type": "date", "label": "Warranty expiry", "value": "2029-03-15T00:00:00", "track": True},
-                {"type": "link", "label": "Spec sheet", "value": "https://example.com/spec.pdf"},
+                {
+                    "type": "date",
+                    "label": "Warranty expiry",
+                    "value": "2029-03-15T00:00:00",
+                    "track": True,
+                },
+                {
+                    "type": "link",
+                    "label": "Spec sheet",
+                    "value": "https://example.com/spec.pdf",
+                },
                 {"type": "text", "label": "Serial", "value": "  SN-7  "},
             ],
         },
@@ -103,14 +114,20 @@ def test_metadata_requires_label():
 def test_metadata_rejects_bad_type():
     with pytest.raises(a.AssetValidationError):
         a.build_asset(
-            {"name": "Furnace", "metadata": [{"type": "number", "label": "x", "value": "1"}]},
+            {
+                "name": "Furnace",
+                "metadata": [{"type": "number", "label": "x", "value": "1"}],
+            },
             now=NOW,
         )
 
 
 def test_metadata_empty_date_is_blank():
     asset = a.build_asset(
-        {"name": "Furnace", "metadata": [{"type": "date", "label": "Purchase date", "value": ""}]},
+        {
+            "name": "Furnace",
+            "metadata": [{"type": "date", "label": "Purchase date", "value": ""}],
+        },
         now=NOW,
     )
     assert asset["metadata"][0]["value"] == ""
@@ -119,7 +136,12 @@ def test_metadata_empty_date_is_blank():
 def test_metadata_bad_date_raises():
     with pytest.raises(a.AssetValidationError):
         a.build_asset(
-            {"name": "Furnace", "metadata": [{"type": "date", "label": "Warranty", "value": "not-a-date"}]},
+            {
+                "name": "Furnace",
+                "metadata": [
+                    {"type": "date", "label": "Warranty", "value": "not-a-date"}
+                ],
+            },
             now=NOW,
         )
 
@@ -127,7 +149,12 @@ def test_metadata_bad_date_raises():
 def test_metadata_link_rejects_non_http():
     with pytest.raises(a.AssetValidationError):
         a.build_asset(
-            {"name": "Furnace", "metadata": [{"type": "link", "label": "Bad", "value": "javascript:alert(1)"}]},
+            {
+                "name": "Furnace",
+                "metadata": [
+                    {"type": "link", "label": "Bad", "value": "javascript:alert(1)"}
+                ],
+            },
             now=NOW,
         )
 
@@ -154,7 +181,12 @@ def test_manual_url_accepts_http_and_https():
 
 
 def test_manual_url_rejects_non_http_scheme():
-    for bad in ("javascript:alert(1)", "ftp://example.com", "data:text/html,x", "/relative"):
+    for bad in (
+        "javascript:alert(1)",
+        "ftp://example.com",
+        "data:text/html,x",
+        "/relative",
+    ):
         with pytest.raises(a.AssetValidationError):
             a.build_asset({"name": "Furnace", "manual_url": bad}, now=NOW)
 
@@ -182,7 +214,9 @@ def test_merge_update_changes_metadata_preserves_anchors():
         asset,
         {
             "manufacturer": "LG",
-            "metadata": [{"type": "date", "label": "Warranty expiry", "value": "2031-06-01"}],
+            "metadata": [
+                {"type": "date", "label": "Warranty expiry", "value": "2031-06-01"}
+            ],
         },
         now=NOW,
     )
@@ -195,9 +229,7 @@ def test_merge_update_changes_metadata_preserves_anchors():
 
 
 def test_merge_update_existing_can_retarget_device():
-    asset = a.build_asset(
-        {"kind": "existing", "device_id": "dev_a"}, now=NOW
-    )
+    asset = a.build_asset({"kind": "existing", "device_id": "dev_a"}, now=NOW)
     updated = a.merge_update(asset, {"device_id": "dev_b"}, now=NOW)
     assert updated["device_id"] == "dev_b"
     assert updated["kind"] == "existing"
@@ -207,7 +239,10 @@ def test_merge_update_existing_can_retarget_device():
 
 
 def test_icon_valid_and_invalid():
-    assert a.build_asset({"name": "Piano", "icon": "mdi:piano"}, now=NOW)["icon"] == "mdi:piano"
+    assert (
+        a.build_asset({"name": "Piano", "icon": "mdi:piano"}, now=NOW)["icon"]
+        == "mdi:piano"
+    )
     assert a.build_asset({"name": "Piano"}, now=NOW)["icon"] == ""
     with pytest.raises(a.AssetValidationError):
         a.build_asset({"name": "Piano", "icon": "not an icon"}, now=NOW)
@@ -225,8 +260,13 @@ def test_parts_normalized_with_ids_and_types():
         {
             "name": "Shades",
             "parts": [
-                {"name": "Shade material", "type": "wear", "replace_interval": 10,
-                 "replace_unit": "months", "cost": "120"},
+                {
+                    "name": "Shade material",
+                    "type": "wear",
+                    "replace_interval": 10,
+                    "replace_unit": "months",
+                    "cost": "120",
+                },
                 {"name": "Cord", "part_number": "C-9"},  # defaults to consumable
             ],
         },
@@ -253,14 +293,27 @@ def test_part_requires_name_and_valid_type():
 def test_part_bad_interval_unit_rejected():
     with pytest.raises(a.AssetValidationError):
         a.build_asset(
-            {"name": "X", "parts": [{"name": "p", "replace_interval": 1, "replace_unit": "eons"}]},
+            {
+                "name": "X",
+                "parts": [{"name": "p", "replace_interval": 1, "replace_unit": "eons"}],
+            },
             now=NOW,
         )
 
 
 def test_merge_update_preserves_part_last_replaced():
     asset = a.build_asset(
-        {"name": "Shades", "parts": [{"name": "Material", "type": "wear", "replace_interval": 6, "replace_unit": "months"}]},
+        {
+            "name": "Shades",
+            "parts": [
+                {
+                    "name": "Material",
+                    "type": "wear",
+                    "replace_interval": 6,
+                    "replace_unit": "months",
+                }
+            ],
+        },
         now=NOW,
     )
     pid = asset["parts"][0]["id"]
@@ -268,7 +321,17 @@ def test_merge_update_preserves_part_last_replaced():
     # The panel re-submits the part without last_replaced; merge must keep it.
     updated = a.merge_update(
         asset,
-        {"parts": [{"id": pid, "name": "Material", "type": "wear", "replace_interval": 12, "replace_unit": "months"}]},
+        {
+            "parts": [
+                {
+                    "id": pid,
+                    "name": "Material",
+                    "type": "wear",
+                    "replace_interval": 12,
+                    "replace_unit": "months",
+                }
+            ]
+        },
         now=NOW,
     )
     assert updated["parts"][0]["last_replaced"] == "2025-01-01"
@@ -276,7 +339,12 @@ def test_merge_update_preserves_part_last_replaced():
 
 
 def test_migrate_legacy_part_numbers():
-    legacy = {"id": "x", "kind": "virtual", "name": "WH", "part_numbers": "anode rod AR-1"}
+    legacy = {
+        "id": "x",
+        "kind": "virtual",
+        "name": "WH",
+        "part_numbers": "anode rod AR-1",
+    }
     changed = a.migrate_legacy_part_numbers(legacy)
     assert changed is True
     assert "part_numbers" not in legacy
@@ -296,7 +364,8 @@ def test_parent_asset_id_only_for_virtual():
 
 
 def test_part_rejects_future_last_replaced():
-    from datetime import date, timedelta as _td
+    from datetime import date
+    from datetime import timedelta as _td
 
     future = (date.today() + _td(days=30)).isoformat()
     with pytest.raises(a.AssetValidationError):
@@ -310,7 +379,10 @@ def test_part_allows_today_last_replaced():
     from datetime import date
 
     asset = a.build_asset(
-        {"name": "Boiler", "parts": [{"name": "Anode", "last_replaced": date.today().isoformat()}]},
+        {
+            "name": "Boiler",
+            "parts": [{"name": "Anode", "last_replaced": date.today().isoformat()}],
+        },
         now=NOW,
     )
     assert asset["parts"][0]["last_replaced"] == date.today().isoformat()
@@ -334,7 +406,10 @@ def test_duplicate_part_ids_are_regenerated():
 def test_oversized_replace_interval_rejected():
     with pytest.raises(a.AssetValidationError):
         a.build_asset(
-            {"name": "Box", "parts": [{"name": "A", "type": "wear", "replace_interval": 10**9}]},
+            {
+                "name": "Box",
+                "parts": [{"name": "A", "type": "wear", "replace_interval": 10**9}],
+            },
             now=NOW,
         )
 
@@ -362,7 +437,10 @@ def test_would_create_cycle():
 # ── spare-inventory tracking (stock / reorder_at) ──────────────────────────────
 def test_part_stock_fields_normalized():
     asset = a.build_asset(
-        {"name": "Furnace", "parts": [{"name": "Filter", "stock": "4", "reorder_at": "1"}]},
+        {
+            "name": "Furnace",
+            "parts": [{"name": "Filter", "stock": "4", "reorder_at": "1"}],
+        },
         now=NOW,
     )
     part = asset["parts"][0]
@@ -485,9 +563,7 @@ def test_merge_update_clears_part_stock_when_omitted():
     )
     pid = asset["parts"][0]["id"]
     asset["parts"][0]["last_replaced"] = "2025-01-01"  # backend completion stamp
-    updated = a.merge_update(
-        asset, {"parts": [{"id": pid, "name": "Filter"}]}, now=NOW
-    )
+    updated = a.merge_update(asset, {"parts": [{"id": pid, "name": "Filter"}]}, now=NOW)
     assert updated["parts"][0]["stock"] is None
     assert updated["parts"][0]["reorder_at"] is None
     assert updated["parts"][0]["last_replaced"] == "2025-01-01"

--- a/tests/unit/test_history.py
+++ b/tests/unit/test_history.py
@@ -49,7 +49,10 @@ def test_relates_by_related_device():
 
 def test_unrelated_standalone_task():
     assert a.task_relates_to_asset({"id": "t", "name": "x"}, _asset()) is False
-    assert a.task_relates_to_asset({"id": "t", "name": "x", "device_id": "z"}, _asset()) is False
+    assert (
+        a.task_relates_to_asset({"id": "t", "name": "x", "device_id": "z"}, _asset())
+        is False
+    )
 
 
 def test_tasks_for_asset_filters():
@@ -71,14 +74,19 @@ def test_find_archiving_asset_prefers_part_source():
 
 def test_find_archiving_asset_by_device():
     assets = {"asset1": _asset()}
-    found = a.find_archiving_asset(assets, {"id": "t", "name": "x", "device_id": "dev1"})
+    found = a.find_archiving_asset(
+        assets, {"id": "t", "name": "x", "device_id": "dev1"}
+    )
     assert found["id"] == "asset1"
 
 
 def test_find_archiving_asset_none_for_standalone():
     assets = {"asset1": _asset()}
     assert a.find_archiving_asset(assets, {"id": "t", "name": "x"}) is None
-    assert a.find_archiving_asset(assets, {"id": "t", "name": "x", "device_id": "z"}) is None
+    assert (
+        a.find_archiving_asset(assets, {"id": "t", "name": "x", "device_id": "z"})
+        is None
+    )
 
 
 def test_find_archiving_asset_part_source_missing_asset():
@@ -88,7 +96,9 @@ def test_find_archiving_asset_part_source_missing_asset():
 
 # ── archive entry construction & append ──────────────────────────────────────
 def test_build_archived_history_snapshots_name_and_part():
-    entry = a.build_archived_history(_part_task(), archived_at="2026-06-15T00:00:00-04:00")
+    entry = a.build_archived_history(
+        _part_task(), archived_at="2026-06-15T00:00:00-04:00"
+    )
     assert entry["task_id"] == "t1"
     assert entry["task_name"] == "Replace anode"
     assert entry["part_id"] == "p1"
@@ -98,7 +108,11 @@ def test_build_archived_history_snapshots_name_and_part():
 
 def test_build_archived_history_standalone_has_no_part():
     entry = a.build_archived_history(
-        {"id": "t", "name": "Flush tank", "completions": [{"ts": "2025-01-01T00:00:00-04:00"}]},
+        {
+            "id": "t",
+            "name": "Flush tank",
+            "completions": [{"ts": "2025-01-01T00:00:00-04:00"}],
+        },
         archived_at="2026-06-15T00:00:00-04:00",
     )
     assert entry["part_id"] is None
@@ -106,7 +120,9 @@ def test_build_archived_history_standalone_has_no_part():
 
 def test_append_task_history_appends_and_returns_true():
     asset = _asset()
-    entry = a.build_archived_history(_part_task(), archived_at="2026-06-15T00:00:00-04:00")
+    entry = a.build_archived_history(
+        _part_task(), archived_at="2026-06-15T00:00:00-04:00"
+    )
     assert a.append_task_history(asset, entry) is True
     assert asset["task_history"] == [entry]
 
@@ -114,7 +130,8 @@ def test_append_task_history_appends_and_returns_true():
 def test_append_task_history_skips_empty_completions():
     asset = _asset()
     entry = a.build_archived_history(
-        {"id": "t", "name": "x", "completions": []}, archived_at="2026-06-15T00:00:00-04:00"
+        {"id": "t", "name": "x", "completions": []},
+        archived_at="2026-06-15T00:00:00-04:00",
     )
     assert a.append_task_history(asset, entry) is False
     assert "task_history" not in asset
@@ -122,7 +139,9 @@ def test_append_task_history_skips_empty_completions():
 
 def test_append_task_history_dedupes_by_task_id():
     asset = _asset()
-    entry = a.build_archived_history(_part_task(), archived_at="2026-06-15T00:00:00-04:00")
+    entry = a.build_archived_history(
+        _part_task(), archived_at="2026-06-15T00:00:00-04:00"
+    )
     assert a.append_task_history(asset, entry) is True
     assert a.append_task_history(asset, entry) is False
     assert len(asset["task_history"]) == 1
@@ -148,19 +167,33 @@ def _asset_with_history():
 
 def test_remove_archived_completion_drops_one():
     asset = _asset_with_history()
-    assert a.remove_archived_completion(asset, "old_flush", "2024-06-01T10:00:00-04:00") is True
-    assert asset["task_history"][0]["completions"] == [{"ts": "2023-06-01T10:00:00-04:00"}]
+    assert (
+        a.remove_archived_completion(asset, "old_flush", "2024-06-01T10:00:00-04:00")
+        is True
+    )
+    assert asset["task_history"][0]["completions"] == [
+        {"ts": "2023-06-01T10:00:00-04:00"}
+    ]
 
 
 def test_remove_archived_completion_drops_entry_when_emptied():
     asset = _asset_with_history()
     asset["task_history"][0]["completions"] = [{"ts": "2023-06-01T10:00:00-04:00"}]
-    assert a.remove_archived_completion(asset, "old_flush", "2023-06-01T10:00:00-04:00") is True
+    assert (
+        a.remove_archived_completion(asset, "old_flush", "2023-06-01T10:00:00-04:00")
+        is True
+    )
     assert asset["task_history"] == []
 
 
 def test_remove_archived_completion_missing_is_noop():
     asset = _asset_with_history()
-    assert a.remove_archived_completion(asset, "old_flush", "2099-01-01T00:00:00-04:00") is False
-    assert a.remove_archived_completion(asset, "no_such_task", "2024-06-01T10:00:00-04:00") is False
+    assert (
+        a.remove_archived_completion(asset, "old_flush", "2099-01-01T00:00:00-04:00")
+        is False
+    )
+    assert (
+        a.remove_archived_completion(asset, "no_such_task", "2024-06-01T10:00:00-04:00")
+        is False
+    )
     assert a.remove_archived_completion(_asset(), "x", "y") is False

--- a/tests/unit/test_inventory.py
+++ b/tests/unit/test_inventory.py
@@ -23,7 +23,12 @@ def _asset(**kw):
         # Descriptive/temporal facts are free-form metadata now.
         "metadata": [
             {"id": "m1", "type": "text", "label": "Serial", "value": "SN-1"},
-            {"id": "m2", "type": "date", "label": "Warranty expiry", "value": "2030-01-01"},
+            {
+                "id": "m2",
+                "type": "date",
+                "label": "Warranty expiry",
+                "value": "2030-01-01",
+            },
         ],
         "parts": [],
     }
@@ -78,7 +83,9 @@ def test_spares_value_is_cost_times_stock():
 
 
 def test_totals_roll_up_cost_and_spares():
-    a = _asset(id="a1", name="A", cost=100.0, parts=[{"name": "p", "cost": 10.0, "stock": 2}])
+    a = _asset(
+        id="a1", name="A", cost=100.0, parts=[{"name": "p", "cost": 10.0, "stock": 2}]
+    )
     b = _asset(id="b1", name="B", cost=50.0, parts=[])
     report = inv.build_inventory([a, b])
     assert report["totals"] == {
@@ -106,8 +113,18 @@ def test_metadata_details_flattened_into_summary():
     asset = _asset(
         metadata=[
             {"id": "m1", "type": "text", "label": "Serial", "value": "SN-9"},
-            {"id": "m2", "type": "link", "label": "Manual", "value": "https://ex/m.pdf"},
-            {"id": "m3", "type": "text", "label": "Blank", "value": ""},  # dropped (no value)
+            {
+                "id": "m2",
+                "type": "link",
+                "label": "Manual",
+                "value": "https://ex/m.pdf",
+            },
+            {
+                "id": "m3",
+                "type": "text",
+                "label": "Blank",
+                "value": "",
+            },  # dropped (no value)
         ]
     )
     row = inv.build_inventory([asset])["assets"][0]
@@ -117,7 +134,12 @@ def test_metadata_details_flattened_into_summary():
 def test_csv_has_header_rows_and_total():
     report = inv.build_inventory(
         [
-            _asset(id="1", name="Apple", cost=100.0, parts=[{"name": "p", "cost": 5.0, "stock": 2}]),
+            _asset(
+                id="1",
+                name="Apple",
+                cost=100.0,
+                parts=[{"name": "p", "cost": 5.0, "stock": 2}],
+            ),
             _asset(id="2", name="Box", cost=50.0, parts=[]),
         ]
     )
@@ -139,19 +161,27 @@ def test_csv_neutralizes_formula_injection():
     # A field a spreadsheet would treat as a formula is prefixed with ' so it renders
     # as literal text (CSV/formula injection guard).
     report = inv.build_inventory(
-        [_asset(id="1", name="=HYPERLINK(\"http://evil\")", manufacturer="@SUM(A1)")]
+        [_asset(id="1", name='=HYPERLINK("http://evil")', manufacturer="@SUM(A1)")]
     )
     text = inv.inventory_to_csv(report)
-    row = next(r for r in csv.reader(io.StringIO(text)) if r and r[0].endswith("evil\")"))
-    assert row[0].startswith("'="), "a formula-like name must be prefixed with an apostrophe"
+    row = next(
+        r for r in csv.reader(io.StringIO(text)) if r and r[0].endswith('evil")')
+    )
+    assert row[0].startswith("'="), (
+        "a formula-like name must be prefixed with an apostrophe"
+    )
     assert row[2].startswith("'@"), "a formula-like manufacturer must be neutralized"
 
 
 def test_spares_total_does_not_drift_from_per_row_rounding():
     # Per-row spares are rounded for display, but the grand total accumulates the raw
     # values and rounds once, so it can't drift from summing rounded rows.
-    a = _asset(id="1", name="A", cost=0.0, parts=[{"name": "p", "cost": 0.005, "stock": 1}])
-    b = _asset(id="2", name="B", cost=0.0, parts=[{"name": "q", "cost": 0.005, "stock": 1}])
+    a = _asset(
+        id="1", name="A", cost=0.0, parts=[{"name": "p", "cost": 0.005, "stock": 1}]
+    )
+    b = _asset(
+        id="2", name="B", cost=0.0, parts=[{"name": "q", "cost": 0.005, "stock": 1}]
+    )
     report = inv.build_inventory([a, b])
     # Each row rounds 0.005 -> 0.01 (banker's rounding may give 0.0), but the total is
     # round(0.005 + 0.005) == 0.01 regardless.

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -11,7 +11,12 @@ NOW = datetime(2026, 6, 13, 10, tzinfo=TZ)
 
 def test_build_floating_task_sets_id_and_is_due_now():
     task = m.build_task(
-        {"name": "Furnace filter", "recurrence_type": "floating", "interval": 3, "unit": "months"},
+        {
+            "name": "Furnace filter",
+            "recurrence_type": "floating",
+            "interval": 3,
+            "unit": "months",
+        },
         now=NOW,
     )
     assert task["id"]
@@ -129,17 +134,30 @@ def test_build_fixed_task_normalizes_naive_anchor():
 
 def test_build_task_rejects_missing_name():
     with pytest.raises(m.TaskValidationError):
-        m.build_task({"recurrence_type": "floating", "interval": 1, "unit": "days"}, now=NOW)
+        m.build_task(
+            {"recurrence_type": "floating", "interval": 1, "unit": "days"}, now=NOW
+        )
 
 
 def test_build_task_rejects_bad_unit():
     with pytest.raises(m.TaskValidationError):
-        m.build_task({"name": "x", "recurrence_type": "floating", "interval": 1, "unit": "lightyears"}, now=NOW)
+        m.build_task(
+            {
+                "name": "x",
+                "recurrence_type": "floating",
+                "interval": 1,
+                "unit": "lightyears",
+            },
+            now=NOW,
+        )
 
 
 def test_build_task_rejects_bad_interval():
     with pytest.raises(m.TaskValidationError):
-        m.build_task({"name": "x", "recurrence_type": "floating", "interval": 0, "unit": "days"}, now=NOW)
+        m.build_task(
+            {"name": "x", "recurrence_type": "floating", "interval": 0, "unit": "days"},
+            now=NOW,
+        )
 
 
 def test_build_task_rejects_oversized_interval():
@@ -147,7 +165,12 @@ def test_build_task_rejects_oversized_interval():
     # OverflowError that surfaces as a 500.
     with pytest.raises(m.TaskValidationError):
         m.build_task(
-            {"name": "x", "recurrence_type": "floating", "interval": 10**9, "unit": "days"},
+            {
+                "name": "x",
+                "recurrence_type": "floating",
+                "interval": 10**9,
+                "unit": "days",
+            },
             now=NOW,
         )
 
@@ -157,14 +180,24 @@ def test_build_task_rejects_non_numeric_interval():
     # validation error (not a raw ValueError that crashes the command).
     with pytest.raises(m.TaskValidationError):
         m.build_task(
-            {"name": "x", "recurrence_type": "floating", "interval": "soon", "unit": "days"},
+            {
+                "name": "x",
+                "recurrence_type": "floating",
+                "interval": "soon",
+                "unit": "days",
+            },
             now=NOW,
         )
 
 
 def test_merge_update_name_only_keeps_schedule():
     task = m.build_task(
-        {"name": "Filter", "recurrence_type": "floating", "interval": 1, "unit": "months"},
+        {
+            "name": "Filter",
+            "recurrence_type": "floating",
+            "interval": 1,
+            "unit": "months",
+        },
         now=NOW,
     )
     original_due = task["next_due"]
@@ -195,7 +228,9 @@ def test_merge_update_interval_recomputes_due():
 def test_build_task_carries_opaque_source():
     # ``source`` is opaque provenance owned by a contributing integration; build_task
     # must store it verbatim so the task can be matched/echoed later.
-    source = {"pawsistant": {"dog_id": "d1", "event_type": "medicine", "schedule_id": "s1"}}
+    source = {
+        "pawsistant": {"dog_id": "d1", "event_type": "medicine", "schedule_id": "s1"}
+    }
     task = m.build_task(
         {
             "name": "Medicine",
@@ -211,7 +246,12 @@ def test_build_task_carries_opaque_source():
 
 def test_build_task_source_defaults_to_none():
     task = m.build_task(
-        {"name": "Filter", "recurrence_type": "floating", "interval": 1, "unit": "months"},
+        {
+            "name": "Filter",
+            "recurrence_type": "floating",
+            "interval": 1,
+            "unit": "months",
+        },
         now=NOW,
     )
     assert task["source"] is None
@@ -258,7 +298,12 @@ def test_build_task_carries_managed_by():
 
 def test_build_task_managed_by_defaults_to_none():
     task = m.build_task(
-        {"name": "Filter", "recurrence_type": "floating", "interval": 1, "unit": "months"},
+        {
+            "name": "Filter",
+            "recurrence_type": "floating",
+            "interval": 1,
+            "unit": "months",
+        },
         now=NOW,
     )
     assert task["managed_by"] is None
@@ -287,17 +332,24 @@ def test_merge_update_respects_locked_fields():
         {"name": "Hacked name", "device_id": "evil-device", "interval": 4},
         now=NOW,
     )
-    assert updated["name"] == "Buddy: Medicine"     # locked — unchanged
+    assert updated["name"] == "Buddy: Medicine"  # locked — unchanged
     assert updated["device_id"] == "dev-buddy-123"  # locked — unchanged
-    assert updated["interval"] == 4                 # not locked — changed
+    assert updated["interval"] == 4  # not locked — changed
 
 
 def test_merge_update_without_managed_by_allows_all_fields():
     task = m.build_task(
-        {"name": "Filter", "recurrence_type": "floating", "interval": 1, "unit": "months"},
+        {
+            "name": "Filter",
+            "recurrence_type": "floating",
+            "interval": 1,
+            "unit": "months",
+        },
         now=NOW,
     )
-    updated = m.merge_update(task, {"name": "New name", "device_id": "some-device"}, now=NOW)
+    updated = m.merge_update(
+        task, {"name": "New name", "device_id": "some-device"}, now=NOW
+    )
     assert updated["name"] == "New name"
     assert updated["device_id"] == "some-device"
 
@@ -348,7 +400,11 @@ def test_deletion_force_bypasses_protection():
 
 
 def test_deletion_not_blocked_without_protection():
-    task = {"id": "t1", "name": "X", "managed_by": {"integration": "p", "display_name": "P"}}
+    task = {
+        "id": "t1",
+        "name": "X",
+        "managed_by": {"integration": "p", "display_name": "P"},
+    }
     assert m.deletion_blocked(task, orphaned=False) is False
 
 
@@ -445,15 +501,13 @@ def test_build_triggered_task_is_created_active_with_no_schedule_fields():
 def test_triggered_task_does_not_require_unit_or_freq():
     # normalize_fields must not fall through to the fixed branch (which demands
     # freq/anchor) for a triggered task.
-    fields = m.normalize_fields(
-        {"name": "Mop up leak", "recurrence_type": "triggered"}
-    )
+    fields = m.normalize_fields({"name": "Mop up leak", "recurrence_type": "triggered"})
     assert fields["recurrence_type"] == "triggered"
     assert "unit" not in fields and "freq" not in fields and "interval" not in fields
 
 
 def test_merge_update_preserves_triggered_dormant_state():
-    # Editing the notes of a dormant triggered task must not re-arm it or add a schedule.
+    # Editing a dormant triggered task's notes must not re-arm it or add a schedule.
     task = m.build_task(
         {"name": "Replace battery", "recurrence_type": "triggered"}, now=NOW
     )

--- a/tests/unit/test_reconcile.py
+++ b/tests/unit/test_reconcile.py
@@ -48,9 +48,10 @@ def test_creates_task_anchored_on_last_replaced():
     assert task["source"]["part"] == {"asset_id": "a1", "part_id": "p1"}
     anchor = datetime.fromisoformat("2025-05-01").replace(tzinfo=TZ)
     assert task["last_completed"] == anchor.isoformat()
-    assert task["next_due"] == r.compute_floating_next_due(
-        anchor, 12, "months", now=NOW
-    ).isoformat()
+    assert (
+        task["next_due"]
+        == r.compute_floating_next_due(anchor, 12, "months", now=NOW).isoformat()
+    )
 
 
 def test_creates_task_due_now_when_no_last_replaced():
@@ -78,7 +79,9 @@ def test_consumable_part_creates_no_task():
 
 
 def test_wear_part_without_interval_creates_no_task():
-    asset = _asset(parts=[{"id": "p1", "name": "Belt", "type": "wear", "replace_interval": None}])
+    asset = _asset(
+        parts=[{"id": "p1", "name": "Belt", "type": "wear", "replace_interval": None}]
+    )
     tasks, changed = _reconcile({"a1": asset})
     assert tasks == {} and changed is False
 
@@ -135,9 +138,10 @@ def test_changing_interval_rebases_off_anchor_not_now():
     tasks, changed = _reconcile({"a1": bumped}, created)
     assert changed is True
     anchor = datetime.fromisoformat("2025-05-01").replace(tzinfo=TZ)
-    assert _only(tasks)["next_due"] == r.compute_floating_next_due(
-        anchor, 24, "months", now=NOW
-    ).isoformat()
+    assert (
+        _only(tasks)["next_due"]
+        == r.compute_floating_next_due(anchor, 24, "months", now=NOW).isoformat()
+    )
 
 
 def test_changing_device_id_updates_task():
@@ -164,12 +168,16 @@ def test_changing_replace_unit_updates_task():
 # ── timezone healing vs. real completions ─────────────────────────────────────
 def test_heals_legacy_naive_last_completed():
     # Simulate a task persisted by an older build: naive last_completed/next_due.
-    created, _ = _reconcile({"a1": _asset(parts=[_wear_part(last_replaced="2025-05-01")])})
+    created, _ = _reconcile(
+        {"a1": _asset(parts=[_wear_part(last_replaced="2025-05-01")])}
+    )
     task = _only(created)
     tid = task["id"]
     task["last_completed"] = "2025-05-01T00:00:00"  # naive (no tz)
     task["next_due"] = "2026-05-01T00:00:00"  # naive
-    tasks, changed = _reconcile({"a1": _asset(parts=[_wear_part(last_replaced="2025-05-01")])}, created)
+    tasks, changed = _reconcile(
+        {"a1": _asset(parts=[_wear_part(last_replaced="2025-05-01")])}, created
+    )
     assert changed is True
     healed = tasks[tid]
     assert healed["last_completed"].endswith("-04:00")  # now aware
@@ -207,7 +215,9 @@ def test_part_source_extracts_provenance():
 def test_qualify_iso():
     assert rc.qualify_iso("2025-05-01", TZ) == "2025-05-01T00:00:00-04:00"
     # Already-aware values are returned unchanged.
-    assert rc.qualify_iso("2025-05-01T12:00:00-04:00", TZ) == "2025-05-01T12:00:00-04:00"
+    assert (
+        rc.qualify_iso("2025-05-01T12:00:00-04:00", TZ) == "2025-05-01T12:00:00-04:00"
+    )
     assert rc.qualify_iso(None, TZ) is None
     assert rc.qualify_iso("", TZ) is None
     assert rc.qualify_iso("not-a-date", TZ) is None

--- a/tests/unit/test_recurrence_fixed.py
+++ b/tests/unit/test_recurrence_fixed.py
@@ -66,7 +66,10 @@ def test_expand_fixed_occurrences_weekly():
 
 def test_expand_empty_when_range_inverted():
     anchor = dt(2026, 1, 1, 8)
-    assert r.expand_fixed_occurrences(anchor, "DAILY", 1, dt(2026, 6, 2), dt(2026, 6, 1)) == []
+    assert (
+        r.expand_fixed_occurrences(anchor, "DAILY", 1, dt(2026, 6, 2), dt(2026, 6, 1))
+        == []
+    )
 
 
 def test_next_daily_occurrence_with_far_past_anchor_does_not_raise():
@@ -90,12 +93,17 @@ def test_next_weekly_occurrence_with_far_past_anchor():
 def test_expand_daily_with_far_past_anchor_returns_window():
     anchor = dt(2020, 1, 1, 8)
     occ = r.expand_fixed_occurrences(anchor, "DAILY", 1, dt(2026, 6, 1), dt(2026, 6, 4))
-    assert [o.date().isoformat() for o in occ] == ["2026-06-01", "2026-06-02", "2026-06-03"]
+    assert [o.date().isoformat() for o in occ] == [
+        "2026-06-01",
+        "2026-06-02",
+        "2026-06-03",
+    ]
 
 
 def test_remove_completion_keeps_fixed_schedule():
+    from datetime import datetime, timedelta, timezone
+
     import hk_recurrence as r
-    from datetime import datetime, timezone, timedelta
 
     tz = timezone(timedelta(hours=-4))
     now = datetime(2026, 6, 13, 10, tzinfo=tz)

--- a/tests/unit/test_transitions.py
+++ b/tests/unit/test_transitions.py
@@ -5,12 +5,12 @@ runtime): a task announces due-soon then overdue against the same ``next_due`` e
 once each, re-arms when its schedule moves, and never fires while dormant or disabled.
 """
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import hk_transitions as t
 from hk_const import EVENT_TASK_DUE_SOON, EVENT_TASK_OVERDUE
 
-TZ = timezone.utc
+TZ = UTC
 NOW = datetime(2026, 6, 18, 12, 0, tzinfo=TZ)
 
 
@@ -89,7 +89,7 @@ def test_triggered_task_fires_overdue_on_arm():
     _, state = t.detect_transitions({}, {"d": dormant}, now=NOW)
 
     armed = _task("d", next_due=NOW, recurrence_type="triggered")
-    fired, state2 = t.detect_transitions(state, {"d": armed}, now=NOW)
+    fired, _state2 = t.detect_transitions(state, {"d": armed}, now=NOW)
     assert _names(fired) == [EVENT_TASK_OVERDUE]
 
 

--- a/tests/unit/test_translations_parity.py
+++ b/tests/unit/test_translations_parity.py
@@ -28,9 +28,7 @@ from pathlib import Path
 import pytest
 
 _COMPONENT_DIR = (
-    Path(__file__).resolve().parent.parent.parent
-    / "custom_components"
-    / "home_keeper"
+    Path(__file__).resolve().parent.parent.parent / "custom_components" / "home_keeper"
 )
 _STRINGS = _COMPONENT_DIR / "strings.json"
 _TRANSLATIONS = _COMPONENT_DIR / "translations"
@@ -50,18 +48,94 @@ _INTENTIONALLY_IDENTICAL: frozenset[str] = frozenset(
 # for every other locale. Examples: German "Name", French "Notes", Catalan
 # "Cost", and technical loanwords "Delta"/"Model"/"Metadata"/"Interval".
 _COGNATE_IDENTICAL: dict[str, frozenset[str]] = {
-    "ca": frozenset({"services.add_asset.fields.cost.name", "services.add_asset.fields.model.name", "services.add_task.fields.interval.name", "services.add_task.fields.notes.name", "services.adjust_part_stock.fields.delta.name", "services.update_asset.fields.cost.name", "services.update_asset.fields.model.name", "services.update_task.fields.interval.name", "services.update_task.fields.notes.name"}),
-    "cs": frozenset({"services.add_asset.fields.metadata.name", "services.add_asset.fields.model.name", "services.add_task.fields.interval.name", "services.adjust_part_stock.fields.delta.name", "services.update_asset.fields.metadata.name", "services.update_asset.fields.model.name", "services.update_task.fields.interval.name"}),
-    "da": frozenset({"services.add_asset.fields.metadata.name", "services.add_asset.fields.model.name", "services.add_task.fields.interval.name", "services.update_asset.fields.metadata.name", "services.update_asset.fields.model.name", "services.update_task.fields.interval.name"}),
-    "de": frozenset({"services.add_asset.fields.name.name", "services.add_task.fields.name.name", "services.update_asset.fields.name.name", "services.update_task.fields.name.name"}),
+    "ca": frozenset(
+        {
+            "services.add_asset.fields.cost.name",
+            "services.add_asset.fields.model.name",
+            "services.add_task.fields.interval.name",
+            "services.add_task.fields.notes.name",
+            "services.adjust_part_stock.fields.delta.name",
+            "services.update_asset.fields.cost.name",
+            "services.update_asset.fields.model.name",
+            "services.update_task.fields.interval.name",
+            "services.update_task.fields.notes.name",
+        }
+    ),
+    "cs": frozenset(
+        {
+            "services.add_asset.fields.metadata.name",
+            "services.add_asset.fields.model.name",
+            "services.add_task.fields.interval.name",
+            "services.adjust_part_stock.fields.delta.name",
+            "services.update_asset.fields.metadata.name",
+            "services.update_asset.fields.model.name",
+            "services.update_task.fields.interval.name",
+        }
+    ),
+    "da": frozenset(
+        {
+            "services.add_asset.fields.metadata.name",
+            "services.add_asset.fields.model.name",
+            "services.add_task.fields.interval.name",
+            "services.update_asset.fields.metadata.name",
+            "services.update_asset.fields.model.name",
+            "services.update_task.fields.interval.name",
+        }
+    ),
+    "de": frozenset(
+        {
+            "services.add_asset.fields.name.name",
+            "services.add_task.fields.name.name",
+            "services.update_asset.fields.name.name",
+            "services.update_task.fields.name.name",
+        }
+    ),
     "es": frozenset({"services.adjust_part_stock.fields.delta.name"}),
-    "fr": frozenset({"services.add_task.fields.notes.name", "services.update_task.fields.notes.name"}),
-    "it": frozenset({"services.add_asset.fields.area_id.name", "services.add_task.fields.area_id.name", "services.adjust_part_stock.fields.delta.name", "services.update_asset.fields.area_id.name", "services.update_task.fields.area_id.name"}),
-    "nb": frozenset({"services.add_asset.fields.metadata.name", "services.update_asset.fields.metadata.name"}),
-    "nl": frozenset({"services.add_asset.fields.metadata.name", "services.add_asset.fields.model.name", "services.add_task.fields.interval.name", "services.update_asset.fields.metadata.name", "services.update_asset.fields.model.name", "services.update_task.fields.interval.name"}),
-    "pl": frozenset({"services.add_asset.fields.model.name", "services.adjust_part_stock.fields.delta.name", "services.update_asset.fields.model.name"}),
+    "fr": frozenset(
+        {
+            "services.add_task.fields.notes.name",
+            "services.update_task.fields.notes.name",
+        }
+    ),
+    "it": frozenset(
+        {
+            "services.add_asset.fields.area_id.name",
+            "services.add_task.fields.area_id.name",
+            "services.adjust_part_stock.fields.delta.name",
+            "services.update_asset.fields.area_id.name",
+            "services.update_task.fields.area_id.name",
+        }
+    ),
+    "nb": frozenset(
+        {
+            "services.add_asset.fields.metadata.name",
+            "services.update_asset.fields.metadata.name",
+        }
+    ),
+    "nl": frozenset(
+        {
+            "services.add_asset.fields.metadata.name",
+            "services.add_asset.fields.model.name",
+            "services.add_task.fields.interval.name",
+            "services.update_asset.fields.metadata.name",
+            "services.update_asset.fields.model.name",
+            "services.update_task.fields.interval.name",
+        }
+    ),
+    "pl": frozenset(
+        {
+            "services.add_asset.fields.model.name",
+            "services.adjust_part_stock.fields.delta.name",
+            "services.update_asset.fields.model.name",
+        }
+    ),
     "pt-BR": frozenset({"services.adjust_part_stock.fields.delta.name"}),
-    "sv": frozenset({"services.add_asset.fields.metadata.name", "services.update_asset.fields.metadata.name"}),
+    "sv": frozenset(
+        {
+            "services.add_asset.fields.metadata.name",
+            "services.update_asset.fields.metadata.name",
+        }
+    ),
 }
 
 # Token of the form ``{name}`` used by HA/Python ``str.format`` placeholders.


### PR DESCRIPTION
Adds **ruff** (lint + format) and **dependabot** to Home Keeper — the same tooling just added to the integration template.

## What's here

- **`pyproject.toml`** — `[tool.ruff]` config: line-length 88, target `py312`, rules `E/F/W/I/UP/B/C4/SIM/RUF`. Tests relax the two opinionated *simplify* rules (`SIM105`, `SIM113`) since they favour explicit loops / try-except.
- **`ruff format` applied** across `custom_components`, `tests`, `ci`, and all lint findings cleared (E501 rewraps, unused-import/var cleanups, `UP`/`RUF` fixes).
- **`.github/workflows/lint.yml`** — CI ruff lint + format check.
- **`.github/dependabot.yml`** — weekly updates for GitHub Actions / pip / npm (root, frontend, e2e).

## Risk / review notes

The product-code diff is **mechanical**: `ruff format` is AST-preserving line-wrapping, plus two `# noqa: E402` on `store.py`'s deliberately-deferred `reconcile` imports (kept where they were — non-behavioral). The bulk of the diff is test-file reformatting.

## Verification

Run locally before pushing:
- `ruff check` + `ruff format --check` — clean
- **238 pure unit tests pass**; `py_compile` clean

The HA-harness, Docker integration/e2e, and vitest tiers run in CI (couldn't spin up Docker HA / install the full harness in this session for home-keeper).

No `CHANGELOG.md` entry — this is developer tooling (CI config), which Home Keeper's `AGENTS.md` says doesn't need one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBfHuqPtfm5KC7nxrdQBo6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBfHuqPtfm5KC7nxrdQBo6)_