### PR TITLE
release: 0.6.0 stable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,10 @@
   roll the beta work into Added/Changed/Fixed as they'd perceive it. A feature
   introduced over the betas is **Added** (even if a later beta changed how it worked
   mid-stream); don't carry beta-to-beta framing — e.g. a `### Changed` for something
-  that didn't exist in the last stable — into the stable section.
+  that didn't exist in the last stable — into the stable section. **Include a `###
+  Fixed` section listing every GitHub issue closed by commits since the last stable**
+  — check the git log for `(Fixes #N)` / `(#N)` references and link each issue number
+  so they auto-close on merge (`Fixes #N` in the CHANGELOG entry).
 - **Beta versioning — always use the next release number.** After every stable
   `X.Y.0` ships, immediately bump `manifest.json` and `const.py` (`PANEL_VERSION`)
   to `X.(Y+1).0b1` on `main`, and rename the `## [Unreleased]` CHANGELOG section to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,70 @@ All notable changes to Home Keeper are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas).
 
+## [0.6.0] - 2026-06-29
+
+This release adds **consumable linking** so completing a task (e.g. swapping a water
+filter) automatically draws down your spare stock and fires a reorder alert,
+**appliance document shortcuts** directly on dashboard card rows so a manual or parts
+page is one tap away, and a round of **panel clarity improvements** that make the task
+list easier to read at a glance. Highlights, for anyone upgrading from 0.5.0:
+
+### Added
+
+- **Link a task to a consumable (sensor-driven reorder).** Any task can now be
+  **linked to an appliance consumable** so that marking it done **consumes one spare**
+  from the part's stock — and fires `home_keeper_part_low_stock` when you cross the
+  reorder threshold, so an automation can add it to your shopping list. Pair it with a
+  **sensor-based** task to cover the *"there's no schedule — my fridge tells me when
+  the water filter is spent"* case: the sensor arms the task, and completing it (when
+  you swap the filter) draws down inventory and signals **buy more**. Link from the
+  task form's new **Linked consumable** picker — scoped to the consumables of the
+  appliance the task is attached to — or with the new
+  **`home_keeper.set_task_consumable`** service (omit the ids to unlink).
+
+- **Show appliance documents on a task's dashboard-card row.** Each task can now pick
+  which of its appliance's documents to surface directly on the
+  [dashboard task card](README.md#dashboard-task-card): external **document links**,
+  **uploaded files** (a PDF manual, a photo), and free-form **metadata links** (e.g. a
+  reorder or warranty page). Choose them in the panel's task editor under **Links to
+  show on card** (the picker appears once the task's appliance has documents); the card
+  renders each as a compact chip on the task's row — a link or file opens in a new tab
+  (an uploaded file via a short-lived signed URL) — so a manual or parts page is one
+  tap away while you work. The selection rides the existing `home_keeper.add_task` /
+  `update_task` services (`card_links`), and entries resolve live — rename or remove
+  one on the appliance and the card follows.
+
+### Changed
+
+- **Panel clarity improvements for first-time users.** Several refinements make the
+  task list easier to read at a glance: a dismissible **"Welcome to Home Keeper"**
+  banner on the Tasks tab explains the kinds of tasks you'll see; the recurrence
+  picker now uses **plain language** ("Repeats after each completion", "Repeats on a
+  fixed schedule", "Just once", "Based on a sensor") instead of internal jargon;
+  overdue tasks show **how overdue** they are (e.g. "3 days overdue"); monitored tasks
+  are labelled simply **"Monitored"** and a completion-blocked task shows a muted
+  **"Clears automatically"** caption; sensor-synced tasks owned by Home Keeper show an
+  **"Auto-synced"** chip; and the appliance editor's **Custom fields** and
+  **Parts & wear items** sections collapse by default on a new appliance so first
+  setup isn't a wall of fields.
+
+- **Tapping a task row on the dashboard card no longer opens an edit form.** The card
+  is now a focused do-and-glance surface: one-tap **Done**, add via the header **+**,
+  and link chips — while editing and deleting move to the sidebar panel, where the
+  full task editor lives.
+
+### Fixed
+
+- **The dashboard card and panel now reliably refresh after an update.** Their module
+  URLs are cache-busted by the bundle's **content hash** instead of the integration
+  version, so a rebuilt frontend always loads fresh — no more stale card (or "card
+  configuration error" in the mobile app) after upgrading, including across preview
+  builds that reuse a version string.
+- **Uploaded file documents on the card now open in the mobile app.** A pinned file
+  chip is now a plain link with its URL pre-signed when the card loads, so a tap opens
+  it natively — the Home Assistant companion app (iOS/WKWebView) was silently blocking
+  the previous open-on-tap.
+
 ## [0.6.0b4]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,13 @@ list easier to read at a glance. Highlights, for anyone upgrading from 0.5.0:
   chip is now a plain link with its URL pre-signed when the card loads, so a tap opens
   it natively — the Home Assistant companion app (iOS/WKWebView) was silently blocking
   the previous open-on-tap.
+- **Back navigation from a cross-view detail page now returns to the correct previous
+  page.** Navigating Appliance → device → related Task and pressing Back used to jump
+  to the top-level Tasks tab instead of back to the appliance/device view. (Fixes #105)
+- **Problem Sensor Sync no longer leaves stale entities after disabling or excluding.**
+  Disabling the sync, or adding a device/entity/label exclusion, now removes the
+  `next_due` sensor and `overdue` binary sensor that were created for the synced task —
+  they no longer linger on the device after the task is gone. (Fixes #104)
 
 ## [0.6.0b4]
 

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.6.0b4"
+PANEL_VERSION = "0.6.0"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -15,5 +15,5 @@
   "issue_tracker": "https://github.com/prestomation/ha-home-keeper/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "0.6.0b4"
+  "version": "0.6.0"
 }


### PR DESCRIPTION
Cuts the 0.6.0 stable release from `0.6.0b4`.

## Changes

- `manifest.json`: `0.6.0b4` → `0.6.0`
- `const.py` (`PANEL_VERSION`): `0.6.0b4` → `0.6.0`
- `CHANGELOG.md`: adds `## [0.6.0] - 2026-06-29` section rolling up all beta work (b1–b4) into Added/Changed/Fixed for someone upgrading from 0.5.0

## What's in 0.6.0

### Added
- **Consumable linking (`home_keeper.set_task_consumable`)** — completing a task consumes a spare from stock and fires `home_keeper_part_low_stock` at the reorder threshold; pairs naturally with sensor-based tasks (swap filter → draw down inventory → signal buy more).
- **Appliance document chips on dashboard card rows** — each task can expose its appliance's document links, uploaded files, and metadata links as compact chips; configured via `card_links` on `add_task`/`update_task`.

### Changed
- **Panel clarity pass** — welcome banner, plain-language recurrence picker, overdue-age labels, simplified Monitored/Auto-synced chips, collapsible appliance editor sections.
- **Card row tap no longer opens edit form** — card is now a focused do-and-glance surface; editing moves to the panel.

### Fixed
- Dashboard card and panel cache-busted by content hash (no more stale card after upgrade).
- Uploaded file chips now open natively in the iOS companion app.

## Post-merge follow-up

After this merges and the CI release ships, bump `main` to `0.7.0b1` per the beta versioning convention.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWJgfKjvc7m7ED3bESCuqB)_