### PR TITLE
Release 0.3.0b11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas)
 
 ## [Unreleased]
 
+## [0.3.0b11] - 2026-06-20
+
 ### Added
 
 - **Filter the dashboard card by label — one card per subject.** Tag tasks with

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.3.0b10"
+PANEL_VERSION = "0.3.0b11"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -13,5 +13,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/prestomation/ha-home-keeper/issues",
   "requirements": [],
-  "version": "0.3.0b10"
+  "version": "0.3.0b11"
 }


### PR DESCRIPTION
Beta release **0.3.0b11**.

Bumps `manifest.json` `version` and `const.py` `PANEL_VERSION` to `0.3.0b11` and cuts the `## [0.3.0b11]` CHANGELOG section. On merge, `release.yml` tags `v0.3.0b11`, builds the panel + `home_keeper.zip`, and publishes it as a **pre-release** (HACS beta channel).

### What's in this beta
- **Filter the dashboard card by label — one card per subject** (#55): tag tasks with HA labels and scope a card to one (dog / car / home / each kid). Matches a task by its own labels or the labels on its device/area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ADdwaqb2Xh5RNQTU9VmGtT

---
_Generated by [Claude Code](https://claude.ai/code/session_01ADdwaqb2Xh5RNQTU9VmGtT)_