### PR TITLE
chore: bump to 0.7.0b1 after 0.6.0 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Home Keeper are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas).
 
+## [0.7.0b1]
+
 ## [0.6.0] - 2026-06-29
 
 This release adds **consumable linking** so completing a task (e.g. swapping a water

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.6.0"
+PANEL_VERSION = "0.7.0b1"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -15,5 +15,5 @@
   "issue_tracker": "https://github.com/prestomation/ha-home-keeper/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "0.6.0"
+  "version": "0.7.0b1"
 }


### PR DESCRIPTION
Post-release version bump per the beta versioning convention in AGENTS.md.

## Changes

- `manifest.json`: `0.6.0` → `0.7.0b1`
- `const.py` (`PANEL_VERSION`): `0.6.0` → `0.7.0b1`
- `CHANGELOG.md`: adds empty `## [0.7.0b1]` section for future work

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWJgfKjvc7m7ED3bESCuqB)_