### PR TITLE
Release 0.3.0b6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas)
 
 ## [Unreleased]
 
+## [0.3.0b6] - 2026-06-19
+
 ### Added
 
 - **Comprehensive events for everything that happens — and automation-editor

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.3.0b5"
+PANEL_VERSION = "0.3.0b6"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/prestomation/ha-home-keeper/issues",
   "requirements": [],
-  "version": "0.3.0b5"
+  "version": "0.3.0b6"
 }


### PR DESCRIPTION
## Release 0.3.0b6

Beta pre-release. Merging this PR to `main` will trigger `release.yml` to tag `v0.3.0b6` and publish a GitHub pre-release (HACS beta channel only).

### What's in this release

#### Added

- **Comprehensive events for everything that happens — and automation-editor triggers.** Home Keeper now fires a Home Assistant bus event for every meaningful change: tasks **created / updated / deleted / uncompleted / triggered** and the time-based **overdue** and **due-soon** transitions; spare parts **out of stock** and **restocked** (alongside the existing low-stock); and appliances **created / updated / deleted**. Transitions are edge-triggered (one event per crossing, never replayed on restart). Each event surfaces as a **device trigger** in the visual automation editor. See [docs/EVENTS.md](docs/EVENTS.md) for the full catalog, payloads, and example automations.

#### Changed

- **A spare part dropping straight to zero now fires `home_keeper_part_out_of_stock`, not `home_keeper_part_low_stock`.** Switch any automation that listened for `home_keeper_part_low_stock` to catch zero-stock to use `home_keeper_part_out_of_stock` instead.

### Checklist

- [x] `manifest.json` version → `0.3.0b6`
- [x] `const.py` `PANEL_VERSION` → `"0.3.0b6"`
- [x] `CHANGELOG.md` `## [0.3.0b6] - 2026-06-19` section added
- [x] Unit tests pass (238/238)

/q review Please give critical, skeptical feedback on this release PR. Focus on: **correctness** of the version bump (manifest, const, changelog all aligned), **changelog accuracy** (does the entry faithfully describe what's in the commits since 0.3.0b5?), and whether anything in the unreleased commits since b5 was missed or mischaracterized.


---
_Generated by [Claude Code](https://claude.ai/code/session_014aDDNpZpSWkZ8rRGVrBSCU)_