### PR TITLE
Fix recurrence-engine crash and triggered-task conversion bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,17 +38,6 @@ versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas)
 
 ### Fixed
 
-- **Fixed monthly schedules anchored far in the past no longer crash.** A `fixed`
-  task with a `MONTHLY` frequency whose anchor was more than ~41 years before now
-  (with a 1-month interval) could blow the recurrence engine's iteration cap and
-  raise, taking down the task's *next due* sensor, *overdue* binary sensor, and the
-  calendar. The monthly fast-forward now jumps to the right occurrence directly,
-  matching the day-by-day clamping behaviour exactly (verified against an
-  exhaustive reference) including end-of-month and leap-year cases.
-- **Converting a monitored (triggered) task to a recurring one no longer errors.**
-  Changing a `triggered` task to `floating`/`fixed` without re-sending an interval
-  raised "interval must be a valid integer"; the interval now defaults to 1 (as on
-  a fresh task) when not supplied.
 - **Settings exclusions now take effect immediately.** Adding a problem-sensor
   entity, area, or label to a *skip* list in the panel's **Settings** tab is now
   reflected right away: the integration reload that re-runs the problem-sensor sync

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,17 @@ versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas)
 
 ### Fixed
 
+- **Fixed monthly schedules anchored far in the past no longer crash.** A `fixed`
+  task with a `MONTHLY` frequency whose anchor was more than ~41 years before now
+  (with a 1-month interval) could blow the recurrence engine's iteration cap and
+  raise, taking down the task's *next due* sensor, *overdue* binary sensor, and the
+  calendar. The monthly fast-forward now jumps to the right occurrence directly,
+  matching the day-by-day clamping behaviour exactly (verified against an
+  exhaustive reference) including end-of-month and leap-year cases.
+- **Converting a monitored (triggered) task to a recurring one no longer errors.**
+  Changing a `triggered` task to `floating`/`fixed` without re-sending an interval
+  raised "interval must be a valid integer"; the interval now defaults to 1 (as on
+  a fresh task) when not supplied.
 - **Settings exclusions now take effect immediately.** Adding a problem-sensor
   entity, area, or label to a *skip* list in the panel's **Settings** tab is now
   reflected right away: the integration reload that re-runs the problem-sensor sync

--- a/custom_components/home_keeper/models.py
+++ b/custom_components/home_keeper/models.py
@@ -164,8 +164,16 @@ def normalize_fields(data: dict, *, tz: Any = None) -> dict:
     if rec_type == REC_TRIGGERED:
         return fields
 
+    # Default to 1 when interval is absent *or* explicitly unset. ``merge_update``
+    # always carries an ``interval`` key forward, so for a task that never had one
+    # (e.g. converting a triggered task to floating/fixed) the value is ``None``;
+    # ``dict.get("interval", 1)`` would return that ``None`` rather than the default,
+    # so coalesce here to keep the conversion working like a fresh creation.
+    raw_interval = data.get("interval", 1)
+    if raw_interval in (None, ""):
+        raw_interval = 1
     try:
-        interval = int(data.get("interval", 1))
+        interval = int(raw_interval)
     except (TypeError, ValueError) as err:
         raise TaskValidationError("interval must be a valid integer") from err
     if interval < 1:

--- a/custom_components/home_keeper/recurrence.py
+++ b/custom_components/home_keeper/recurrence.py
@@ -107,15 +107,27 @@ def _step(dt: datetime, freq: str, interval: int) -> datetime:
 def _fast_forward(
     anchor: datetime, freq: str, interval: int, target: datetime
 ) -> datetime:
-    """An occurrence at or just before *target*, jumped to in O(1).
+    """An occurrence at or just before *target*, jumped to in O(1) where possible.
 
     A long-dormant fixed schedule can be thousands of steps past its anchor;
     stepping one occurrence at a time would be slow (and historically raised once
     it blew an iteration cap). We deliberately *under*-shoot (``- 1`` step) so the
     caller's short loop finishes on the exact occurrence using wall-clock stepping
     — correct across DST and month-length clamping. Day/week deltas are exact, so
-    the bulk jump is too; MONTHLY is left to the loop (it would need ~830 years to
-    approach the cap) to preserve its progressive day-clamping behavior.
+    the bulk jump is too.
+
+    MONTHLY is trickier: progressive day-clamping makes the grid path-dependent, so
+    we can't jump directly from the anchor for a day > 28 (``add_months(Jan 31, 2)``
+    is Mar 31, but stepping is Jan 31 -> Feb 28 -> Mar 28). We exploit the fact that
+    the clamped day is monotonically non-increasing toward 28 — once it bottoms out
+    at 28 (the global floor: every month has >= 28 days) it never changes again, so
+    from that occurrence we *can* jump in O(1). We therefore step until the day hits
+    28 (typically a handful of steps — interval-1 monthly reaches a non-leap
+    February within a few years) and then bulk-jump the remainder. Schedules whose
+    reachable months never include a short-enough month (e.g. an even interval that
+    skips February) keep a day > 28 forever; for those we simply step to the target,
+    bounded by the (finite) span between anchor and target — slower, but never the
+    old iteration-cap crash.
     """
     elapsed = (target - anchor).total_seconds()
     if elapsed <= 0:
@@ -126,7 +138,20 @@ def _fast_forward(
     if freq == FREQ_WEEKLY:
         steps = max(0, int(elapsed // (604_800 * interval)) - 1)
         return anchor + timedelta(weeks=interval * steps)
-    return anchor
+    # MONTHLY
+    occ = anchor
+    while occ.day > 28:
+        nxt = add_months(occ, interval)
+        if nxt > target:
+            # Reached the target before the day stabilized: hand the (exact) grid
+            # occurrence to the caller's loop. Bounded by the anchor→target span.
+            return occ
+        occ = nxt
+    # The day has bottomed out at 28 and is now stable for every further step, so
+    # the remaining whole steps can be jumped at once (under-shooting by one).
+    remaining = (target.year - occ.year) * 12 + (target.month - occ.month)
+    jump = max(0, remaining // interval - 1)
+    return add_months(occ, jump * interval)
 
 
 def next_fixed_occurrence(

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -546,6 +546,40 @@ def test_merge_update_keeps_armed_triggered_armed():
     assert merged["next_due"] == armed
 
 
+def test_merge_update_converts_triggered_to_floating():
+    # Regression: a triggered task has no interval, so merge_update's candidate
+    # carries interval=None. normalize_fields' `data.get("interval", 1)` returned
+    # that None (key present) instead of defaulting to 1, raising "interval must be
+    # a valid integer". Converting to floating with just unit must now succeed,
+    # defaulting interval to 1 like a fresh creation.
+    task = m.build_task(
+        {"name": "Replace battery", "recurrence_type": "triggered"}, now=NOW
+    )
+    merged = m.merge_update(
+        task, {"recurrence_type": "floating", "unit": "days"}, now=NOW
+    )
+    assert merged["recurrence_type"] == "floating"
+    assert merged["interval"] == 1
+    assert merged["unit"] == "days"
+    # A floating task with no completion is due now.
+    assert merged["next_due"] == NOW.isoformat()
+
+
+def test_merge_update_converts_triggered_to_floating_with_explicit_interval():
+    # When the conversion does supply an interval, it is honored (not overwritten).
+    task = m.build_task(
+        {"name": "Replace battery", "recurrence_type": "triggered"}, now=NOW
+    )
+    merged = m.merge_update(
+        task,
+        {"recurrence_type": "floating", "unit": "months", "interval": 6},
+        now=NOW,
+    )
+    assert merged["recurrence_type"] == "floating"
+    assert merged["interval"] == 6
+    assert merged["unit"] == "months"
+
+
 def test_build_task_normalizes_labels():
     # Labels are de-duplicated and blank-stripped, order preserved.
     task = m.build_task(

--- a/tests/unit/test_recurrence_fixed.py
+++ b/tests/unit/test_recurrence_fixed.py
@@ -100,6 +100,61 @@ def test_expand_daily_with_far_past_anchor_returns_window():
     ]
 
 
+def _naive_next_monthly(anchor, interval, after):
+    """Reference: smallest occurrence strictly after *after* by single-stepping."""
+    if anchor > after:
+        return anchor
+    occ = anchor
+    while occ <= after:
+        occ = r.add_months(occ, interval)
+    return occ
+
+
+def test_next_monthly_occurrence_with_far_past_anchor_does_not_raise():
+    # Regression: a fixed MONTHLY task anchored more than MAX_EXPAND_ITERATIONS
+    # months (~41.6 years) in the past used to blow the iteration cap and raise a
+    # RuntimeError, taking the next-due sensor / calendar / overdue sensor down (the
+    # MONTHLY branch of _fast_forward did not jump). It must compute the correct
+    # next occurrence instead.
+    anchor = dt(1976, 6, 21, 9)  # 50 years before `after`
+    after = dt(2026, 6, 21)
+    nxt = r.next_fixed_occurrence(anchor, "MONTHLY", 1, after=after)
+    assert nxt == dt(2026, 6, 21, 9)
+    assert nxt == _naive_next_monthly(anchor, 1, after)
+
+
+def test_next_monthly_far_past_matches_naive_across_day_clamping():
+    # The O(1) MONTHLY fast-forward must stay byte-identical to single-stepping,
+    # including end-of-month clamping (Jan 31 -> Feb 28 -> ... sticks at 28) and
+    # leap years. Spot-check several clamping-prone anchors/intervals far in the past.
+    after = dt(2026, 6, 13, 9)
+    cases = [
+        (dt(1980, 1, 31, 9), 1),
+        (dt(1980, 3, 31, 9), 1),
+        (dt(1981, 1, 29, 9), 1),
+        (dt(1975, 8, 30, 9), 2),
+        (dt(1970, 12, 31, 9), 3),
+        (dt(1984, 2, 29, 9), 12),
+    ]
+    for anchor, interval in cases:
+        assert r.next_fixed_occurrence(
+            anchor, "MONTHLY", interval, after=after
+        ) == _naive_next_monthly(anchor, interval, after), (anchor, interval)
+
+
+def test_expand_monthly_with_far_past_anchor_returns_window():
+    anchor = dt(1980, 1, 31, 9)  # far past + end-of-month clamping
+    occ = r.expand_fixed_occurrences(
+        anchor, "MONTHLY", 1, dt(2026, 6, 1), dt(2026, 9, 1)
+    )
+    # Day clamps to 28 permanently once a non-leap February is crossed.
+    assert [o.date().isoformat() for o in occ] == [
+        "2026-06-28",
+        "2026-07-28",
+        "2026-08-28",
+    ]
+
+
 def test_remove_completion_keeps_fixed_schedule():
     from datetime import datetime, timedelta, timezone
 


### PR DESCRIPTION
## Exploratory testing — bugs found & fixed

I went bug-hunting through the pure-logic core (recurrence, models, store, assets, reconcile, transitions, inventory, card-filter) and the frontend utilities. Two concrete backend bugs surfaced; both are fixed here with regression tests. The full unit suite is green (276 passed).

### Bug 1 — fixed `MONTHLY` schedule crashes when anchored far in the past (correctness, crash)

`next_fixed_occurrence` raised `RuntimeError: next_fixed_occurrence exceeded iteration cap` for a `fixed` task with `freq=MONTHLY`, `interval=1`, whose anchor was more than `MAX_EXPAND_ITERATIONS` (500) months — **~41.6 years** — before `now`. `_fast_forward` handled `DAILY`/`WEEKLY` with an O(1) jump but fell through to `return anchor` for `MONTHLY`, leaving the bounded loop to step month-by-month into the cap. (The docstring claimed it'd take "~830 years" to approach the cap — that was wrong; the real figure is ~41.6 years.)

Reproduction (pre-fix):

```python
next_fixed_occurrence(datetime(1976,6,21,tzinfo=utc), "MONTHLY", 1, after=datetime(2026,6,21,tzinfo=utc))
# RuntimeError: ... exceeded iteration cap
```

This crash propagates through `compute_next_due` / `apply_completion`, so creating or completing such a task — or any refresh recomputing it — takes down its *next due* sensor, *overdue* binary sensor, and the calendar.

**Fix.** `_fast_forward` now jumps `MONTHLY` occurrences. The clamped occurrence day is monotonically non-increasing toward 28 (every month has ≥28 days), so once it bottoms out at 28 it is permanently stable and the remainder can be jumped in O(1). We step until the day reaches 28, then bulk-jump; schedules whose reachable months never clamp to 28 (e.g. an even interval that skips February) just step to the target, bounded by the finite anchor→target span — never the old cap crash.

I verified the new path is **byte-identical to single-stepping** across **665,760 exhaustive cases** (every anchor day 1–31, every anchor month, 19 intervals, year offsets spanning leap-year and century edges). The caller's loop runs ≤2 iterations afterward.

### Bug 2 — converting a `triggered` task to `floating`/`fixed` errors (correctness)

`merge_update`'s candidate always carries an `interval` key. A `triggered` task has no interval, so the candidate gets `interval=None`, and `normalize_fields`' `int(data.get("interval", 1))` returned that `None` (key present) rather than the default → `TaskValidationError: interval must be a valid integer`. Converting a monitored task to a recurring one with just a unit failed.

**Fix.** Coalesce an absent/`None`/`""` interval to `1` (matching fresh creation) before validation.

### Notes / observations (not changed here)

- A `fixed` task that is never completed keeps its stored `next_due` pinned to the first occurrence (perpetually overdue), while the **calendar** entity shows future occurrences — the coordinator never recomputes `next_due` over time. Self-consistent but arguably an inconsistency between surfaces; left as-is pending a product call.
- Completing a wear-part task with a future `completed_at` would stamp a future `last_replaced`, which a later asset edit rejects ("last_replaced must not be in the future"). Edge case, not addressed.

### Testing

- `pytest tests/unit -v` → 276 passed (5 new).
- `ruff check` + `ruff format --check` clean on the changed files.
- Brute-force oracle comparison for the monthly fast-forward (665k cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014spKqiUDGg8KHMA7RXw3x8)_