### PR TITLE
release: 0.5.0 stable (documents, profiles, notifications, snooze/skip)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,16 @@ All notable changes to Home Keeper are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas).
 
-## [0.5.0b1]
+## [0.6.0b1]
+
+## [0.5.0] - 2026-06-26
+
+This release adds **offline manuals & documents** so appliance files are available
+even when a manufacturer's site isn't, **profiles** as named, reusable task filters
+you define once and use everywhere, **actionable mobile notifications** so each
+household member can complete, snooze, or skip tasks right from their phone, and
+standalone **snooze** and **skip** services for any automation. Highlights, for
+anyone upgrading from 0.4.0:
 
 ### Added
 

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.5.0b1"
+PANEL_VERSION = "0.5.0"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -15,5 +15,5 @@
   "issue_tracker": "https://github.com/prestomation/ha-home-keeper/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "0.5.0b1"
+  "version": "0.5.0"
 }


### PR DESCRIPTION
## Summary

Cuts the **0.5.0 stable release** from `0.5.0b1`.

- Bumps `manifest.json` and `const.py` `PANEL_VERSION` from `0.5.0b1` → `0.5.0`
- Renames `## [0.5.0b1]` in `CHANGELOG.md` → `## [0.5.0] - 2026-06-26` and adds the upgrade intro paragraph for users coming from 0.4.0
- Adds an empty `## [0.6.0b1]` section to `CHANGELOG.md` for the next development cycle (the follow-up PR will bump manifest/const to `0.6.0b1`)

### What's in 0.5.0 (since 0.4.0)

- **Offline manuals & documents** — per-appliance file/link library with authenticated serving; migrates existing `manual_url` automatically
- **Profiles** — named, reusable task filters consumed by notifications, the panel filter dropdown, and the Lovelace card
- **Actionable notifications** — mobile push with Mark done / Snooze / Skip buttons; walk and digest styles; auto-send on overdue/due-soon
- **Snooze and skip** — standalone `home_keeper.snooze_task` / `home_keeper.skip_task` services + device-automation triggers

### After merge

Once CI creates the `v0.5.0` GitHub Release, open a follow-up PR to bump `manifest.json` and `const.py` to `0.6.0b1` — the `## [0.6.0b1]` CHANGELOG section is already in place.

## Test plan

- [ ] Confirm `manifest.json` version is `0.5.0`
- [ ] Confirm `const.py` `PANEL_VERSION` is `"0.5.0"`
- [ ] Confirm `CHANGELOG.md` has `## [0.5.0] - 2026-06-26` with full notes and intro paragraph
- [ ] Confirm `CHANGELOG.md` has empty `## [0.6.0b1]` section above it
- [ ] After merge: verify CI creates `v0.5.0` stable GitHub Release (not pre-release) with correct changelog body and `home_keeper.zip` attached

---
_Generated by [Claude Code](https://claude.ai/code/session_015PQsCsvzGDb5qCz5qWXyn3)_