### PR TITLE
Release 0.3.0b12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas)
 
 ## [Unreleased]
 
+## [0.3.0b12] - 2026-06-21
+
 ### Added
 
 - **Per-completion metadata (note, cost, photo, who).** A completion can now carry

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.3.0b11"
+PANEL_VERSION = "0.3.0b12"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -15,5 +15,5 @@
   "issue_tracker": "https://github.com/prestomation/ha-home-keeper/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "0.3.0b11"
+  "version": "0.3.0b12"
 }


### PR DESCRIPTION
Beta release **0.3.0b12**.

Per `RELEASE.md`, this PR contains exactly the release changes:

- `custom_components/home_keeper/manifest.json` — `version` → `0.3.0b12`
- `custom_components/home_keeper/const.py` — `PANEL_VERSION` → `"0.3.0b12"`
- `CHANGELOG.md` — roll the `[Unreleased]` section into `## [0.3.0b12] - 2026-06-21` (fresh empty `[Unreleased]` left on top)

On merge, `release.yml` tags `v0.3.0b12`, builds the panel + `home_keeper.zip`, and publishes a **pre-release** GitHub Release (so HACS offers it only to users with betas enabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014spKqiUDGg8KHMA7RXw3x8)_