### PR TITLE
fix(card): fire ll-custom-cards-update so card appears in picker on first load

### DIFF
--- a/custom_components/home_keeper/frontend/src/card-index.ts
+++ b/custom_components/home_keeper/frontend/src/card-index.ts
@@ -25,6 +25,9 @@ if (!w.customCards.some((c) => c.type === 'home-keeper-card')) {
     preview: true,
     documentationURL: 'https://github.com/prestomation/ha-home-keeper',
   });
+  // Notify Lovelace to re-read window.customCards — needed when this module
+  // loads after the dashboard has already initialised (first cold load).
+  window.dispatchEvent(new CustomEvent('ll-custom-cards-update'));
 }
 
 export { HomeKeeperCard, HomeKeeperCardEditor };

--- a/tests/e2e/tests/helpers.ts
+++ b/tests/e2e/tests/helpers.ts
@@ -27,10 +27,10 @@ export async function openDashboard(page: Page): Promise<void> {
  * the dashboard's nested shadow DOM, which Playwright locators pierce.
  */
 export async function openCardDashboard(page: Page) {
-  // The card JS is an auto-registered extra module. On the very first dashboard
-  // load of a run HA may not have finished loading it, so the custom element
-  // doesn't upgrade in time; a reload (the module is warm by then) fixes it.
-  // Retry a couple of times so the first test isn't flaky on a cold frontend.
+  // The card JS is an auto-registered extra module. card-index.ts fires
+  // ll-custom-cards-update so the picker refreshes when the module loads late,
+  // but on a cold frontend the element may not yet be upgraded when we first
+  // arrive. Retry a couple of times so the first test isn't flaky.
   let lastErr: unknown;
   for (let attempt = 0; attempt < 3; attempt++) {
     if (attempt === 0) await openDashboard(page);


### PR DESCRIPTION
## Summary

- `card-index.ts` now dispatches `ll-custom-cards-update` after pushing to `window.customCards`
- Updated the e2e helper comment to reflect the fix

## Root cause

The Lovelace card picker reads `window.customCards` once when it initialises. When the card JS loads as an extra module (via `frontend.add_extra_js_url`), it may arrive *after* the dashboard has already rendered — especially on the first cold load. Because no notification was sent, the picker never re-read the registry, so the card was invisible until the user reloaded the page (at which point the module was cached and executed before the picker).

`window.dispatchEvent(new CustomEvent('ll-custom-cards-update'))` is the standard HA hook that tells the Lovelace card picker to re-read `window.customCards` immediately, so the card appears without a reload.

## Test plan

- [ ] Install the integration, open a dashboard → "Add card" picker — **Home Keeper Tasks** should appear on the first load without a manual page reload
- [ ] Manually add `type: custom:home-keeper-card` in YAML — card renders correctly
- [ ] E2e tests pass (`bash ci/e2e-up.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BwrMtzD4KwFdShBVegGDSK

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwrMtzD4KwFdShBVegGDSK)_