### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,49 @@ versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas)
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-22
+
+This release adds **companion discovery** so integrations that work with Home Keeper
+surface in the panel, **sensor-based tasks** driven by a numeric entity rather than the
+clock, and **device exclusions** for problem-sensor sync. Highlights, for anyone
+upgrading from 0.3.0:
+
 ### Added
 
-- **Exclude devices from problem-sensor sync.** The problem-sensor sync feature
-  gains an **Excluded devices** picker (panel **Settings**, the options flow, and the
+- **Companion discovery (Settings → Companions).** Home Keeper now surfaces
+  integrations that work with it, right in the panel. **Connected** companions
+  (integrations that announce themselves — e.g. Pawsistant, or the Battery Notes
+  bridge) get a **Configure** button that deep-links to their own settings.
+  **Suggested** rows point you at a bridge for a *popular* integration you already have
+  installed (e.g. **Battery Notes**) but haven't connected yet, with an **Install**
+  link and a **Dismiss** to silence it. Two paths feed this: an integration can
+  *register itself* via the new `home_keeper.register_companion` service (so Home
+  Keeper never hard-codes it), and Home Keeper *detects* a small curated set of popular
+  upstreams from a catalog. New `home_keeper_companion_connected` /
+  `home_keeper_companion_suggested` events let automations react. See the
+  [Companions](README.md#companions--discover-integrations-that-work-with-home-keeper)
+  README section and [docs/INTEGRATING.md](docs/INTEGRATING.md) §7.
+- **Sensor-based tasks.** A recurrence type whose due-state is derived from a bound
+  numeric Home Assistant entity rather than the clock, in two modes. **Usage / meter**
+  generalises floating recurrence from elapsed time to elapsed sensor *units* — *"service
+  every 500 running hours"*, *"oil every 15,000 km"* — arming once the reading advances
+  the chosen **target** since the last completion (which resets the meter; a meter reset
+  re-anchors automatically). **Threshold** arms when the reading crosses a comparison
+  against a value, with an optional hold and attribute read — *"replace the filter when
+  airflow drops below 60 %"* — and re-arms only on a fresh crossing. Armed sensor tasks
+  appear on the to-do list and fire `home_keeper_task_overdue` like any
+  other; the task detail shows live meter progress. Create them in the panel or via
+  `home_keeper.add_task` with a `sensor` mapping.
+- **Exclude devices from problem-sensor sync.** The problem-sensor sync feature gains
+  an **Excluded devices** picker (panel **Settings**, the options flow, and the
   `home_keeper.set_options` service) alongside the existing entity / area / label
-  exclusions. Excluding a device leaves out every `device_class: problem` binary
-  sensor that belongs to it.
+  exclusions. Excluding a device leaves out every `device_class: problem` binary sensor
+  that belongs to it.
+
+### Changed
+
+- **Settings tab layout.** The completed one-off retention setting now lives in its own
+  **General** card, separate from the **Problem sensor sync** card it's unrelated to.
 
 ## [0.4.0b1] - 2026-06-21
 

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.4.0b1"
+PANEL_VERSION = "0.4.0"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -15,5 +15,5 @@
   "issue_tracker": "https://github.com/prestomation/ha-home-keeper/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "0.4.0b1"
+  "version": "0.4.0"
 }


### PR DESCRIPTION
## Release 0.4.0

Cuts the **0.4.0 stable** release from the `0.4.0b1` line. Per RELEASE.md, this is the release PR — on merge, `release.yml` tags `v0.4.0`, builds `home_keeper.zip`, and publishes the GitHub Release with the `## [0.4.0]` changelog section as the body.

### Changes (exactly the three release-gated files)
- `custom_components/home_keeper/manifest.json` — `version` → `0.4.0`
- `custom_components/home_keeper/const.py` — `PANEL_VERSION` → `0.4.0` (must match manifest; the workflow refuses to ship otherwise)
- `CHANGELOG.md` — new `## [0.4.0] - 2026-06-22` section

### Changelog (written for upgrades from the last stable, 0.3.0)
The `0.4.0b1` beta work is rolled into the stable section as users would perceive it:

**Added**
- Companion discovery (Settings → Companions)
- Sensor-based tasks (usage/meter + threshold recurrence)
- Exclude devices from problem-sensor sync

**Changed**
- Settings tab split into separate **Problem sensor sync** and **General** cards

The granular `## [0.4.0b1]` section is retained below it, matching the existing pattern (`[0.3.0]` above `[0.3.0b12]…b1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NU64chkCnaGPVEJLfajLrA

---
_Generated by [Claude Code](https://claude.ai/code/session_01NU64chkCnaGPVEJLfajLrA)_