### PR TITLE
Document that "require details" is a panel-only capture prompt

### DIFF
--- a/.amazonq/rules/architecture-and-code.md
+++ b/.amazonq/rules/architecture-and-code.md
@@ -88,6 +88,15 @@ reviewing code in this repository (the `home_keeper` Home Assistant integration)
   future per-field "which are required" editor needs only to populate the list — no
   storage migration. Both fields are additive (`.get()` with `none`/`[]` defaults); no
   `STORAGE_VERSION` bump.
+- **Capture mode is a panel-only prompt, not a chokepoint constraint.** `store.complete_task`
+  records whatever metadata it's given and **never rejects** a completion for missing
+  required fields, and the `complete_task` service/websocket fields are all optional. The
+  `optional`/`required` gate lives in the panel completion dialog (the card defers a
+  `required` task to the panel). This is intentional: every non-panel surface (the native
+  `todo` checkbox, the device `button`, automations/voice via the service) funnels through
+  the same chokepoint and can't show a dialog, so enforcing there would make a `required`
+  task uncompletable from those surfaces. Keep enforcement where a dialog can be shown; do
+  not add hard required-field validation to the store/service.
 
 ## Entities & devices
 - Entity `unique_id`s are anchored to the task `id` so they survive renames.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,17 @@ same fields for automations.
 > The set of *required* fields is stored per task, so a future release can let you
 > require specific fields (e.g. always a cost) without any migration.
 
+> **Where "require details" applies.** The capture dialog — and the *required*
+> gate — live in the **panel**. Completing a task from a surface that has no dialog
+> (the native **to-do** checkbox, the mobile app, the device **mark-done** button, or
+> a bare `home_keeper.complete_task` service call) just records the completion
+> immediately, with whatever metadata was passed (none from a checkbox). This is
+> deliberate: those surfaces can't prompt, and hard-blocking them would make a
+> *required* task impossible to complete from the to-do list or an automation. So
+> *required* is a capture prompt in the panel, not a global constraint — the dashboard
+> card honours it by sending you to the panel instead of quick-completing. Automations
+> that want to record detail can pass `note` / `cost` / `photo` / `who` to the service.
+
 ![The completion-details dialog — note, cost, who and photo captured when a task is marked done](docs/images/11-panel-completion-dialog.png)
 
 Every completion's note and cost (and who/photo) then show in the task's history,


### PR DESCRIPTION
Follow-up to #61. Documents how the per-completion **capture mode** behaves outside the panel.

## Why
The `optional`/`required` capture gate lives in the **panel** completion dialog. Every other completion surface — the native **to-do** checkbox, the device **mark-done** button, the mobile app, and a bare `home_keeper.complete_task` service/websocket call — funnels through the shared `store.complete_task` chokepoint, which records the completion immediately with whatever metadata was passed (none from a checkbox) and **never rejects it for missing required fields**.

This is deliberate: those surfaces can't show a dialog, so hard-blocking the chokepoint would make a `required` task **uncompletable** from the to-do list or an automation. The dashboard card honours `required` by deferring to the panel; automations that want to record detail can pass `note`/`cost`/`photo`/`who` to the service.

## Changes (docs only — no behavior change)
- **README** "Logging completions" section: a note explaining where *require details* applies (panel) vs. where completions just record immediately.
- **`.amazonq/rules/architecture-and-code.md`**: records the design intent — capture mode is a panel prompt, not a chokepoint constraint; do not add hard required-field validation to the store/service.

No code, tests, or UI surfaces touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2NhqWVty8Sbinb5uFMR75

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2NhqWVty8Sbinb5uFMR75)_