### PR TITLE
ci: switch preview release to a HACS-installable pre-release (Model B)

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -1,69 +1,70 @@
 name: Preview release (PR build)
 
-# Opt-in, artifact-only "preview release" of the integration from a PR — a build a
-# maintainer can download and install manually to test the PR *without* merging to
-# main, bumping the version, or publishing anything HACS-visible. See RELEASE.md
-# ("Preview releases") and docs/PR_PREVIEW_RELEASE_PLAN.md.
+# Opt-in, HACS-installable "preview release" of the integration from a PR — an
+# ephemeral GitHub **pre-release** (zip attached) a maintainer/tester can install via
+# HACS (Show beta versions) to try the PR *without* merging to main or bumping the
+# real version. See RELEASE.md ("Preview releases") and
+# docs/PR_PREVIEW_RELEASE_PLAN.md.
 #
 # Trigger: add the `preview-release` label to the PR (only users with write access
-# can label, so the label itself is a maintainer gate). The job additionally runs in
-# the `preview-release` GitHub Environment, so the repo owner can require an explicit
+# can label, so the label is a maintainer gate). The publish job runs in the
+# `preview-release` GitHub Environment, so the repo owner can require an explicit
 # approval there (Settings → Environments → preview-release → Required reviewers).
+# The pre-release is re-published on each push and **deleted when the PR closes**.
 
 on:
   pull_request:
-    types: [labeled, synchronize, reopened]
+    types: [labeled, synchronize, reopened, closed]
 
 concurrency:
   group: preview-release-${{ github.event.number }}
   cancel-in-progress: true
 
 permissions:
-  contents: read
-  pull-requests: write
+  contents: write       # create/delete the ephemeral pre-release + tag
+  pull-requests: write  # sticky install comment
 
 jobs:
-  preview-release:
-    # Build only when opted in via the label, and only for same-repo PRs — a fork PR
-    # gets no write token, and we never build untrusted code with elevated scope
-    # (no `pull_request_target`). Forks should be reviewed/landed normally instead.
+  publish:
+    # Build + publish only when opted in via the label, on an open PR, and only for
+    # same-repo PRs — a fork gets no token, and we never build untrusted code with
+    # write scope (no `pull_request_target`).
     if: >-
+      github.event.action != 'closed' &&
       contains(github.event.pull_request.labels.*.name, 'preview-release') &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    # Owner-approval hook: configure Required reviewers on this environment to make
-    # each preview build wait for an explicit approval.
     environment: preview-release
     steps:
       - uses: actions/checkout@v4
         with:
-          # Build the PR's head exactly (what the tester expects to install), not the
-          # synthetic merge commit.
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Compute synthetic preview version
+      - name: Compute preview version + tag
         id: ver
         env:
           PR: ${{ github.event.number }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           BASE=$(python3 -c "import json;print(json.load(open('custom_components/home_keeper/manifest.json'))['version'])")
-          SHORT=${HEAD_SHA:0:7}
-          # PEP 440 local version: sorts BELOW any real release of BASE (so it can
-          # never look like "latest"), and encodes the PR + commit for traceability.
-          PREVIEW="${BASE}.dev${PR}+pr${PR}.g${SHORT}"
-          echo "preview=$PREVIEW" >> "$GITHUB_OUTPUT"
-          echo "Preview version: $PREVIEW"
+          # X.Y.Z core of the current manifest version (drop any pre/dev suffix).
+          CORE=$(python3 -c "import re;print(re.match(r'\d+\.\d+\.\d+', '$BASE').group())")
+          # PEP 440 dev release keyed by PR number: a valid version HACS parses as a
+          # beta, unique per PR, and sorting BELOW the X.Y.Z release so it never
+          # nags users as an "update" — it's selectable in HACS, not pushed.
+          VERSION="${CORE}.dev${PR}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Preview version: $VERSION"
 
       - name: Stamp the preview version into the manifest (zip only; never committed)
         env:
-          PREVIEW: ${{ steps.ver.outputs.preview }}
+          VERSION: ${{ steps.ver.outputs.version }}
         run: |
           python3 - <<'PY'
           import json, os
           path = "custom_components/home_keeper/manifest.json"
           data = json.load(open(path))
-          data["version"] = os.environ["PREVIEW"]
+          data["version"] = os.environ["VERSION"]
           json.dump(data, open(path, "w"), indent=2)
           open(path, "a").write("\n")
           PY
@@ -89,42 +90,93 @@ jobs:
           fi
           echo "home_keeper.zip exists ($(du -h home_keeper.zip | cut -f1))"
 
-      - name: Upload preview artifact
-        uses: actions/upload-artifact@v4
+      - name: Replace any previous preview release for this PR
+        uses: actions/github-script@v7
+        env:
+          TAG: ${{ steps.ver.outputs.tag }}
         with:
-          name: home_keeper-preview-pr${{ github.event.number }}
-          path: home_keeper.zip
-          retention-days: 5
+          script: |
+            const { owner, repo } = context.repo;
+            const tag = process.env.TAG;
+            // Delete the prior release (if any) and its tag so the new build's tag
+            // points at the current head commit.
+            try {
+              const rel = await github.rest.repos.getReleaseByTag({ owner, repo, tag });
+              await github.rest.repos.deleteRelease({ owner, repo, release_id: rel.data.id });
+            } catch (e) { if (e.status !== 404) throw e; }
+            try {
+              await github.rest.git.deleteRef({ owner, repo, ref: `tags/${tag}` });
+            } catch (e) { if (e.status !== 404 && e.status !== 422) throw e; }
+
+      - name: Publish ephemeral pre-release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ steps.ver.outputs.tag }}
+          target_commitish: ${{ github.event.pull_request.head.sha }}
+          name: "Preview · PR #${{ github.event.number }} (${{ steps.ver.outputs.version }})"
+          body: |
+            ⚠️ **Ephemeral preview build of #${{ github.event.number }}** — not a real release. It is **deleted when the PR closes**; do not depend on it.
+
+            Built from commit `${{ github.event.pull_request.head.sha }}`.
+
+            **Install via HACS:** open *Home Keeper* → ⋮ → **Redownload**, enable **Show beta versions**, and pick `${{ steps.ver.outputs.version }}`. Or download `home_keeper.zip` below and unzip into `config/custom_components/home_keeper/`.
+          prerelease: true
+          files: home_keeper.zip
 
       - name: Sticky comment with install instructions
         uses: actions/github-script@v7
         env:
-          PREVIEW: ${{ steps.ver.outputs.preview }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          ARTIFACT: home_keeper-preview-pr${{ github.event.number }}
+          VERSION: ${{ steps.ver.outputs.version }}
+          TAG: ${{ steps.ver.outputs.tag }}
         with:
           script: |
             const marker = '<!-- preview-release -->';
+            const { owner, repo } = context.repo;
+            const version = process.env.VERSION;
+            const url = `${context.serverUrl}/${owner}/${repo}/releases/tag/${process.env.TAG}`;
             const body = [
               marker,
-              '### 📦 Preview build ready',
+              '### 📦 Preview release published',
               '',
-              '`' + process.env.PREVIEW + '` — an installable build of **this PR**, not a real release.',
+              '`' + version + '` — an installable **pre-release** of this PR, not a real release.',
               '',
-              '**Download:** the `' + process.env.ARTIFACT + '` artifact on [this workflow run](' + process.env.RUN_URL + ').',
+              '**Install via HACS:** open *Home Keeper* → ⋮ → **Redownload**, enable **Show beta versions**, and pick `' + version + '`. (HACS may need a refresh to see it.)',
               '',
-              '**Install (manual):**',
-              '1. Unzip into `config/custom_components/home_keeper/` (replace the existing folder).',
-              '2. Restart Home Assistant.',
+              'Or grab `home_keeper.zip` from the [release](' + url + ') and unzip into `config/custom_components/home_keeper/`.',
               '',
-              '> Ephemeral test build — do not depend on it. Re-download after each push (the artifact expires in 5 days).',
+              '> Ephemeral — this release is **deleted when the PR closes**, and re-published on each push.',
             ].join('\n');
-            const { owner, repo } = context.repo;
-            const issue_number = context.issue.number;
-            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number: context.issue.number });
             const existing = comments.find((c) => c.body && c.body.includes(marker));
             if (existing) {
               await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
             } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+              await github.rest.issues.createComment({ owner, repo, issue_number: context.issue.number, body });
+            }
+
+  cleanup:
+    # When the PR closes (merged or not), delete its ephemeral pre-release + tag so
+    # nothing lingers in the Releases list or HACS' beta channel.
+    if: >-
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete this PR's preview release + tag
+        uses: actions/github-script@v7
+        env:
+          PR: ${{ github.event.number }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const needle = `Preview · PR #${process.env.PR} (`;
+            const releases = await github.paginate(github.rest.repos.listReleases, { owner, repo, per_page: 100 });
+            for (const rel of releases) {
+              if (rel.name && rel.name.startsWith(needle)) {
+                await github.rest.repos.deleteRelease({ owner, repo, release_id: rel.id });
+                try {
+                  await github.rest.git.deleteRef({ owner, repo, ref: `tags/${rel.tag_name}` });
+                } catch (e) { if (e.status !== 404 && e.status !== 422) throw e; }
+                console.log(`Deleted preview release ${rel.tag_name}`);
+              }
             }

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -39,21 +39,25 @@ Cut the final `0.2.0` (with its own `## [0.2.0]` changelog section) when ready.
 
 ## Preview releases (test a PR build without merging)
 
-Sometimes you want to **install and try a PR's build** before merging it — without
-bumping the version or publishing anything. Add the **`preview-release`** label to the
-PR and `preview-release.yml` builds the panel + `home_keeper.zip` from the PR head,
-stamps a synthetic version (`X.Y.Z.dev<pr>+pr<pr>.g<sha>`), uploads it as a **workflow
-artifact**, and posts a sticky comment with the download link and manual-install steps
-(unzip into `config/custom_components/home_keeper/`, restart HA).
+Sometimes you want to **install and try a PR's build via HACS** before merging it —
+without bumping the version or cutting a real release. Add the **`preview-release`**
+label to the PR and `preview-release.yml` builds the panel + `home_keeper.zip` from the
+PR head, stamps a synthetic version (`X.Y.Z.dev<pr>`) into the zip's manifest, and
+publishes an **ephemeral GitHub pre-release** with the zip attached. Install it from
+HACS: open *Home Keeper* → ⋮ → **Redownload**, enable **Show beta versions**, and pick
+`X.Y.Z.dev<pr>` (or download `home_keeper.zip` from the release and unzip into
+`config/custom_components/home_keeper/`).
 
 - **Opt-in only** — nothing happens without the label (and only users with write
   access can label).
 - **Same-repo PRs only** — fork PRs get no token and are not built this way.
-- **Owner approval** — the job runs in the `preview-release` GitHub Environment; add
-  **Required reviewers** to it (Settings → Environments) to make each build wait for an
-  explicit approval.
-- **No pollution** — no tag, no GitHub Release, nothing HACS-visible; the synthetic
-  `.devN` version sorts below any real release. Artifacts expire after 5 days.
+- **Owner approval** — the publish job runs in the `preview-release` GitHub
+  Environment; add **Required reviewers** to it (Settings → Environments) to make each
+  build wait for an explicit approval.
+- **Ephemeral & low-noise** — it's a **pre-release** (`prerelease: true`), so it's
+  offered only to users who enabled *Show beta versions*; the `.dev<pr>` version sorts
+  *below* the real `X.Y.Z` release so it never nags anyone as an update; it's
+  re-published on each push and **deleted automatically when the PR closes**.
 
 See [docs/PR_PREVIEW_RELEASE_PLAN.md](docs/PR_PREVIEW_RELEASE_PLAN.md) for the full
 design and rationale.

--- a/docs/PR_PREVIEW_RELEASE_PLAN.md
+++ b/docs/PR_PREVIEW_RELEASE_PLAN.md
@@ -1,31 +1,35 @@
 # Preview releases from a PR (without merging to main)
 
-**Status: shipped (Model A).** This documents the design for producing an
-**installable build of the integration from a PR** — testable before merging —
-without bumping the real version, tagging, or publishing anything HACS-visible. It
-mirrors the existing **website PR preview** (`docs-preview.yml` → ephemeral
+**Status: shipped (Model B — HACS-installable pre-release).** This documents the
+design for producing an **installable build of the integration from a PR** — testable
+*through HACS* before merging — without bumping the real version or cutting a real
+release. It mirrors the existing **website PR preview** (`docs-preview.yml` → ephemeral
 `gh-pages/pr-preview/pr-<n>/` + sticky comment) but for the integration zip.
 
 Implemented by [`.github/workflows/preview-release.yml`](../.github/workflows/preview-release.yml).
 
-## What ships (Model A — artifact, manual install)
+## What ships (Model B — ephemeral pre-release, HACS-installable)
 
 On an **opted-in** PR, CI builds the panel + `home_keeper.zip` from the PR head,
-stamps a synthetic version into the zip's `manifest.json`, uploads the zip as a
-**workflow artifact**, and posts a **sticky PR comment** with the download link and
-manual-install steps. No tag, no GitHub Release, nothing HACS picks up.
+stamps a synthetic version into the zip's `manifest.json`, and publishes an **ephemeral
+GitHub pre-release** (`prerelease: true`) with the zip attached, then posts a sticky PR
+comment with install steps. A tester installs it from **HACS** (Home Keeper →
+Redownload → *Show beta versions* → pick the `.dev<pr>` version), or downloads the zip
+from the release for a manual drop-in.
 
-We deliberately chose Model A over a HACS-installable pre-release (Model B) because
-artifact-only delivery has **zero release/version pollution** and no mutable-tag
-caveats — and "let me try this PR's build" is satisfied by a manual drop-in. Model B
-(an ephemeral `preview/pr-<n>` pre-release, or a dedicated preview repo) is recorded
-under "Deferred" for if HACS-native install testing is ever actually needed.
+> An earlier iteration shipped **Model A** (artifact-only, manual install, no release).
+> We switched to Model B so the build is installable through HACS like a normal beta.
+> Model A's trade-off was zero release/version pollution; Model B accepts a *gated,
+> ephemeral, auto-cleaned* footprint in the beta channel to gain the HACS install path
+> (see "Pollution & low-noise" below). The artifact-only approach remains a valid
+> fallback if HACS-channel noise ever becomes a problem.
 
 ## How it's triggered (opt-in, gated)
 
 - **Label `preview-release`** on the PR (`pull_request` `types: [labeled,
-  synchronize, reopened]`). Only users with **write access can apply labels**, so the
-  label itself is a maintainer gate; pushing more commits to a labelled PR rebuilds.
+  synchronize, reopened, closed]`). Only users with **write access can apply labels**,
+  so the label itself is a maintainer gate; pushing more commits to a labelled PR
+  re-publishes, and closing the PR cleans up.
 - **Same-repo PRs only.** The job's `if:` requires
   `head.repo.full_name == github.repository`. A fork PR gets no write token, and we
   refuse to build untrusted code with elevated scope. We do **not** use
@@ -38,20 +42,23 @@ under "Deferred" for if HACS-native install testing is ever actually needed.
   explicit approval before running. *This is the one manual setup step — workflow YAML
   can reference the environment, but the reviewer list is a repo setting.*
 
-## Versioning (no real-version bump, no collisions)
+## Versioning (no real-version bump, HACS-parseable, no collisions)
 
-The preview never edits committed files. At build time it computes a **PEP 440 local
-version** and stamps it into the zip's `manifest.json` only:
+The preview never edits committed files. At build time it computes a version and
+stamps it into the zip's `manifest.json` only, and tags the pre-release `v<version>`:
 
 ```
-<base_version>.dev<pr>+pr<pr>.g<short_sha>     e.g. 0.4.0.dev81+pr81.gd1f30f3
+<x.y.z>.dev<pr>     e.g. 0.4.0.dev81   (tag v0.4.0.dev81)
 ```
 
-- The `.devN` segment sorts **below** any real `0.4.x` release, so an installed
-  preview can never masquerade as "latest" and HACS would never prefer it.
-- The `+pr<n>.g<sha>` local segment ties the build to its PR and commit.
-- It is written in-workflow and **never committed** — the branch's `manifest.json`
-  and `CHANGELOG.md` are untouched, so the strict release gates (changelog entry,
+- A clean **PEP 440 dev release** (no `+local` segment, so HACS/`AwesomeVersion`
+  parses it reliably and treats it as a beta).
+- The `.dev<pr>` segment sorts **below** the `x.y.z` release, so it never appears as
+  an available *upgrade* — it's only **selectable** in HACS' version list (with betas
+  enabled), never pushed at users.
+- Keyed by PR number, so two PRs off the same base never collide.
+- Written in-workflow and **never committed** — the branch's `manifest.json` and
+  `CHANGELOG.md` are untouched, so the strict release gates (changelog entry,
   `PANEL_VERSION == version`, unique `vX.Y.Z` tag) don't apply.
 
 ## Why a separate workflow (not a flag on `release.yml`)
@@ -59,39 +66,45 @@ version** and stamps it into the zip's `manifest.json` only:
 `release.yml` enforces the production release contract (matching changelog +
 `PANEL_VERSION`, unique tag) and only tags/publishes off `main`. Previews live in
 their own `preview-release.yml` so those guarantees stay strict and un-bypassable —
-the preview path can't accidentally publish a real release.
+the preview path can't accidentally publish a real release. (Creating a `v*.dev*` tag
+does not trigger `release.yml`: it's gated on pushes to the `main` *branch*, not tags.)
 
-## Cleanup
+## Cleanup (ephemeral)
 
-Artifacts carry `retention-days: 5` and expire on their own; a `concurrency` group
-`preview-release-${{ github.event.number }}` with `cancel-in-progress` supersedes an
-in-flight build when new commits land. The sticky comment is updated in place (one
-comment per PR), so there's nothing to delete on close. (Model B, if added, would also
-need a `closed`-event step to delete its tag/Release — Model A has no such state.)
+The pre-release is **re-published on each push** (the prior release + tag are deleted
+first so the tag tracks the current head) and **deleted when the PR closes** — a
+`closed`-event `cleanup` job removes any release named `Preview · PR #<n> (…)` and its
+tag, so nothing lingers in the Releases list or HACS' beta channel. A `concurrency`
+group `preview-release-${{ github.event.number }}` with `cancel-in-progress` supersedes
+an in-flight build, and the sticky comment is updated in place (one per PR).
 
 ## Additional considerations (carried from the design review)
 
-- **Security / untrusted code.** Covered by same-repo-only + the label gate + the
-  environment approval; no `pull_request_target`.
+- **Pollution & low-noise.** A pre-release is visible to users with *Show beta
+  versions* enabled. We keep the footprint minimal: `prerelease: true` (off the stable
+  channel), `.dev<pr>` sorting below the real release (never an "update"), the
+  per-push re-publish, and the **auto-delete on close**. If beta-channel noise ever
+  becomes a problem, the artifact-only Model A or a dedicated preview repo are the
+  fallbacks.
+- **Security / untrusted code.** Same-repo-only + the label gate + the environment
+  approval; no `pull_request_target`. Note the publish job needs `contents: write`, so
+  the same-repo/label/approval gates matter more than in an artifact-only build.
 - **Panel build parity.** The preview runs `ci/build-panel.sh` exactly like
   `release.yml`, so the zip contains the same built `home-keeper-panel.js` a real
   release would — "works in preview" tracks "works on release".
-- **Discoverability.** Nothing lands in the Releases list or HACS; the artifact is
-  visible only to people who can see the PR's Actions run.
+- **HACS caching.** HACS may need a manual refresh (or its periodic poll) before a new
+  pre-release appears; the sticky comment notes this.
 - **Cost/concurrency.** Bounded by the label gate + `cancel-in-progress`.
-- **Provenance.** Preview artifacts are intentionally **not** signed/attested as
-  production builds; the synthetic `.devN` version and the comment's "do not depend on
+- **Provenance.** Preview builds are intentionally **not** signed/attested as
+  production releases; `prerelease: true`, the `.dev` version, and the "do not depend on
   it" wording keep them clearly non-production.
 
-## Deferred (Model B and beyond)
+## Deferred (beyond Model B)
 
-- **HACS-installable preview** — an ephemeral `prerelease: true` Release tagged
-  `preview/pr-<n>` (a non-`vX.Y.Z` namespace) with the zip attached, plus a
-  `closed`-event cleanup step. Only worth it if testers specifically need the HACS
-  install path; it reintroduces beta-channel visibility and mutable-tag caching
-  caveats.
 - **Dedicated preview repository** that testers add as a HACS custom repo — the
-  cleanest isolation for HACS-native testing, at the cost of standing up and
-  maintaining a second repo.
+  cleanest isolation (no beta-channel footprint on the main repo at all), at the cost
+  of standing up and maintaining a second repo.
 - **`/preview-release` PR-comment command** as an alternative trigger to the label
   (more `issue_comment` plumbing; the label is simpler).
+- **Artifact-only mode (former Model A)** kept in mind as the fallback if HACS-channel
+  noise is unwelcome.


### PR DESCRIPTION
## Summary

Switches the opt-in PR preview from **Model A** (artifact, manual install) to **Model B** (ephemeral GitHub **pre-release**) so a build can be **installed through HACS** before merging.

## What changes

On a labelled, same-repo PR, `preview-release.yml` now:
- builds the panel + `home_keeper.zip`, stamps a clean **PEP 440 dev version** `X.Y.Z.dev<pr>` into the zip's manifest, and **publishes a pre-release** (`prerelease: true`) tagged `v<version>` with the zip attached;
- **re-publishes on each push** (deletes the prior release + tag so the tag tracks the new head) and **auto-deletes on PR close** (a `closed`-event `cleanup` job);
- posts a sticky comment with **HACS install steps** (Home Keeper → Redownload → *Show beta versions* → pick `X.Y.Z.dev<pr>`).

## Why these choices

- **`.dev<pr>` sorts below the real `X.Y.Z` release**, so it's *selectable* in HACS but never shows as an upgrade — no nagging beta users.
- **`prerelease: true`** keeps it off the stable channel (beta-only), and **auto-cleanup on close** keeps the Releases list / beta channel tidy.
- Clean dev version (no `+local`) so HACS/`AwesomeVersion` parses it reliably.

## Security (unchanged gates, plus write scope)

Same-repo PRs only (no `pull_request_target`), write-access-only **label** gate, and the **`preview-release` Environment** for owner approval. The publish job now needs `contents: write` (to create/delete the release+tag), so those gates matter more — documented.

## Docs

`RELEASE.md` and `docs/PR_PREVIEW_RELEASE_PLAN.md` updated to document Model B and why we switched from artifact-only Model A (which stays recorded as the fallback).

CI-only; no integration code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011Sc7dq83KFJd9zxb1HsptT)_