### PR TITLE
fix: two task-management correctness bugs (reconcile + triggered conversion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,17 +34,6 @@ versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas)
   floating task's clock are left untouched). Each fires a `home_keeper_task_snoozed` /
   `home_keeper_task_skipped` event, also available as device-automation triggers.
 
-### Fixed
-
-- **Appliance with multiple wear parts could corrupt a derived task on edit.** When
-  two or more wear-part maintenance tasks existed, renaming (or otherwise editing) one
-  appliance wrote the update to the wrong task's record — dropping a task and leaving a
-  duplicate. The reconciler now updates the correct task.
-- **Converting a scheduled task to a *triggered* (condition-driven) task left a stale
-  due date.** The converted task kept its old schedule date and rendered as "armed" at
-  an arbitrary past/future instant; it now arms immediately like a freshly-created
-  triggered task (matching the existing behaviour when converting to a sensor task).
-
 ## [0.4.0] - 2026-06-22
 
 This release adds **companion discovery** so integrations that work with Home Keeper

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,17 @@ versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas)
   floating task's clock are left untouched). Each fires a `home_keeper_task_snoozed` /
   `home_keeper_task_skipped` event, also available as device-automation triggers.
 
+### Fixed
+
+- **Appliance with multiple wear parts could corrupt a derived task on edit.** When
+  two or more wear-part maintenance tasks existed, renaming (or otherwise editing) one
+  appliance wrote the update to the wrong task's record — dropping a task and leaving a
+  duplicate. The reconciler now updates the correct task.
+- **Converting a scheduled task to a *triggered* (condition-driven) task left a stale
+  due date.** The converted task kept its old schedule date and rendered as "armed" at
+  an arbitrary past/future instant; it now arms immediately like a freshly-created
+  triggered task (matching the existing behaviour when converting to a sensor task).
+
 ## [0.4.0] - 2026-06-22
 
 This release adds **companion discovery** so integrations that work with Home Keeper

--- a/custom_components/home_keeper/models.py
+++ b/custom_components/home_keeper/models.py
@@ -519,9 +519,7 @@ def merge_update(existing: dict, updates: dict, *, now: datetime) -> dict:
     }
     new_type = merged.get("recurrence_type")
     old_type = existing.get("recurrence_type")
-    if new_type not in (REC_TRIGGERED, REC_SENSOR) and (
-        recurrence_keys & set(updates)
-    ):
+    if new_type not in (REC_TRIGGERED, REC_SENSOR) and (recurrence_keys & set(updates)):
         merged["next_due"] = recurrence.compute_next_due(merged, now=now).isoformat()
     elif new_type == REC_SENSOR and old_type != REC_SENSOR:
         # Converting an existing (e.g. floating, due-now) task into a sensor task: it

--- a/custom_components/home_keeper/models.py
+++ b/custom_components/home_keeper/models.py
@@ -517,16 +517,23 @@ def merge_update(existing: dict, updates: dict, *, now: datetime) -> dict:
         "due",
         "sensor",
     }
-    if merged.get("recurrence_type") not in (REC_TRIGGERED, REC_SENSOR) and (
+    new_type = merged.get("recurrence_type")
+    old_type = existing.get("recurrence_type")
+    if new_type not in (REC_TRIGGERED, REC_SENSOR) and (
         recurrence_keys & set(updates)
     ):
         merged["next_due"] = recurrence.compute_next_due(merged, now=now).isoformat()
-    elif (
-        merged.get("recurrence_type") == REC_SENSOR
-        and existing.get("recurrence_type") != REC_SENSOR
-    ):
+    elif new_type == REC_SENSOR and old_type != REC_SENSOR:
         # Converting an existing (e.g. floating, due-now) task into a sensor task: it
         # starts dormant like a freshly-built one, so the watcher arms it only when the
         # bound reading meets the condition (rather than inheriting a stale due date).
         merged["next_due"] = None
+    elif new_type == REC_TRIGGERED and old_type != REC_TRIGGERED:
+        # Converting a scheduled (floating/fixed/one-off) or sensor task into a
+        # condition-driven one: the old next_due is a stale schedule date that has no
+        # meaning for a triggered task — carried verbatim it would render as "armed" at
+        # an arbitrary past/future instant. Reset to the fresh-build state — armed now,
+        # exactly like ``build_task`` creates a triggered task — so the owner can
+        # complete it to dormancy or let it re-arm on the next condition.
+        merged["next_due"] = recurrence.compute_next_due(merged, now=now).isoformat()
     return merged

--- a/custom_components/home_keeper/reconcile.py
+++ b/custom_components/home_keeper/reconcile.py
@@ -150,7 +150,7 @@ def reconcile_part_tasks(
                     merged, now=now
                 ).isoformat()
             if merged is not before:
-                result[tid] = merged
+                result[existing_tid] = merged
                 changed = True
 
     return result, changed

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -580,6 +580,42 @@ def test_merge_update_converts_triggered_to_floating_with_explicit_interval():
     assert merged["unit"] == "months"
 
 
+def test_merge_update_converts_fixed_to_triggered_arms_now_not_stale_date():
+    # Regression: converting a scheduled task to ``triggered`` left ``next_due`` at the
+    # old schedule date. A triggered task's next_due is an armed-now timestamp (or None
+    # when dormant), so a stale future/past date made it render as "armed" at a
+    # meaningless instant. It must reset to the fresh-build state (armed == now), like
+    # ``build_task`` creates a triggered task. The ``-> sensor`` direction already did
+    # this (resetting to None); the ``-> triggered`` direction was missed.
+    task = m.build_task(
+        {
+            "name": "Service boiler",
+            "recurrence_type": "fixed",
+            "freq": "MONTHLY",
+            "interval": 1,
+            "anchor": "2026-12-30T08:00:00",
+        },
+        now=NOW,
+    )
+    assert task["next_due"] != NOW.isoformat()  # a real future schedule date
+    merged = m.merge_update(task, {"recurrence_type": "triggered"}, now=NOW)
+    assert merged["recurrence_type"] == "triggered"
+    assert merged["next_due"] == NOW.isoformat()  # armed now, not the stale Dec date
+
+
+def test_merge_update_converts_floating_to_triggered_arms_now():
+    task = m.build_task(
+        {"name": "Replace filter", "recurrence_type": "floating", "unit": "months"},
+        now=NOW,
+    )
+    # Pretend it was completed so next_due sits a real interval in the future.
+    future = datetime(2026, 9, 24, 12, tzinfo=TZ).isoformat()
+    task["next_due"] = future
+    merged = m.merge_update(task, {"recurrence_type": "triggered"}, now=NOW)
+    assert merged["recurrence_type"] == "triggered"
+    assert merged["next_due"] == NOW.isoformat()
+
+
 def test_build_one_off_task_uses_due_date_and_no_schedule_fields():
     due = datetime(2026, 7, 1, 8, tzinfo=TZ)
     task = m.build_task(

--- a/tests/unit/test_reconcile.py
+++ b/tests/unit/test_reconcile.py
@@ -165,6 +165,29 @@ def test_changing_replace_unit_updates_task():
     assert changed is True and _only(tasks)["unit"] == "weeks"
 
 
+def test_updating_one_of_several_part_tasks_writes_to_the_right_task():
+    # Regression: the update branch wrote ``result[tid]`` using a stale loop variable
+    # left over from the orphan/index loops instead of ``existing_tid``. With two or
+    # more part-tasks present, renaming a non-last one corrupted a *different* task's
+    # slot (the rename landed on the wrong id, dropping a task entirely).
+    a1 = _asset(aid="a1", name="Heater", parts=[_wear_part(pid="p1")])
+    a2 = _asset(aid="a2", name="Boiler", parts=[_wear_part(pid="p2")])
+    created, _ = _reconcile({"a1": a1, "a2": a2})
+    assert len(created) == 2
+
+    # Rename only the first asset; the second is untouched.
+    a1_renamed = _asset(aid="a1", name="HeaterRENAMED", parts=[_wear_part(pid="p1")])
+    tasks, changed = _reconcile({"a1": a1_renamed, "a2": a2}, created)
+
+    assert changed is True
+    # Both tasks survive, each still keyed to its own part, with names applied to the
+    # correct task (no cross-contamination).
+    by_asset = {t["source"]["part"]["asset_id"]: t for t in tasks.values()}
+    assert set(by_asset) == {"a1", "a2"}
+    assert by_asset["a1"]["name"] == "Replace Anode (HeaterRENAMED)"
+    assert by_asset["a2"]["name"] == "Replace Anode (Boiler)"
+
+
 # ── timezone healing vs. real completions ─────────────────────────────────────
 def test_heals_legacy_naive_last_completed():
     # Simulate a task persisted by an older build: naive last_completed/next_due.


### PR DESCRIPTION
## Summary

A focused correctness-bug review of Home Keeper's pure task logic surfaced **two genuine bugs**, each fixed with a **red/green** unit test (verified failing on the old code, passing on the new). No UI surfaces are touched, so the screenshot gate doesn't apply.

### Bug 1 — wear-part reconciler corrupts a task when several exist (high confidence)

`reconcile.reconcile_part_tasks` updated an existing part-derived task with `result[tid] = merged`, but `tid` is a **stale loop variable** left over from the earlier orphan/index loops — the update loop's own key is `existing_tid`. With **two or more** wear-part tasks, editing a non-last appliance (e.g. a rename) wrote the merged update into a *different* task's slot, dropping one task and duplicating another.

```
before fix: renaming appliance a1 → both tasks end up keyed to a1/p1; a2's task lost
```

Fix: write to `result[existing_tid]`. Regression test: `test_updating_one_of_several_part_tasks_writes_to_the_right_task`.

### Bug 2 — converting a scheduled task to *triggered* leaves a stale due date (medium confidence)

`models.merge_update` recomputes `next_due` for schedule edits and resets it to `None` when converting **to a sensor** task — but had no branch for converting **to a triggered** task. So a `floating`/`fixed`/`one-off` task converted via the `home_keeper.update_task` service kept its **old schedule date** as `next_due`, rendering as "armed" at an arbitrary past/future instant (e.g. a fixed task due Dec 30 stayed "armed" on Dec 30).

A freshly-built triggered task is *armed now* (`build_task` → `compute_next_due` → `now`). The fix makes the conversion match: reset `next_due` to the fresh-build state. Regression tests: `test_merge_update_converts_fixed_to_triggered_arms_now_not_stale_date`, `test_merge_update_converts_floating_to_triggered_arms_now`.

## Testing

- `pytest tests/unit` — **367 passed** (was 365 + 4 new assertions across 3 new tests).
- Each fix confirmed red on the pre-fix code and green after.

## Scope / what was reviewed

Reviewed the pure, unit-testable core (`recurrence`, `models`, `reconcile`, `transitions`, `events`, `assets`, `sensor_tasks`, `inventory`, `profiles`, `notifications`, `companions_catalog`) plus the storage/coordinator/watcher/notifier/devices layers. Everything else traced as correct; these two were the actionable correctness defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014f2XFpZtZa4vSbLiHGD8Zs)_