### PR TITLE
chore: bump to 0.5.0b1 and document beta versioning convention

### DIFF
--- a/.amazonq/rules/testing-and-workflow.md
+++ b/.amazonq/rules/testing-and-workflow.md
@@ -57,6 +57,12 @@ gate); CI publishes it to the job summary.
   bumps `const.py` `PANEL_VERSION` to match, and adds a `## [X.Y.Z]`
   `CHANGELOG.md` section. PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) ship as
   GitHub pre-releases → HACS beta channel.
+- **Beta versioning — always use the next release number.** After every stable
+  `X.Y.0` ships, immediately bump `manifest.json` and `const.py` to `X.(Y+1).0b1`
+  on `main`, and rename the `## [Unreleased]` CHANGELOG section to
+  `## [X.(Y+1).0b1]`. Beta iterations go `b1 → b2 → …`. Never cut `X.Y.0bN`
+  betas after `X.Y.0` has shipped — PEP 440 sorts them below stable, causing HACS
+  to offer the stable as an "upgrade" to beta users.
 - The built `home-keeper-panel.js` is gitignored; CI builds it.
 
 ## Typing (strict-typing gate — Platinum)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,13 @@
   introduced over the betas is **Added** (even if a later beta changed how it worked
   mid-stream); don't carry beta-to-beta framing — e.g. a `### Changed` for something
   that didn't exist in the last stable — into the stable section.
+- **Beta versioning — always use the next release number.** After every stable
+  `X.Y.0` ships, immediately bump `manifest.json` and `const.py` (`PANEL_VERSION`)
+  to `X.(Y+1).0b1` on `main`, and rename the `## [Unreleased]` CHANGELOG section to
+  `## [X.(Y+1).0b1]`. Beta iterations go `b1 → b2 → …` until the stable
+  `X.(Y+1).0` is cut. **Never use `X.Y.0bN` after `X.Y.0` has shipped** — PEP 440
+  sorts those below the stable version, so HACS would offer the stable as an
+  "upgrade" to anyone on the beta, which feels like a downgrade.
 - **Always run tests locally before pushing.** Never use CI as the test runner.
   - Pure-logic unit tests need only `pip install pytest`: `pytest tests/unit -v`.
   - Full unit suite uses `pip install pytest-homeassistant-custom-component`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Home Keeper are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas).
 
-## [Unreleased]
+## [0.5.0b1]
 
 ### Added
 

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.4.0"
+PANEL_VERSION = "0.5.0b1"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -15,5 +15,5 @@
   "issue_tracker": "https://github.com/prestomation/ha-home-keeper/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "0.4.0"
+  "version": "0.5.0b1"
 }


### PR DESCRIPTION
## Summary

- **Root cause fixed**: `0.4.0bN < 0.4.0` in PEP 440, so HACS offered `0.4.0` as an "upgrade" to anyone on a `0.4.0b*` beta — which felt like a downgrade since the beta was already ahead. Betas must be pre-releases of the *next* version so they sort above the current stable.
- Bumped `manifest.json` and `const.py` from `0.4.0` → `0.5.0b1`
- Renamed `## [Unreleased]` → `## [0.5.0b1]` in CHANGELOG so `release.yml` validation passes when `0.5.0b1` is tagged
- Added explicit rule to `AGENTS.md` and `.amazonq/rules/testing-and-workflow.md`: after every stable `X.Y.0` ships, immediately bump to `X.(Y+1).0b1` and rename the CHANGELOG section

## Going forward

The process is now:
1. Cut `0.5.0b1` → `0.5.0b2` → … (each sorts above `0.4.0`, no HACS nag)
2. When ready, cut stable `0.5.0` — rename `## [0.5.0b1]` → `## [0.5.0]` in CHANGELOG, set a date, write stable release notes
3. Immediately after, bump to `0.6.0b1` on `main`

## Test plan

- [ ] CI passes (no version mismatch — `release.yml` validates `manifest.json` == `const.py` PANEL_VERSION and that `## [0.5.0b1]` exists in CHANGELOG)
- [ ] `release.yml` would correctly mark a `0.5.0b1` GitHub release as `prerelease: true`

---
_Generated by [Claude Code](https://claude.ai/code/session_01PYmokvrqjkF3niJBDiUU4v)_