### PR TITLE
Add Assist voice intents to complete and query tasks

### DIFF
--- a/.amazonq/rules/architecture-and-code.md
+++ b/.amazonq/rules/architecture-and-code.md
@@ -105,6 +105,31 @@ reviewing code in this repository (the `home_keeper` Home Assistant integration)
 - Read-only/report actions use `SupportsResponse.ONLY`; data mutations reload the
   entry or refresh the coordinator exactly as the equivalent CRUD service does.
 
+## Conversation/voice intents delegate to the store — they are not a new path
+- Assist intents live in `intents.py` (`intent.IntentHandler` subclasses, registered
+  via `intent.async_register` from `async_setup_intents`, called in
+  `async_setup_entry` after `_register_services`). Registration is **global and
+  idempotent** (keyed by `intent_type`), so it survives entry reloads; handlers
+  resolve the coordinator per-call (never capture it). Like a websocket command, an
+  intent is an **additional UI surface that delegates to the same `HomeKeeperStore`
+  method** (e.g. `complete_task` with `origin=ORIGIN_INTENT`) — never a divergent
+  mutation path, so completions stay observable and obey the same guards (a
+  problem-sensor-synced task is still rejected). No new service is required when an
+  existing one already covers the action.
+- **Keep intent resolution pure and testable.** Fuzzy task-name matching and
+  due-task selection live in `task_match.py` (no HA imports, loaded in the `hk`
+  synthetic package) so the branchy logic is unit-tested in isolation; the handler
+  only does HA-specific work (registry name→id lookups, spoken responses, error
+  mapping). Prefer **disambiguation over guessing** — when more than one task could
+  match, return candidates and ask, because completing the wrong task advances its
+  recurrence.
+- **Ship the sentences and test the NLU layer.** Natural-language phrases live in
+  `custom_sentences/<lang>/home_keeper.yaml` (users copy them into their config). The
+  sentence→intent→slot routing is covered by a `hassil` unit test
+  (`tests/unit/test_intent_sentences.py`) — the same engine HA uses — and the
+  handler→store wiring by an integration test driving `/api/intent/handle` (the test
+  config enables `intent:`).
+
 ## Events are the observation surface — fire one for every state change
 - **Every observable state change fires a documented `home_keeper_<noun>_<verb>` bus
   event**, built by a **pure function in `events.py`** (no HA imports) so the test fake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas)
 
 ## [Unreleased]
 
+### Added
+
+- **Voice control (Assist).** Two new conversation intents let you manage chores
+  hands-free. Say *"mark the furnace filter as done"*, *"I just replaced the fridge
+  filter"*, or *"clear take medicine"* to complete a task — Home Keeper fuzzy-matches
+  the spoken name, and if more than one task could match it lists them and asks which
+  one rather than risk completing the wrong chore. Ask *"what chores are due?"* to
+  hear the tasks that are due or overdue. Voice completions flow through the same path
+  as every other surface (they advance recurrence and fire
+  `home_keeper_task_completed`), and a problem-sensor-synced task still can't be
+  cleared this way. Copy `custom_sentences/en/home_keeper.yaml` into your config to
+  teach the default Assist agent the phrases — see the README "Voice control" section.
+
 ### Fixed
 
 - **Settings exclusions now take effect immediately.** Adding a problem-sensor

--- a/README.md
+++ b/README.md
@@ -213,6 +213,31 @@ integrations HA won't let us reparent — which show up alongside the appliance.
 > heater now has its own device page with a warranty-expiry sensor, plus an automatic
 > *"Replace Anode rod"* to-do that's due 12 months after each completion.
 
+## Voice control (Assist)
+
+Complete and check on your chores hands-free. Home Keeper ships two
+[Assist](https://www.home-assistant.io/voice_control/) intents so you can clear
+tasks by voice or text instead of opening the panel:
+
+- **Complete a task** — *"mark the furnace filter as done"*, *"I just replaced the
+  fridge filter"*, *"clear take medicine"*, *"check off the water filter"*. Home
+  Keeper fuzzy-matches what you said against your tasks, completes the match (which
+  advances its recurrence and fires the usual `home_keeper_task_completed` event),
+  and reads back a confirmation. If more than one task could match — you have a
+  *fridge* filter and a *furnace* filter and only said "filter" — it lists them and
+  asks which one rather than guessing, so it never clears the wrong chore. A
+  problem-sensor-synced task can't be cleared by voice (the same rule as everywhere
+  else); Assist explains why.
+- **Ask what's due** — *"what chores are due?"*, *"what tasks need to be done?"*,
+  *"what's due right now?"* — and Home Keeper reads back the tasks that are due or
+  overdue.
+
+**Setup.** The intent handlers are registered automatically. To teach the default
+Assist agent the sentences, copy
+[`custom_sentences/en/home_keeper.yaml`](custom_sentences/en/home_keeper.yaml) into
+your Home Assistant config at `<config>/custom_sentences/en/home_keeper.yaml`
+(create the folders if needed) and restart Home Assistant.
+
 ## Services
 
 Every data action is a Home Assistant service, so it's usable from automations,

--- a/custom_components/home_keeper/__init__.py
+++ b/custom_components/home_keeper/__init__.py
@@ -17,7 +17,7 @@ from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.util import dt as dt_util
 
-from . import card, devices, inventory, options, panel, websocket_api
+from . import card, devices, intents, inventory, options, panel, websocket_api
 from .assets import AssetValidationError
 from .const import (
     DOMAIN,
@@ -211,6 +211,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     _register_services(hass)
+    # Register the conversation/voice intents (idempotent across reloads). These are
+    # an additional Assist surface that delegates to the same store methods as the
+    # services/entities — never a substitute for the complete_task service.
+    await intents.async_setup_intents(hass)
     # React to options-flow changes (e.g. toggling problem-sensor syncing) by
     # reloading the entry, which re-runs this setup with the new options.
     entry.async_on_unload(entry.add_update_listener(_async_options_updated))

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -107,6 +107,19 @@ TASK_SOURCE_PROBLEM_SENSOR = "problem_sensor"
 # omits it, so they are rejected; only the internal sync can drive these tasks.
 ORIGIN_PROBLEM_SENSOR_SYNC = f"{DOMAIN}_problem_sensor_sync"
 
+# Conversation / voice intents. The handlers live in ``intents.py`` (registered in
+# ``async_setup_entry``) and delegate to the same store methods every other surface
+# uses; the natural-language sentences that route to them ship in
+# ``custom_sentences/en/home_keeper.yaml``. See docs and README "Voice control".
+INTENT_COMPLETE_TASK = "HomeKeeperCompleteTask"
+INTENT_LIST_DUE_TASKS = "HomeKeeperListDueTasks"
+
+# Opaque ``origin`` marker stamped on completions driven by the voice/intent layer
+# (passed to ``store.complete_task``), so automations subscribed to
+# ``home_keeper_task_completed`` can recognise — and ignore — the echo of a
+# completion they themselves triggered by voice. Home Keeper never interprets it.
+ORIGIN_INTENT = f"{DOMAIN}_intent"
+
 # Config-entry options keys (set via the options flow). Syncing is opt-in.
 OPTION_SYNC_PROBLEM_SENSORS = "sync_problem_sensors"  # bool, default False
 # Exclusion filters narrowing which ``device_class: problem`` binary sensors are

--- a/custom_components/home_keeper/intents.py
+++ b/custom_components/home_keeper/intents.py
@@ -1,0 +1,185 @@
+"""Conversation / voice intents for Home Keeper (Assist).
+
+Registers intent handlers so tasks can be **completed** and **queried** by voice or
+text through Home Assistant's Assist. The handlers delegate to the same store
+methods every other surface uses — ``store.complete_task`` is the single completion
+chokepoint — so a voice completion stays fully observable (it fires
+``home_keeper_task_completed`` with ``origin=ORIGIN_INTENT``) and obeys the same
+guards (a problem-sensor-synced task is rejected with a spoken explanation).
+
+Resolving a spoken task name to a stored task is pure logic and lives in
+``task_match.py`` (unit-tested in isolation); this module only does the HA-specific
+work: registry lookups (area/device names -> ids), building the spoken response, and
+mapping store errors to speech. The natural-language sentences that route here ship
+in ``custom_sentences/en/home_keeper.yaml`` (see README "Voice control").
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import voluptuous as vol
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import area_registry as ar
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import intent
+from homeassistant.util import dt as dt_util
+
+from .const import (
+    DOMAIN,
+    INTENT_COMPLETE_TASK,
+    INTENT_LIST_DUE_TASKS,
+    ORIGIN_INTENT,
+)
+from .coordinator import HomeKeeperCoordinator
+from .models import TaskValidationError
+from .task_match import match_task, select_due_tasks
+
+
+def _coordinator(hass: HomeAssistant) -> HomeKeeperCoordinator | None:
+    """Return the active Home Keeper coordinator, or None if not set up.
+
+    Resolved per-call (not captured at registration) so the global, idempotently
+    registered handlers always see the current coordinator across entry reloads.
+    """
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        coord = getattr(entry, "runtime_data", None)
+        if isinstance(coord, HomeKeeperCoordinator):
+            return coord
+    return None
+
+
+def _resolve_area_id(hass: HomeAssistant, name: str) -> str | None:
+    """Map a spoken area name (or alias) to its area id, case-insensitively."""
+    target = name.strip().casefold()
+    for area in ar.async_get(hass).async_list_areas():
+        if area.name.casefold() == target:
+            return area.id
+        for alias in area.aliases or ():
+            if alias.casefold() == target:
+                return area.id
+    return None
+
+
+def _resolve_device_id(hass: HomeAssistant, name: str) -> str | None:
+    """Map a spoken device name to its device id, case-insensitively."""
+    target = name.strip().casefold()
+    for device in dr.async_get(hass).devices.values():
+        label = device.name_by_user or device.name
+        if label and label.casefold() == target:
+            return device.id
+    return None
+
+
+def _join_names(names: list[str]) -> str:
+    """Join task names into a natural spoken list ("A, B, and C")."""
+    if len(names) == 1:
+        return names[0]
+    if len(names) == 2:
+        return f"{names[0]} and {names[1]}"
+    return ", ".join(names[:-1]) + f", and {names[-1]}"
+
+
+class CompleteTaskIntentHandler(intent.IntentHandler):
+    """Complete a Home Keeper task named in the utterance."""
+
+    intent_type = INTENT_COMPLETE_TASK
+    description = "Mark a Home Keeper maintenance task or chore as done."
+    slot_schema: ClassVar[dict] = {
+        vol.Required("name"): cv.string,
+        vol.Optional("area"): cv.string,
+        vol.Optional("device"): cv.string,
+    }
+
+    async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
+        hass = intent_obj.hass
+        slots = self.async_validate_slots(intent_obj.slots)
+        name = slots["name"]["value"]
+        response = intent_obj.create_response()
+
+        coord = _coordinator(hass)
+        if coord is None:
+            response.async_set_speech("Home Keeper isn't set up yet.")
+            return response
+
+        area_id = None
+        if "area" in slots:
+            area_name = slots["area"]["value"]
+            area_id = _resolve_area_id(hass, area_name)
+            if area_id is None:
+                response.async_set_speech(f"I don't know an area called {area_name}.")
+                return response
+
+        device_id = None
+        if "device" in slots:
+            device_name = slots["device"]["value"]
+            device_id = _resolve_device_id(hass, device_name)
+            if device_id is None:
+                response.async_set_speech(
+                    f"I don't know a device called {device_name}."
+                )
+                return response
+
+        tasks = [t for t in coord.store.list_tasks() if t.get("enabled", True)]
+        result = match_task(tasks, name, area_id=area_id, device_id=device_id)
+
+        if result.not_found:
+            response.async_set_speech(f"I couldn't find a task matching {name}.")
+            return response
+        if result.ambiguous:
+            names = _join_names([t["name"] for t in result.candidates])
+            response.async_set_speech(
+                f"I found more than one task matching {name}: {names}. "
+                "Which one should I complete?"
+            )
+            return response
+
+        task = result.task
+        try:
+            await coord.store.complete_task(task["id"], origin=ORIGIN_INTENT)
+        except TaskValidationError as err:
+            # e.g. a problem-sensor-synced task can't be cleared here — speak why.
+            response.async_set_speech(str(err))
+            return response
+        await coord.async_request_refresh()
+        response.async_set_speech(f"Done. I've completed {task['name']}.")
+        return response
+
+
+class ListDueTasksIntentHandler(intent.IntentHandler):
+    """Report which Home Keeper tasks are currently due or overdue."""
+
+    intent_type = INTENT_LIST_DUE_TASKS
+    description = "List Home Keeper tasks that are currently due or overdue."
+    # No slots: inherit the base handler's "accept no slots" default.
+
+    async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
+        hass = intent_obj.hass
+        response = intent_obj.create_response()
+
+        coord = _coordinator(hass)
+        if coord is None:
+            response.async_set_speech("Home Keeper isn't set up yet.")
+            return response
+
+        due = select_due_tasks(coord.store.list_tasks(), dt_util.now())
+        if not due:
+            response.async_set_speech("You have no tasks due right now.")
+            return response
+
+        names = _join_names([t["name"] for t in due])
+        count = len(due)
+        noun = "task" if count == 1 else "tasks"
+        response.async_set_speech(f"You have {count} {noun} due: {names}.")
+        return response
+
+
+async def async_setup_intents(hass: HomeAssistant) -> None:
+    """Register Home Keeper conversation intents.
+
+    Idempotent across entry reloads: ``intent.async_register`` keys handlers by
+    ``intent_type``, so re-registering simply replaces the previous instance.
+    """
+    intent.async_register(hass, CompleteTaskIntentHandler())
+    intent.async_register(hass, ListDueTasksIntentHandler())

--- a/custom_components/home_keeper/task_match.py
+++ b/custom_components/home_keeper/task_match.py
@@ -1,0 +1,176 @@
+"""Pure task-resolution helpers for the Home Keeper voice/intent layer.
+
+This module imports nothing from Home Assistant so it can be unit-tested in
+isolation under the synthetic ``hk`` package (see ``tests/conftest.py``), mirroring
+``recurrence.py`` and ``models.py``. The HA-facing intent handlers in
+``intents.py`` do the registry lookups (area/device names -> ids) and then delegate
+the actual fuzzy name resolution and due-task selection to the functions here.
+
+The matcher deliberately prefers asking the user to disambiguate over guessing:
+completing the wrong task advances its recurrence, which is a destructive surprise,
+so when two tasks are plausible we return them as *candidates* rather than picking
+one. See ``tests/unit/test_task_match.py``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from datetime import datetime
+from difflib import SequenceMatcher
+from typing import Any
+
+# Leading filler words an utterance commonly wraps a task name in. Stripped before
+# matching so "mark the fridge filter as done" resolves to the task "Replace fridge
+# filter" without the article skewing the similarity score.
+_ARTICLES = ("the ", "a ", "an ", "my ", "our ", "your ")
+
+# Minimum similarity (0..1) for a fuzzy name match to be considered at all. Below
+# this we report "no match" rather than guess. Tuned to accept typos and partial
+# names ("furnace filter" -> "Replace furnace filter") while rejecting unrelated
+# names; see ``tests/unit/test_task_match.py``.
+NAME_MATCH_THRESHOLD = 0.6
+
+# How much better the top candidate must score than a runner-up for it to be treated
+# as an unambiguous winner. Anything scoring within this band of the top (and at or
+# above the threshold) is collected as a co-candidate and the caller is asked to
+# disambiguate, rather than risk completing the wrong task.
+DOMINANCE_MARGIN = 0.12
+
+
+def _normalize(text: str) -> str:
+    """Lowercase, trim, and strip leading articles for comparison."""
+    text = (text or "").strip().casefold()
+    changed = True
+    while changed:
+        changed = False
+        for article in _ARTICLES:
+            if text.startswith(article):
+                text = text[len(article) :]
+                changed = True
+    return text.strip()
+
+
+def _score(query: str, name: str) -> float:
+    """Similarity in 0..1 between a spoken *query* and a task *name*."""
+    q, n = _normalize(query), _normalize(name)
+    if not q or not n:
+        return 0.0
+    if q == n:
+        return 1.0
+    ratio = SequenceMatcher(None, q, n).ratio()
+    # SequenceMatcher underweights containment when the lengths differ a lot
+    # ("filter" vs "Replace furnace filter"), yet that is exactly how people refer
+    # to tasks by a keyword. Floor such matches so they clear the threshold.
+    if q in n or n in q:
+        ratio = max(ratio, 0.85)
+    return ratio
+
+
+@dataclass
+class MatchResult:
+    """Outcome of resolving a spoken task name to a stored task.
+
+    Exactly one of three states holds: a single ``task`` (unambiguous match),
+    two-or-more ``candidates`` (ambiguous — ask the user), or neither (not found).
+    """
+
+    task: dict[str, Any] | None = None
+    candidates: list[dict[str, Any]] = field(default_factory=list)
+
+    @property
+    def matched(self) -> bool:
+        return self.task is not None
+
+    @property
+    def ambiguous(self) -> bool:
+        return self.task is None and len(self.candidates) > 1
+
+    @property
+    def not_found(self) -> bool:
+        return self.task is None and not self.candidates
+
+
+def match_task(
+    tasks: Iterable[dict[str, Any]],
+    name: str,
+    *,
+    area_id: str | None = None,
+    device_id: str | None = None,
+) -> MatchResult:
+    """Resolve *name* to one of *tasks*, optionally scoped by area/device.
+
+    *area_id*/*device_id*, when given, are hard filters (the caller has already
+    resolved them from spoken area/device names); they narrow the pool before the
+    fuzzy name match runs, which is what lets "complete the filter in the kitchen"
+    disambiguate two same-named tasks in different areas.
+    """
+    pool = list(tasks)
+    if area_id is not None:
+        pool = [t for t in pool if t.get("area_id") == area_id]
+    if device_id is not None:
+        pool = [t for t in pool if t.get("device_id") == device_id]
+    if not pool:
+        return MatchResult()
+
+    scored = sorted(
+        ((_score(name, t.get("name", "")), t) for t in pool),
+        key=lambda st: st[0],
+        reverse=True,
+    )
+    top_score = scored[0][0]
+    if top_score < NAME_MATCH_THRESHOLD:
+        return MatchResult()
+
+    # An exact (normalized) name wins outright — unless several tasks share it, in
+    # which case only the user can say which, so surface them as candidates.
+    if top_score == 1.0:
+        exact = [t for s, t in scored if s == 1.0]
+        if len(exact) == 1:
+            return MatchResult(task=exact[0])
+        return MatchResult(candidates=exact)
+
+    contenders = [
+        t
+        for s, t in scored
+        if s >= NAME_MATCH_THRESHOLD and top_score - s <= DOMINANCE_MARGIN
+    ]
+    if len(contenders) == 1:
+        return MatchResult(task=contenders[0])
+    return MatchResult(candidates=contenders)
+
+
+def _parse_due(value: Any) -> datetime | None:
+    """Parse a stored ISO ``next_due`` string to an aware datetime, or None."""
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def select_due_tasks(
+    tasks: Iterable[dict[str, Any]],
+    now: datetime,
+    *,
+    enabled_only: bool = True,
+) -> list[dict[str, Any]]:
+    """Return tasks that are currently due or overdue, soonest-due first.
+
+    A task counts as due when its ``next_due`` is set and at or before *now*. A
+    dormant triggered task (``next_due`` is None) is never due. Disabled tasks are
+    excluded by default. *now* is passed in (not read from the clock) so callers and
+    tests stay deterministic.
+    """
+    due: list[tuple[datetime, dict[str, Any]]] = []
+    for task in tasks:
+        if enabled_only and not task.get("enabled", True):
+            continue
+        when = _parse_due(task.get("next_due"))
+        if when is None:
+            continue
+        if when <= now:
+            due.append((when, task))
+    due.sort(key=lambda wt: wt[0])
+    return [task for _, task in due]

--- a/custom_sentences/en/home_keeper.yaml
+++ b/custom_sentences/en/home_keeper.yaml
@@ -1,0 +1,31 @@
+# Home Keeper voice/Assist sentences.
+#
+# Copy this file to your Home Assistant config under
+#   <config>/custom_sentences/en/home_keeper.yaml
+# (create the folders if needed) and restart Home Assistant. The default Assist
+# conversation agent then routes these utterances to Home Keeper's intent handlers
+# (registered automatically by the integration). See README "Voice control".
+#
+# {name} is a wildcard that captures the spoken task name; Home Keeper fuzzy-matches
+# it against your tasks and asks you to clarify if more than one could match.
+language: "en"
+intents:
+  HomeKeeperCompleteTask:
+    data:
+      - sentences:
+          - "mark [the] {name} (as done|done|as complete|complete|completed)"
+          - "complete [the] [task] {name}"
+          - "clear [the] [task] {name}"
+          - "check off [the] {name}"
+          - "[I] [just] (finished|did|completed|replaced|changed|cleaned) [the] {name}"
+  HomeKeeperListDueTasks:
+    data:
+      - sentences:
+          - "what [home keeper] (tasks|chores) are due [right now|today]"
+          - "what [home keeper] (tasks|chores) (do I have|are there) due [right now|today]"
+          - "what [home keeper] (tasks|chores) (need|needs) [to be] done"
+          - "(what is|what's) due [right now|today]"
+          - "do I have any [home keeper] (tasks|chores) due"
+lists:
+  name:
+    wildcard: true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,7 @@ def _load_pure_modules() -> None:
         "reconcile",
         "problem_tasks",
         "inventory",
+        "task_match",
     ):
         spec = importlib.util.spec_from_file_location(
             f"hk.{name}", str(_COMPONENT_DIR / f"{name}.py")
@@ -58,6 +59,7 @@ def _load_pure_modules() -> None:
     sys.modules["hk_reconcile"] = sys.modules["hk.reconcile"]
     sys.modules["hk_problem_tasks"] = sys.modules["hk.problem_tasks"]
     sys.modules["hk_inventory"] = sys.modules["hk.inventory"]
+    sys.modules["hk_task_match"] = sys.modules["hk.task_match"]
 
 
 _load_pure_modules()

--- a/tests/integration/ha_config/configuration.yaml
+++ b/tests/integration/ha_config/configuration.yaml
@@ -9,6 +9,12 @@ homeassistant:
 # Enable the REST API
 api:
 
+# Enable the intent component so the /api/intent/handle endpoint is available. The
+# Home Keeper conversation intents (registered by the integration) are exercised
+# through it in tests/integration/test_intents.py. A real install gets this via
+# default_config; this minimal test config omits that, so enable it explicitly.
+intent:
+
 # Enable frontend (required for the custom sidebar panel + Lovelace resources)
 frontend:
 

--- a/tests/integration/test_intents.py
+++ b/tests/integration/test_intents.py
@@ -1,0 +1,135 @@
+"""Integration coverage for the Home Keeper conversation/voice intents.
+
+Drives the real HA ``/api/intent/handle`` endpoint (enabled via ``intent:`` in the
+test config) so the registered intent handlers run end-to-end against the live store:
+completing a task by name advances its recurrence and fires
+``home_keeper_task_completed`` with ``origin=home_keeper_intent`` (asserted via the
+configuration.yaml automation), ambiguous/unknown names are reported without
+mutating anything, a problem-sensor-synced task is rejected with a spoken reason,
+the due-task query reads back armed tasks, and the handlers survive an entry reload.
+
+The sentence -> intent NLU layer is covered separately and deterministically by the
+hassil unit test (tests/unit/test_intent_sentences.py).
+"""
+
+import time
+
+from conftest import HA_URL, call_service, get_state, poll_state
+
+SENSOR = "binary_sensor.sump_pump_problem"
+ORIGIN_INTENT = "home_keeper_intent"
+
+
+def _handle(ha, intent_name, data):
+    r = ha.post(
+        f"{HA_URL}/api/intent/handle",
+        json={"name": intent_name, "data": data},
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def _speech(resp):
+    return resp.get("speech", {}).get("plain", {}).get("speech", "")
+
+
+def _list_tasks(ha):
+    resp = call_service(ha, "home_keeper", "list_tasks", {}, return_response=True)
+    return resp.get("service_response", resp)["tasks"]
+
+
+def _add_task(ha, name, **extra):
+    data = {
+        "name": name,
+        "recurrence_type": "floating",
+        "interval": 7,
+        "unit": "days",
+        **extra,
+    }
+    resp = call_service(ha, "home_keeper", "add_task", data, return_response=True)
+    return resp.get("service_response", resp)["task_id"]
+
+
+def _get_task(ha, task_id):
+    return next((t for t in _list_tasks(ha) if t["id"] == task_id), None)
+
+
+def _synced_task(ha):
+    """The triggered task mirroring the problem sensor, polled (sync is async)."""
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        try:
+            for task in _list_tasks(ha):
+                src = (task.get("source") or {}).get("problem_sensor")
+                if src and src.get("entity_id") == SENSOR:
+                    return task
+        except Exception:
+            pass
+        time.sleep(1)
+    return None
+
+
+def test_complete_task_by_name_via_intent(ha):
+    task_id = _add_task(ha, "Vacuum the stairs")
+    resp = _handle(ha, "HomeKeeperCompleteTask", {"name": "vacuum the stairs"})
+    assert "completed" in _speech(resp).lower()
+
+    # The completion went through store.complete_task with the intent origin marker
+    # (captured by the configuration.yaml automation into an input_text).
+    origin = poll_state(
+        ha,
+        "input_text.hk_last_completed_origin",
+        lambda s: s == ORIGIN_INTENT,
+    )
+    assert origin == ORIGIN_INTENT
+    # ...and the recurrence advanced.
+    assert _get_task(ha, task_id)["last_completed"] is not None
+
+
+def test_unknown_task_name_is_reported(ha):
+    resp = _handle(ha, "HomeKeeperCompleteTask", {"name": "fly to the moon"})
+    assert "couldn't find" in _speech(resp).lower()
+
+
+def test_ambiguous_name_asks_to_disambiguate(ha):
+    _add_task(ha, "Clean upstairs windows")
+    _add_task(ha, "Clean downstairs windows")
+    before = get_state(ha, "input_text.hk_last_completed_origin")
+    before_val = before["state"] if before else None
+
+    resp = _handle(ha, "HomeKeeperCompleteTask", {"name": "clean windows"})
+    speech = _speech(resp).lower()
+    assert "more than one" in speech
+    assert "upstairs windows" in speech and "downstairs windows" in speech
+
+    # Nothing was completed, so the captured-origin marker is unchanged.
+    time.sleep(1)
+    after = get_state(ha, "input_text.hk_last_completed_origin")
+    assert (after["state"] if after else None) == before_val
+
+
+def test_synced_problem_task_rejected_via_intent(ha):
+    task = _synced_task(ha)
+    assert task is not None, "expected a synced task for the problem binary sensor"
+    resp = _handle(ha, "HomeKeeperCompleteTask", {"name": task["name"]})
+    speech = _speech(resp).lower()
+    assert "can't be cleared" in speech or "originating integration" in speech
+
+
+def test_list_due_tasks_via_intent(ha):
+    # A floating task last done long ago is overdue, so it must show up as due.
+    _add_task(ha, "Descale the kettle", last_completed="2020-01-01T09:00:00-05:00")
+    resp = _handle(ha, "HomeKeeperListDueTasks", {})
+    speech = _speech(resp).lower()
+    assert "due" in speech
+    assert "descale the kettle" in speech
+
+
+def test_intents_survive_entry_reload(ha):
+    task_id = _add_task(ha, "Water the ferns")
+    # set_options awaits its own entry reload, which re-runs async_setup_entry and
+    # re-registers the intents. Firing afterwards proves registration is reload-safe.
+    call_service(ha, "home_keeper", "set_options", {"sync_problem_sensors": True})
+    resp = _handle(ha, "HomeKeeperCompleteTask", {"name": "water the ferns"})
+    assert "completed" in _speech(resp).lower()
+    assert _get_task(ha, task_id)["last_completed"] is not None

--- a/tests/unit/test_intent_sentences.py
+++ b/tests/unit/test_intent_sentences.py
@@ -1,0 +1,73 @@
+"""Recognition tests for the shipped Assist sentences (NLU layer).
+
+These load ``custom_sentences/en/home_keeper.yaml`` and run it through ``hassil`` —
+the very engine Home Assistant's default conversation agent uses — to assert that
+representative utterances route to the right intent and capture the task name slot.
+This is the only tier that exercises sentence -> intent matching, so it guards
+against a typo or syntax error in the sentence file silently breaking voice control.
+
+``hassil`` ships with Home Assistant (installed in CI via
+pytest-homeassistant-custom-component); a bare ``pip install pytest`` run skips this.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+hassil = pytest.importorskip("hassil")
+yaml = pytest.importorskip("yaml")
+
+from hassil import Intents, recognize  # noqa: E402
+
+_SENTENCES = (
+    Path(__file__).resolve().parents[2] / "custom_sentences" / "en" / "home_keeper.yaml"
+)
+
+
+@pytest.fixture(scope="module")
+def intents() -> Intents:
+    data = yaml.safe_load(_SENTENCES.read_text())
+    return Intents.from_dict(data)
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_name"),
+    [
+        ("mark furnace filter as done", "furnace filter"),
+        ("mark the furnace filter done", "furnace filter"),
+        ("complete take medicine", "take medicine"),
+        ("complete the task take medicine", "take medicine"),
+        ("clear the fridge filter", "fridge filter"),
+        ("check off the water filter", "water filter"),
+        ("I just replaced the furnace filter", "furnace filter"),
+        ("I changed the fridge filter", "fridge filter"),
+    ],
+)
+def test_complete_sentences_route_and_capture_name(intents, text, expected_name):
+    result = recognize(text, intents)
+    assert result is not None, f"no intent matched: {text!r}"
+    assert result.intent.name == "HomeKeeperCompleteTask"
+    captured = result.entities["name"].value
+    assert expected_name in captured.lower()
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "what tasks are due",
+        "what chores are due today",
+        "what tasks need to be done",
+        "what's due right now",
+        "do I have any chores due",
+    ],
+)
+def test_query_sentences_route_to_list_due(intents, text):
+    result = recognize(text, intents)
+    assert result is not None, f"no intent matched: {text!r}"
+    assert result.intent.name == "HomeKeeperListDueTasks"
+
+
+def test_unrelated_sentence_does_not_match(intents):
+    assert recognize("turn on the kitchen lights", intents) is None

--- a/tests/unit/test_task_match.py
+++ b/tests/unit/test_task_match.py
@@ -1,0 +1,135 @@
+"""Unit tests for the pure voice/intent task matcher (no Home Assistant).
+
+These exercise the branchy resolution logic that backs the conversation intents —
+exact vs fuzzy vs ambiguous vs not-found, area/device scoping, and due-task
+selection — so the fragile parts get cheap, deterministic coverage. The HA wiring
+that calls these (registry lookups, spoken responses) is covered by the integration
+tests instead.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import hk_task_match as tm
+
+TZ = timezone(timedelta(hours=-4))
+
+
+def _task(name, **extra):
+    return {
+        "id": name.lower().replace(" ", "_"),
+        "name": name,
+        "enabled": True,
+        **extra,
+    }
+
+
+# A small task set echoing the seeded integration fixture (three "Replace … filter"
+# tasks, which is what makes keyword matching ambiguous).
+TASKS = [
+    _task("Replace fridge filter"),
+    _task("Replace furnace filter"),
+    _task("Replace water filter", device_id="dev_water", area_id="kitchen"),
+    _task("Take medicine"),
+]
+
+
+def test_exact_name_matches_uniquely():
+    result = tm.match_task(TASKS, "Replace furnace filter")
+    assert result.matched
+    assert result.task["name"] == "Replace furnace filter"
+
+
+def test_exact_match_is_case_and_article_insensitive():
+    result = tm.match_task(TASKS, "the take medicine")
+    assert result.matched
+    assert result.task["name"] == "Take medicine"
+
+
+def test_fuzzy_typo_still_resolves():
+    result = tm.match_task(TASKS, "take medecine")  # typo
+    assert result.matched
+    assert result.task["name"] == "Take medicine"
+
+
+def test_unique_keyword_resolves_via_containment():
+    result = tm.match_task(TASKS, "furnace filter")
+    assert result.matched
+    assert result.task["name"] == "Replace furnace filter"
+
+
+def test_ambiguous_keyword_returns_candidates_not_a_guess():
+    result = tm.match_task(TASKS, "filter")
+    assert result.ambiguous
+    names = {t["name"] for t in result.candidates}
+    assert names == {
+        "Replace fridge filter",
+        "Replace furnace filter",
+        "Replace water filter",
+    }
+    assert result.task is None
+
+
+def test_unrelated_name_is_not_found():
+    result = tm.match_task(TASKS, "walk the dog")
+    assert result.not_found
+    assert result.task is None and result.candidates == []
+
+
+def test_area_filter_disambiguates():
+    # "filter" alone is ambiguous, but scoped to the kitchen only one task qualifies.
+    result = tm.match_task(TASKS, "filter", area_id="kitchen")
+    assert result.matched
+    assert result.task["name"] == "Replace water filter"
+
+
+def test_device_filter_disambiguates():
+    result = tm.match_task(TASKS, "filter", device_id="dev_water")
+    assert result.matched
+    assert result.task["name"] == "Replace water filter"
+
+
+def test_area_filter_with_no_tasks_is_not_found():
+    result = tm.match_task(TASKS, "filter", area_id="garage")
+    assert result.not_found
+
+
+def test_duplicate_exact_names_are_ambiguous():
+    dupes = [_task("Water the plants"), _task("Water the plants")]
+    result = tm.match_task(dupes, "water the plants")
+    assert result.ambiguous
+    assert len(result.candidates) == 2
+
+
+# ── select_due_tasks ─────────────────────────────────────────────────────────────
+NOW = datetime(2026, 6, 20, 12, 0, tzinfo=TZ)
+
+
+def _due_task(name, due_iso, **extra):
+    return _task(name, next_due=due_iso, **extra)
+
+
+def test_due_selection_includes_overdue_and_due_now_sorted():
+    tasks = [
+        _due_task("A overdue", "2026-06-01T09:00:00-04:00"),
+        _due_task("B future", "2026-12-01T09:00:00-04:00"),
+        _due_task("C due now", NOW.isoformat()),
+        _due_task("D dormant", None),  # triggered, not armed
+    ]
+    due = tm.select_due_tasks(tasks, NOW)
+    assert [t["name"] for t in due] == ["A overdue", "C due now"]
+
+
+def test_due_selection_excludes_disabled():
+    tasks = [_due_task("Off", "2026-01-01T09:00:00-04:00", enabled=False)]
+    assert tm.select_due_tasks(tasks, NOW) == []
+
+
+def test_due_selection_tolerates_bad_timestamp():
+    tasks = [
+        _due_task("Bad", "not-a-date"),
+        _due_task("Good", "2026-06-01T09:00:00-04:00"),
+    ]
+    due = tm.select_due_tasks(tasks, NOW)
+    assert [t["name"] for t in due] == ["Good"]


### PR DESCRIPTION
## What & why

Competitive research flagged that we should let users **clear tasks via Home Assistant intents**. This adds voice/text control through Assist: two conversation intents so chores can be completed and checked hands-free instead of opening the panel.

- **`HomeKeeperCompleteTask`** — *"mark the furnace filter as done"*, *"I just replaced the fridge filter"*, *"clear take medicine"*, *"check off the water filter"*. Fuzzy-matches the spoken name against your tasks and completes it. When more than one task could match (you have a *fridge* filter and a *furnace* filter and only said "filter"), it **lists them and asks which one** rather than guessing — completing the wrong task would advance its recurrence, a destructive surprise.
- **`HomeKeeperListDueTasks`** — *"what chores are due?"*, *"what tasks need to be done?"* — reads back tasks that are due or overdue.

## Design

- **Delegates to the store, not a new path.** Both handlers funnel through the existing `store.complete_task` chokepoint with `origin=ORIGIN_INTENT`, so a voice completion stays observable (fires `home_keeper_task_completed`) and obeys the same guards — a problem-sensor-synced task is still rejected, now with a spoken explanation. No new service needed (`complete_task` already exists).
- **Pure matching.** Name resolution + due-task selection live in `task_match.py` (no HA imports, loaded in the `hk` synthetic package), unit-tested in isolation like `recurrence.py`. The handler only does HA-specific work: registry name→id lookups, spoken responses, error mapping.
- **Reload-safe.** Registration is global and idempotent (keyed by `intent_type`) and resolves the coordinator per-call.

## Tests

- **Unit** — `tests/unit/test_task_match.py` (exact/fuzzy/ambiguous/not-found, area & device scoping, due selection) and `tests/unit/test_intent_sentences.py` (loads the shipped `custom_sentences/en/home_keeper.yaml` and runs it through **hassil**, the same engine HA uses, to assert sentence→intent→slot routing — this is the only tier that covers the NLU layer).
- **Integration** — `tests/integration/test_intents.py` drives the real `/api/intent/handle` endpoint (enabled `intent:` in the test config): completion + `origin` marker via the existing capture automation, unknown/ambiguous (no mutation), problem-sensor rejection, due-query, and **reload survival**.
- Ran locally before pushing: **279 unit passed**, **48 integration passed** (incl. 6 new), `ruff check` + `ruff format --check` clean.

## Setup for users

Intent handlers register automatically. To teach the default Assist agent the phrases, copy `custom_sentences/en/home_keeper.yaml` into `<config>/custom_sentences/en/home_keeper.yaml` and restart. Documented in README "Voice control" + CHANGELOG, and the convention is recorded in `.amazonq/rules/architecture-and-code.md`.

## Known gaps (deliberate)

- **Multi-turn disambiguation** isn't a true conversation follow-up — it speaks the candidates and asks you to re-utter a more specific command.
- **Localization**: sentences/responses ship in English (responses are in-code); the matcher is language-agnostic.
- Fuzzy-match **threshold** is tuned conservatively (prefers asking over guessing); no per-language tuning.

No panel UI surface changed, so no screenshots are required for this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013ytrgbbCH5n5mrrhzQW1tg)_