### PR TITLE
fix: clean up orphaned devices after Problem Sensor Sync disable/exclude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Home Keeper are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas).
 
+## [0.7.0b3]
+
+### Fixed
+
+- **Problem Sensor Sync no longer leaves empty device cards behind.** When you
+  disable Problem Sensor Sync — or exclude an individual sensor, device, area, or
+  label — the synced task and its entities are removed as before, and now the
+  associated device is cleaned up too: a device Home Keeper created for the synced
+  task is removed outright, and a device owned by another integration simply loses
+  its (now entity-less) Home Keeper association. No more orphaned, zero-entity
+  Home Keeper devices under **Settings → Devices & Services → Home Keeper**.
+
 ## [0.7.0b2]
 
 ### Added

--- a/custom_components/home_keeper/__init__.py
+++ b/custom_components/home_keeper/__init__.py
@@ -384,6 +384,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     manuals.async_register_http(hass)
     websocket_api.async_register(hass)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    # Platforms have removed entities for deleted/excluded tasks; drop Home Keeper
+    # from any device that no longer carries one of our entities so disabling Problem
+    # Sensor Sync (or an exclusion) leaves no empty device card behind.
+    await devices.async_prune_orphaned_devices(hass, entry)
 
     _register_services(hass)
     # Now that the register_companion service exists, ask companions to (re-)announce

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.7.0b2"
+PANEL_VERSION = "0.7.0b3"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/devices.py
+++ b/custom_components/home_keeper/devices.py
@@ -20,6 +20,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import area_registry as ar
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
 
 from . import assets as asset_model
 from .const import (
@@ -145,6 +146,42 @@ async def async_reconcile_assets(
         ):
             _LOGGER.debug("Removing orphaned asset device %s", device.id)
             registry.async_remove_device(device.id)
+
+
+async def async_prune_orphaned_devices(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Drop Home Keeper from devices that no longer carry any of our entities.
+
+    Per-task entities (``sensor.*_next_due``, ``binary_sensor.*_overdue``) attach to
+    the task's device — an existing/shared device, or a self-owned device we create
+    when the task has none. When the task goes away (Problem Sensor Sync disabled, an
+    entity/device/area/label excluded, or an ordinary delete) the platforms remove
+    those entities, but Home Assistant keeps the device/association — so the device
+    lingers under **Settings → Devices & Services → Home Keeper** with zero entities.
+
+    Call this *after* ``async_forward_entry_setups`` so the entity registry already
+    reflects the current set, then drop our config-entry link from any non-asset
+    device we no longer have an entity on. ``async_update_device`` removes a
+    self-owned device outright (we were its last config entry) and merely detaches us
+    from a shared device (its real owner keeps it). Virtual asset devices may be
+    legitimately entity-less and are reconciled by ``async_reconcile_assets``, so
+    they are skipped here.
+    """
+    dev_reg = dr.async_get(hass)
+    ent_reg = er.async_get(hass)
+    for device in list(dr.async_entries_for_config_entry(dev_reg, entry.entry_id)):
+        if _is_asset_device(device):
+            continue
+        has_our_entity = any(
+            entity.config_entry_id == entry.entry_id
+            for entity in er.async_entries_for_device(
+                ent_reg, device.id, include_disabled_entities=True
+            )
+        )
+        if not has_our_entity:
+            _LOGGER.debug("Pruning Home Keeper from orphaned device %s", device.id)
+            dev_reg.async_update_device(
+                device.id, remove_config_entry_id=entry.entry_id
+            )
 
 
 async def _reconcile_virtual(

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -15,5 +15,5 @@
   "issue_tracker": "https://github.com/prestomation/ha-home-keeper/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "0.7.0b2"
+  "version": "0.7.0b3"
 }

--- a/tests/integration/test_device_cleanup.py
+++ b/tests/integration/test_device_cleanup.py
@@ -1,0 +1,122 @@
+"""Integration test: orphaned device cleanup after a synced/attached task is removed.
+
+When Problem Sensor Sync is disabled (or a sensor/device/area/label is excluded), or
+when an ordinary device-attached task is deleted, the config entry reloads and the
+per-task entities are removed (covered by ``test_entity_cleanup.py``). This test
+covers the *device* side of the same scenario: ``async_setup_entry`` must also drop
+Home Keeper from any device that no longer carries one of our entities, so no empty
+zero-entity device card lingers under **Settings → Devices & Services → Home Keeper**.
+
+The deterministic case exercised here is a **self-owned** Home Keeper device: a task
+with a ``device_id`` that resolves to no real device gets a self-owned device keyed on
+``(home_keeper, task_id)``. Deleting the task must remove that device entirely (Home
+Keeper was its only config entry) — the same prune that detaches Home Keeper from a
+shared device drives both paths via ``async_update_device(remove_config_entry_id=…)``.
+
+Follow-up to #104 (Problem Sensor Sync leaves stale entities/devices after disabling
+or exclusions).
+"""
+
+import json
+import time
+
+import websockets.sync.client
+from conftest import HA_URL, call_service
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+_WS_URL = HA_URL.replace("http://", "ws://") + "/api/websocket"
+
+
+def _device_registry(ha) -> list[dict]:
+    """Fetch all device registry entries via HA's WebSocket API."""
+    token = ha.headers["Authorization"].split(" ", 1)[1]
+    with websockets.sync.client.connect(_WS_URL) as ws:
+        msg = json.loads(ws.recv())
+        assert msg["type"] == "auth_required"
+        ws.send(json.dumps({"type": "auth", "access_token": token}))
+        msg = json.loads(ws.recv())
+        assert msg["type"] == "auth_ok", f"auth failed: {msg}"
+        ws.send(json.dumps({"id": 1, "type": "config/device_registry/list"}))
+        msg = json.loads(ws.recv())
+        assert msg.get("success"), f"device_registry/list failed: {msg}"
+        return msg["result"]
+
+
+def _has_self_owned_device(ha, task_id: str) -> bool:
+    """True if a self-owned ``(home_keeper, task_id)`` device exists in the registry."""
+    wanted = ["home_keeper", task_id]
+    for device in _device_registry(ha):
+        # identifiers come back as a list of [domain, id] pairs.
+        if any(list(ident) == wanted for ident in device.get("identifiers", [])):
+            return True
+    return False
+
+
+# ── test ─────────────────────────────────────────────────────────────────────
+
+
+def test_self_owned_device_removed_after_task_deleted(ha):
+    """Deleting a device-attached task must remove its orphaned self-owned device.
+
+    add_task and delete_task both trigger a config-entry reload. Before the fix,
+    async_setup_entry removed the deleted task's per-task entities but left the
+    self-owned device behind, so it lingered as an empty Home Keeper device card.
+    After the fix, async_prune_orphaned_devices removes the now entity-less device.
+    """
+    resp = call_service(
+        ha,
+        "home_keeper",
+        "add_task",
+        {
+            "name": "Device cleanup probe task",
+            "recurrence_type": "floating",
+            "interval": 1,
+            "unit": "months",
+            # A fake device_id resolves to no real device, so Home Keeper creates a
+            # self-owned device keyed on (home_keeper, task_id) for the per-task
+            # entities — exactly the kind of device left orphaned on deletion.
+            "device_id": "device_cleanup_probe_fake_device",
+        },
+        return_response=True,
+    )
+    task_id = resp.get("service_response", resp)["task_id"]
+
+    try:
+        # add_task triggers an entry reload; poll until the self-owned device appears.
+        deadline = time.monotonic() + 20
+        present = False
+        while time.monotonic() < deadline:
+            if _has_self_owned_device(ha, task_id):
+                present = True
+                break
+            time.sleep(1)
+        assert present, (
+            "self-owned Home Keeper device should be created for the probe task"
+        )
+
+        # Delete the task — this also triggers a config-entry reload.
+        call_service(ha, "home_keeper", "delete_task", {"task_id": task_id})
+        task_id_to_cleanup = task_id
+        task_id = None  # consumed; finally block won't re-delete
+
+        # After the reload + prune, the self-owned device must be gone.
+        deadline = time.monotonic() + 20
+        still_present = True
+        while time.monotonic() < deadline:
+            if not _has_self_owned_device(ha, task_id_to_cleanup):
+                still_present = False
+                break
+            time.sleep(1)
+
+        assert not still_present, (
+            "orphaned self-owned Home Keeper device should be removed from the "
+            "device registry after the attached task is deleted"
+        )
+
+    finally:
+        if task_id:
+            try:
+                call_service(ha, "home_keeper", "delete_task", {"task_id": task_id})
+            except Exception:
+                pass


### PR DESCRIPTION
When Problem Sensor Sync is disabled, or a sensor/device/area/label is excluded, the synced task and its per-task entities are removed on entry reload (issue #104) — but the device was left behind, lingering under Settings → Devices & Services → Home Keeper with zero entities.

Add devices.async_prune_orphaned_devices, run after platforms forward (so the entity registry already reflects the current set), dropping Home Keeper from any non-asset device that no longer carries one of our entities: async_update_device removes a self-owned device outright (we were its last config entry) and merely detaches us from a shared device its real owner keeps. Virtual asset devices are intentionally entity-less and reconciled elsewhere, so they're skipped. The pass also covers ordinary task deletion.

Add an integration test (self-owned device removed after the attached task is deleted) and bump to 0.7.0b3.


Claude-Session: https://claude.ai/code/session_016jXmCcFaJg2WWsZ4fpBMn7