### PR TITLE
chore: release 0.6.0b3 (panel clarity pass)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,22 +4,7 @@ All notable changes to Home Keeper are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas).
 
-## [0.6.0b2]
-
-### Added
-
-- **Link a task to a consumable (sensor-driven reorder).** Any task can now be
-  **linked to an appliance consumable** so that marking it done **consumes one spare**
-  from the part's stock — and fires `home_keeper_part_low_stock` when you cross the
-  reorder threshold, so an automation can add it to your shopping list. Pair it with a
-  **sensor-based** task to cover the *"there's no schedule — my fridge tells me when the
-  water filter is spent"* case: the sensor arms the task, and completing it (when you
-  swap the filter) draws down inventory and signals **buy more**. Link from the task
-  form's new **Linked consumable** picker — scoped to the consumables of the appliance
-  the task is attached to — or with the new
-  **`home_keeper.set_task_consumable`** service (omit the ids to unlink). The link is
-  independent of the auto-generated wear-part tasks, so it's never reconciled away and
-  the task stays fully editable.
+## [0.6.0b3]
 
 ### Changed
 
@@ -43,6 +28,23 @@ versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas)
     appliance editor's advanced **Custom fields** and **Parts & wear items** sections
     **collapse by default** on an empty appliance (and remember your choice while
     editing), so adding a first appliance isn't a wall of fields.
+
+## [0.6.0b2]
+
+### Added
+
+- **Link a task to a consumable (sensor-driven reorder).** Any task can now be
+  **linked to an appliance consumable** so that marking it done **consumes one spare**
+  from the part's stock — and fires `home_keeper_part_low_stock` when you cross the
+  reorder threshold, so an automation can add it to your shopping list. Pair it with a
+  **sensor-based** task to cover the *"there's no schedule — my fridge tells me when the
+  water filter is spent"* case: the sensor arms the task, and completing it (when you
+  swap the filter) draws down inventory and signals **buy more**. Link from the task
+  form's new **Linked consumable** picker — scoped to the consumables of the appliance
+  the task is attached to — or with the new
+  **`home_keeper.set_task_consumable`** service (omit the ids to unlink). The link is
+  independent of the auto-generated wear-part tasks, so it's never reconciled away and
+  the task stays fully editable.
 
 ## [0.6.0b1]
 

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.6.0b2"
+PANEL_VERSION = "0.6.0b3"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -15,5 +15,5 @@
   "issue_tracker": "https://github.com/prestomation/ha-home-keeper/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "0.6.0b2"
+  "version": "0.6.0b3"
 }


### PR DESCRIPTION
Cuts the **0.6.0b3** beta release to ship the panel clarity pass that was merged in PR #98 but missed the `v0.6.0b2` tag.

## Background

PR #97 (consumable link) bumped the version to `0.6.0b2` and was tagged `v0.6.0b2` when it merged. PR #98 (panel clarity pass) landed on `main` afterwards — same version string, so the release workflow skipped it silently (`tag already exists`). The clarity-pass work has been live on `main` but was never actually shipped in a release.

## Changes

- **`CHANGELOG.md`** — split the combined `[0.6.0b2]` section: consumable-link stays under `[0.6.0b2]` (matching the already-published release), panel clarity pass moves into a new `[0.6.0b3]` section.
- **`manifest.json`** — version → `0.6.0b3`
- **`const.py`** — `PANEL_VERSION` → `"0.6.0b3"`

Merging triggers `release.yml` which will tag `v0.6.0b3` and publish a GitHub pre-release (HACS beta channel).

---
_Generated by [Claude Code](https://claude.ai/code/session_01AW8fxDYc1wuZpw3MbufMoK)_