### PR TITLE
Release 0.4.0b1 (beta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas)
 
 ## [Unreleased]
 
+## [0.4.0b1] - 2026-06-21
+
 ### Added
 
 - **Companion discovery (Settings → Companions).** Home Keeper now surfaces

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.3.0"
+PANEL_VERSION = "0.4.0b1"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -15,5 +15,5 @@
   "issue_tracker": "https://github.com/prestomation/ha-home-keeper/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "0.3.0"
+  "version": "0.4.0b1"
 }


### PR DESCRIPTION
Beta release cutting the work merged since **0.3.0**:

- **Companion discovery** (Settings → Companions) — #72
- **Sensor-based tasks** (usage meters + thresholds) — #71

Per [RELEASE.md](RELEASE.md): bumps `manifest.json` `version` and `const.py` `PANEL_VERSION` to `0.4.0b1`, and adds the `## [0.4.0b1]` CHANGELOG section. On merge, `release.yml` tags `v0.4.0b1`, builds the panel + `home_keeper.zip`, and publishes a **pre-release** (HACS offers it only to "Show beta versions" users).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0147z5CAVBggwBaHBf2A1CvN

---
_Generated by [Claude Code](https://claude.ai/code/session_0147z5CAVBggwBaHBf2A1CvN)_