### PR TITLE
ci: opt-in preview release from a PR (artifact, no merge)

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -1,0 +1,130 @@
+name: Preview release (PR build)
+
+# Opt-in, artifact-only "preview release" of the integration from a PR — a build a
+# maintainer can download and install manually to test the PR *without* merging to
+# main, bumping the version, or publishing anything HACS-visible. See RELEASE.md
+# ("Preview releases") and docs/PR_PREVIEW_RELEASE_PLAN.md.
+#
+# Trigger: add the `preview-release` label to the PR (only users with write access
+# can label, so the label itself is a maintainer gate). The job additionally runs in
+# the `preview-release` GitHub Environment, so the repo owner can require an explicit
+# approval there (Settings → Environments → preview-release → Required reviewers).
+
+on:
+  pull_request:
+    types: [labeled, synchronize, reopened]
+
+concurrency:
+  group: preview-release-${{ github.event.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview-release:
+    # Build only when opted in via the label, and only for same-repo PRs — a fork PR
+    # gets no write token, and we never build untrusted code with elevated scope
+    # (no `pull_request_target`). Forks should be reviewed/landed normally instead.
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'preview-release') &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    # Owner-approval hook: configure Required reviewers on this environment to make
+    # each preview build wait for an explicit approval.
+    environment: preview-release
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Build the PR's head exactly (what the tester expects to install), not the
+          # synthetic merge commit.
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Compute synthetic preview version
+        id: ver
+        env:
+          PR: ${{ github.event.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          BASE=$(python3 -c "import json;print(json.load(open('custom_components/home_keeper/manifest.json'))['version'])")
+          SHORT=${HEAD_SHA:0:7}
+          # PEP 440 local version: sorts BELOW any real release of BASE (so it can
+          # never look like "latest"), and encodes the PR + commit for traceability.
+          PREVIEW="${BASE}.dev${PR}+pr${PR}.g${SHORT}"
+          echo "preview=$PREVIEW" >> "$GITHUB_OUTPUT"
+          echo "Preview version: $PREVIEW"
+
+      - name: Stamp the preview version into the manifest (zip only; never committed)
+        env:
+          PREVIEW: ${{ steps.ver.outputs.preview }}
+        run: |
+          python3 - <<'PY'
+          import json, os
+          path = "custom_components/home_keeper/manifest.json"
+          data = json.load(open(path))
+          data["version"] = os.environ["PREVIEW"]
+          json.dump(data, open(path, "w"), indent=2)
+          open(path, "a").write("\n")
+          PY
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install frontend deps
+        run: npm ci --prefix custom_components/home_keeper/frontend
+
+      - name: Build panel JS
+        run: bash ci/build-panel.sh
+
+      - name: Build release zip
+        run: bash ci/build-zip.sh
+
+      - name: Verify release zip
+        run: |
+          if [ ! -f home_keeper.zip ]; then
+            echo "::error::home_keeper.zip not found"
+            exit 1
+          fi
+          echo "home_keeper.zip exists ($(du -h home_keeper.zip | cut -f1))"
+
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: home_keeper-preview-pr${{ github.event.number }}
+          path: home_keeper.zip
+          retention-days: 5
+
+      - name: Sticky comment with install instructions
+        uses: actions/github-script@v7
+        env:
+          PREVIEW: ${{ steps.ver.outputs.preview }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ARTIFACT: home_keeper-preview-pr${{ github.event.number }}
+        with:
+          script: |
+            const marker = '<!-- preview-release -->';
+            const body = [
+              marker,
+              '### 📦 Preview build ready',
+              '',
+              '`' + process.env.PREVIEW + '` — an installable build of **this PR**, not a real release.',
+              '',
+              '**Download:** the `' + process.env.ARTIFACT + '` artifact on [this workflow run](' + process.env.RUN_URL + ').',
+              '',
+              '**Install (manual):**',
+              '1. Unzip into `config/custom_components/home_keeper/` (replace the existing folder).',
+              '2. Restart Home Assistant.',
+              '',
+              '> Ephemeral test build — do not depend on it. Re-download after each push (the artifact expires in 5 days).',
+            ].join('\n');
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -37,6 +37,27 @@ Use a PEP 440 pre-release suffix: `bN` (beta), `aN` (alpha), or `rcN` (e.g.
 a **pre-release**, so HACS offers it only to users who enabled "Show beta versions".
 Cut the final `0.2.0` (with its own `## [0.2.0]` changelog section) when ready.
 
+## Preview releases (test a PR build without merging)
+
+Sometimes you want to **install and try a PR's build** before merging it — without
+bumping the version or publishing anything. Add the **`preview-release`** label to the
+PR and `preview-release.yml` builds the panel + `home_keeper.zip` from the PR head,
+stamps a synthetic version (`X.Y.Z.dev<pr>+pr<pr>.g<sha>`), uploads it as a **workflow
+artifact**, and posts a sticky comment with the download link and manual-install steps
+(unzip into `config/custom_components/home_keeper/`, restart HA).
+
+- **Opt-in only** — nothing happens without the label (and only users with write
+  access can label).
+- **Same-repo PRs only** — fork PRs get no token and are not built this way.
+- **Owner approval** — the job runs in the `preview-release` GitHub Environment; add
+  **Required reviewers** to it (Settings → Environments) to make each build wait for an
+  explicit approval.
+- **No pollution** — no tag, no GitHub Release, nothing HACS-visible; the synthetic
+  `.devN` version sorts below any real release. Artifacts expire after 5 days.
+
+See [docs/PR_PREVIEW_RELEASE_PLAN.md](docs/PR_PREVIEW_RELEASE_PLAN.md) for the full
+design and rationale.
+
 ## Constraints
 
 - **Never push directly to `main`.** All changes go through PRs.

--- a/docs/PR_PREVIEW_RELEASE_PLAN.md
+++ b/docs/PR_PREVIEW_RELEASE_PLAN.md
@@ -1,0 +1,97 @@
+# Preview releases from a PR (without merging to main)
+
+**Status: shipped (Model A).** This documents the design for producing an
+**installable build of the integration from a PR** — testable before merging —
+without bumping the real version, tagging, or publishing anything HACS-visible. It
+mirrors the existing **website PR preview** (`docs-preview.yml` → ephemeral
+`gh-pages/pr-preview/pr-<n>/` + sticky comment) but for the integration zip.
+
+Implemented by [`.github/workflows/preview-release.yml`](../.github/workflows/preview-release.yml).
+
+## What ships (Model A — artifact, manual install)
+
+On an **opted-in** PR, CI builds the panel + `home_keeper.zip` from the PR head,
+stamps a synthetic version into the zip's `manifest.json`, uploads the zip as a
+**workflow artifact**, and posts a **sticky PR comment** with the download link and
+manual-install steps. No tag, no GitHub Release, nothing HACS picks up.
+
+We deliberately chose Model A over a HACS-installable pre-release (Model B) because
+artifact-only delivery has **zero release/version pollution** and no mutable-tag
+caveats — and "let me try this PR's build" is satisfied by a manual drop-in. Model B
+(an ephemeral `preview/pr-<n>` pre-release, or a dedicated preview repo) is recorded
+under "Deferred" for if HACS-native install testing is ever actually needed.
+
+## How it's triggered (opt-in, gated)
+
+- **Label `preview-release`** on the PR (`pull_request` `types: [labeled,
+  synchronize, reopened]`). Only users with **write access can apply labels**, so the
+  label itself is a maintainer gate; pushing more commits to a labelled PR rebuilds.
+- **Same-repo PRs only.** The job's `if:` requires
+  `head.repo.full_name == github.repository`. A fork PR gets no write token, and we
+  refuse to build untrusted code with elevated scope. We do **not** use
+  `pull_request_target` (it would run with the base repo's secrets against PR-authored
+  code — the classic privilege-escalation footgun). Fork contributions are reviewed
+  and landed normally.
+- **Owner approval (optional but recommended).** The job runs in the
+  `preview-release` **GitHub Environment**. Configure **Required reviewers** on it
+  (Settings → Environments → `preview-release`) and every preview build pauses for an
+  explicit approval before running. *This is the one manual setup step — workflow YAML
+  can reference the environment, but the reviewer list is a repo setting.*
+
+## Versioning (no real-version bump, no collisions)
+
+The preview never edits committed files. At build time it computes a **PEP 440 local
+version** and stamps it into the zip's `manifest.json` only:
+
+```
+<base_version>.dev<pr>+pr<pr>.g<short_sha>     e.g. 0.4.0.dev81+pr81.gd1f30f3
+```
+
+- The `.devN` segment sorts **below** any real `0.4.x` release, so an installed
+  preview can never masquerade as "latest" and HACS would never prefer it.
+- The `+pr<n>.g<sha>` local segment ties the build to its PR and commit.
+- It is written in-workflow and **never committed** — the branch's `manifest.json`
+  and `CHANGELOG.md` are untouched, so the strict release gates (changelog entry,
+  `PANEL_VERSION == version`, unique `vX.Y.Z` tag) don't apply.
+
+## Why a separate workflow (not a flag on `release.yml`)
+
+`release.yml` enforces the production release contract (matching changelog +
+`PANEL_VERSION`, unique tag) and only tags/publishes off `main`. Previews live in
+their own `preview-release.yml` so those guarantees stay strict and un-bypassable —
+the preview path can't accidentally publish a real release.
+
+## Cleanup
+
+Artifacts carry `retention-days: 5` and expire on their own; a `concurrency` group
+`preview-release-${{ github.event.number }}` with `cancel-in-progress` supersedes an
+in-flight build when new commits land. The sticky comment is updated in place (one
+comment per PR), so there's nothing to delete on close. (Model B, if added, would also
+need a `closed`-event step to delete its tag/Release — Model A has no such state.)
+
+## Additional considerations (carried from the design review)
+
+- **Security / untrusted code.** Covered by same-repo-only + the label gate + the
+  environment approval; no `pull_request_target`.
+- **Panel build parity.** The preview runs `ci/build-panel.sh` exactly like
+  `release.yml`, so the zip contains the same built `home-keeper-panel.js` a real
+  release would — "works in preview" tracks "works on release".
+- **Discoverability.** Nothing lands in the Releases list or HACS; the artifact is
+  visible only to people who can see the PR's Actions run.
+- **Cost/concurrency.** Bounded by the label gate + `cancel-in-progress`.
+- **Provenance.** Preview artifacts are intentionally **not** signed/attested as
+  production builds; the synthetic `.devN` version and the comment's "do not depend on
+  it" wording keep them clearly non-production.
+
+## Deferred (Model B and beyond)
+
+- **HACS-installable preview** — an ephemeral `prerelease: true` Release tagged
+  `preview/pr-<n>` (a non-`vX.Y.Z` namespace) with the zip attached, plus a
+  `closed`-event cleanup step. Only worth it if testers specifically need the HACS
+  install path; it reintroduces beta-channel visibility and mutable-tag caching
+  caveats.
+- **Dedicated preview repository** that testers add as a HACS custom repo — the
+  cleanest isolation for HACS-native testing, at the cost of standing up and
+  maintaining a second repo.
+- **`/preview-release` PR-comment command** as an alternative trigger to the label
+  (more `issue_comment` plumbing; the label is simpler).


### PR DESCRIPTION
## Summary

Adds an **opt-in "preview release"** so a maintainer can **install and test a PR's build without merging** to `main` — mirroring the website's ephemeral PR preview, but for the integration zip. **Model A** (artifact + manual install), label-triggered.

## How it works

Add the **`preview-release`** label to a PR → `preview-release.yml` builds the panel + `home_keeper.zip` from the PR head, stamps a synthetic version into the zip's `manifest.json`, uploads it as a **workflow artifact**, and posts a sticky comment with the download link + manual-install steps. **No tag, no Release, nothing HACS-visible.**

- **Versioning:** `X.Y.Z.dev<pr>+pr<pr>.g<sha>` (PEP 440 local) — written in-workflow, **never committed**; sorts *below* any real release so it can't masquerade as latest, and the strict release gates don't apply.
- **Separate workflow** from `release.yml` so the production release contract (changelog/`PANEL_VERSION` match, unique tag, main-only) stays strict.

## Security (per the design review)

- **Same-repo PRs only** (`head.repo.full_name == github.repository`) — fork PRs get no token; **no `pull_request_target`** (no building untrusted code with elevated scope).
- **Label gate** — only users with write access can apply labels.
- **Owner approval** — the job runs in a `preview-release` GitHub Environment; add **Required reviewers** to it (Settings → Environments) to make each build wait for explicit approval. *(One-time repo-settings step — referenced by the workflow but configured in the UI.)*

## Docs

- `RELEASE.md` — new "Preview releases" section.
- `docs/PR_PREVIEW_RELEASE_PLAN.md` — full design + rationale (incl. why Model A over a HACS-installable pre-release, which is recorded as deferred).

Docs/CI-only; no integration code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011Sc7dq83KFJd9zxb1HsptT)_