### PR TITLE
chore: bump to 0.6.0b1 after 0.5.0 stable

### DIFF
--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.5.0"
+PANEL_VERSION = "0.6.0b1"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -15,5 +15,5 @@
   "issue_tracker": "https://github.com/prestomation/ha-home-keeper/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "0.5.0"
+  "version": "0.6.0b1"
 }


### PR DESCRIPTION
Post-release version bump following the 0.5.0 stable release (#91).

- `manifest.json`: `0.5.0` → `0.6.0b1`
- `const.py` `PANEL_VERSION`: `"0.5.0"` → `"0.6.0b1"`

The `## [0.6.0b1]` CHANGELOG section was already added in #91, so CI will find the matching entry and publish this as a GitHub pre-release (beta channel only) on merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_015PQsCsvzGDb5qCz5qWXyn3)_