### PR TITLE
docs: deploy site from stable release tag, not main HEAD

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,12 +1,13 @@
 name: Docs site — deploy
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'website/**'
-      - 'docs/images/**'
-      - '.github/workflows/docs-deploy.yml'
+  # Deploy only when a stable (non-pre-release) GitHub Release is published.
+  # This keeps the live docs pinned to the latest release so users don't see
+  # documentation for unreleased features.
+  release:
+    types: [released]
+  # Keep workflow_dispatch for emergency manual deploys (e.g. urgent typo fix
+  # that shouldn't wait for the next release).
   workflow_dispatch:
 
 # Production publishes to the root of the gh-pages branch. PR previews live under
@@ -21,8 +22,15 @@ concurrency:
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
+    # Skip pre-releases (betas, RCs) — only stable releases update the live docs.
+    # workflow_dispatch always runs so maintainers can deploy a manual fix at any time.
+    if: ${{ !github.event.release.prerelease || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # For release events: check out the exact release tag commit.
+          # For workflow_dispatch: fall back to the default branch HEAD.
+          ref: ${{ github.event.release.tag_name || github.ref }}
 
       - uses: actions/setup-node@v4
         with:
@@ -34,10 +42,17 @@ jobs:
         working-directory: website
         run: npm ci
 
+      - name: Extract version
+        id: version
+        run: |
+          VERSION=$(python3 -c "import json; print(json.load(open('custom_components/home_keeper/manifest.json'))['version'])")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Build
         working-directory: website
         env:
           DOCS_BASE_URL: /ha-home-keeper/
+          DOCS_VERSION: ${{ steps.version.outputs.version }}
         run: npm run build
 
       - name: Deploy to gh-pages

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,9 @@ rules. Keep the rules and `AGENTS.md` consistent with each other.
   not duplicated: `website/scripts/sync-assets.mjs` mirrors `docs/images/` into the
   static tree, so `docs/images/` stays the single home for screenshots and the
   UI-screenshots gate is unchanged. Both run via `npm run sync` (wired into
-  prestart/prebuild/pretypecheck). Production deploys on push to `main`; **every PR
+  prestart/prebuild/pretypecheck). **Production deploys on stable GitHub Release
+  publication** (not on push to `main`) — the live site is always pinned to the
+  latest stable release so users never see docs for unreleased features; **every PR
   gets a live preview** at `pr-preview/pr-<n>/` (see `website/README.md`).
 
 ## Conventions

--- a/website/README.md
+++ b/website/README.md
@@ -49,8 +49,12 @@ harness.
 
 ## Deployment
 
-- **`docs-deploy.yml`** — on push to `main` (touching `website/**` or
-  `docs/images/**`), builds and publishes to the root of the `gh-pages` branch.
+- **`docs-deploy.yml`** — fires when a stable GitHub Release is published (not
+  pre-releases). Checks out the release tag commit, injects `DOCS_VERSION` from
+  `manifest.json`, and publishes to the root of the `gh-pages` branch. The live site
+  is therefore always pinned to the latest stable release — users never see docs for
+  unreleased features. A `workflow_dispatch` trigger is available for emergency manual
+  deploys (e.g. an urgent typo fix that can't wait for the next release).
 - **`docs-preview.yml`** — on pull requests, builds a preview and publishes it under
   `pr-preview/pr-<n>/` on the `gh-pages` branch, posting a sticky comment with the
   preview URL. Previews are torn down when the PR closes.

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -7,6 +7,11 @@ import {themes as prismThemes} from 'prism-react-renderer';
 // DOCS_BASE_URL to keep asset paths correct for each deploy target.
 const baseUrl = process.env.DOCS_BASE_URL ?? '/ha-home-keeper/';
 
+// DOCS_VERSION is injected by docs-deploy.yml from manifest.json so the navbar
+// shows the release the site was built from. Falls back to 'dev' locally and in
+// PR previews.
+const docsVersion = process.env.DOCS_VERSION ?? 'dev';
+
 const organizationName = 'prestomation';
 const projectName = 'ha-home-keeper';
 const repoUrl = `https://github.com/${organizationName}/${projectName}`;
@@ -108,6 +113,13 @@ const config: Config = {
           to: '/docs/release-notes',
           label: 'Release Notes',
           position: 'left',
+        },
+        {
+          label: docsVersion !== 'dev' ? `v${docsVersion}` : 'dev',
+          href: docsVersion !== 'dev'
+            ? `${repoUrl}/releases/tag/v${docsVersion}`
+            : `${repoUrl}/commits/main`,
+          position: 'right',
         },
         {
           href: repoUrl,


### PR DESCRIPTION
## Summary

- **`docs-deploy.yml`** now triggers on `release: types: [released]` instead of `push: branches: [main]`. The live docs site is pinned to the latest stable release — users no longer see documentation for unreleased features.
- Pre-releases (betas, RCs) are explicitly skipped via a job-level `if` guard; `workflow_dispatch` is retained for emergency manual deploys.
- The checkout step is made explicit with `ref: github.event.release.tag_name` so the build always uses the exact release tag commit.
- A **version badge** (`v0.4.0`) is added to the Docusaurus navbar, injected via `DOCS_VERSION` env var from `manifest.json` at build time. It links to the corresponding GitHub Release. Falls back to `dev` in local dev and PR previews.
- `AGENTS.md` and `website/README.md` updated to document the new deploy model.

## How it works

```
PR merged to main
  → release.yml fires
  → Creates git tag vX.Y.Z + GitHub Release (stable only)
  → GitHub fires release:released event
  → docs-deploy.yml checks out the release tag commit
  → Builds docs (with DOCS_VERSION=X.Y.Z injected)
  → Deploys to gh-pages root
```

PR previews (`docs-preview.yml`) are unaffected — contributors still get live doc previews.

## Test plan

- [ ] Confirm `docs-deploy.yml` does NOT fire on a push to `main` that touches `website/`
- [ ] Confirm it DOES fire when a stable GitHub Release is published, and the deployed site reflects the release tag content
- [ ] Confirm a pre-release (`v0.5.0b1`) does NOT trigger a docs deploy
- [ ] Confirm `workflow_dispatch` manual trigger still works
- [ ] Confirm the navbar shows the version badge (e.g. `v0.4.0`) linking to the GitHub Release
- [ ] Confirm the badge shows `dev` in PR previews and local dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138ySncdpdxE6Q8yAj3NoPs

---
_Generated by [Claude Code](https://claude.ai/code/session_0138ySncdpdxE6Q8yAj3NoPs)_