### PR TITLE
Fix: open uploaded documents on the current host, not HA's LAN URL

### DIFF
--- a/custom_components/home_keeper/frontend/src/panel.ts
+++ b/custom_components/home_keeper/frontend/src/panel.ts
@@ -2244,7 +2244,13 @@ export class HomeKeeperPanel extends HTMLElement {
   private async _openFileDocument(assetId: string, documentId: string): Promise<void> {
     if (!this._hass) return;
     try {
-      const url = await api.signDocumentUrl(this._hass, assetId, documentId);
+      const path = await api.signDocumentUrl(this._hass, assetId, documentId);
+      // `signDocumentUrl` returns a host-less, signed path (e.g. `/api/.../?authSig=`).
+      // Resolve it against the origin the panel is *actually* loaded from rather than
+      // letting the browser resolve the relative path against the document base — the
+      // latter can yield Home Assistant's internal/LAN URL when you're browsing through
+      // a remote/external address, opening the file on the wrong (unreachable) host.
+      const url = new URL(path, window.location.origin).href;
       window.open(url, '_blank', 'noopener');
     } catch {
       // Best-effort: a failed signing (e.g. deleted file) simply doesn't open.


### PR DESCRIPTION
Follow-up bug fix to the offline-manuals feature (#79 / #87), reported in testing.

## Symptom
A user uploaded a document on their LAN, then — **browsing Home Assistant through a remote/external address** — clicked the file and it opened the **LAN URL** instead, which is unreachable from outside.

## Cause
`home_keeper/sign_document_url` (via HA's `async_sign_path`) returns a **host-less, signed path** like `/api/home_keeper/document/<asset>/<doc>?authSig=…`. The panel opened it with `window.open(path)`, and the browser resolves a relative URL against the **document base URL** — which can resolve to Home Assistant's internal/LAN address. So the file opened on the wrong host when you weren't on that network.

## Fix
Resolve the signed path against **`window.location.origin`** — the address the panel is actually loaded from — before opening it:

```ts
const path = await api.signDocumentUrl(this._hass, assetId, documentId);
const url = new URL(path, window.location.origin).href; // current host, base-immune
window.open(url, '_blank', 'noopener');
```

One method changed (`_openFileDocument`), 7 lines. The signed path and its auth are unchanged; only the host it opens on is corrected.

## Verification
e2e: with a deliberately misleading `<base href="http://10.99.99.99:1234/">` injected, `new URL(path, window.location.origin)` still resolves to the current host (`localhost:8123`, **not** the fake host), and the real click flow opens the file on the current origin with the signed query intact. `tsc` + 184 vitest pass.

No visible-surface change (the documents editor/detail look identical; only the opened URL's host differs), so no new screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ag7g5tNZbgJSVdx8CEwxJt)_