### PR TITLE
fix(ci): deploy docs via workflow_call from release.yml

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,14 +1,28 @@
 name: Docs site — deploy
 
 on:
-  # Deploy only when a stable (non-pre-release) GitHub Release is published.
-  # This keeps the live docs pinned to the latest release so users don't see
-  # documentation for unreleased features.
-  release:
-    types: [released]
-  # Keep workflow_dispatch for emergency manual deploys (e.g. urgent typo fix
-  # that shouldn't wait for the next release).
+  # Called by release.yml after a *stable* release is cut. We can't use the
+  # `release: [released]` event here: that release is created by release.yml
+  # with the default GITHUB_TOKEN, and events triggered by GITHUB_TOKEN never
+  # start a new workflow run (GitHub's anti-recursion safeguard) — so the event
+  # would silently never fire. A workflow_call runs inside the same triggering
+  # run, sidestepping that restriction. `ref` is the tag to build docs from, so
+  # the live site stays pinned to the released commit (not main HEAD).
+  workflow_call:
+    inputs:
+      ref:
+        description: Git ref (release tag) to build the docs from.
+        required: false
+        type: string
+  # Manual deploys: emergency fixes, or the one-time recovery of a release that
+  # shipped before this pipeline was wired up. Pass `ref` (e.g. v0.7.0) to pin
+  # to a tag; omit it to build from the default branch HEAD.
   workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref (release tag) to build the docs from. Defaults to the branch HEAD.
+        required: false
+        type: string
 
 # Production publishes to the root of the gh-pages branch. PR previews live under
 # pr-preview/ on the same branch, so clean-exclude keeps them from being wiped.
@@ -22,15 +36,13 @@ concurrency:
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
-    # Skip pre-releases (betas, RCs) — only stable releases update the live docs.
-    # workflow_dispatch always runs so maintainers can deploy a manual fix at any time.
-    if: ${{ !github.event.release.prerelease || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v4
         with:
-          # For release events: check out the exact release tag commit.
-          # For workflow_dispatch: fall back to the default branch HEAD.
-          ref: ${{ github.event.release.tag_name || github.ref }}
+          # Build from the release tag passed by the caller (workflow_call) or by
+          # a manual dispatch. Falls back to the default branch HEAD when no ref
+          # is given (plain workflow_dispatch).
+          ref: ${{ inputs.ref || github.ref }}
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+      prerelease: ${{ steps.check.outputs.prerelease }}
+      release: ${{ steps.check.outputs.release }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -122,3 +126,20 @@ jobs:
           draft: false
           prerelease: ${{ steps.check.outputs.prerelease == 'true' }}
           files: home_keeper.zip
+
+  # Deploy the docs site once a *stable* release has been cut. We call the deploy
+  # workflow directly (workflow_call) rather than relying on a `release: [released]`
+  # event — that event would be created by this job's GITHUB_TOKEN and so would
+  # never start a workflow run. Pinned to the freshly created tag so the live site
+  # tracks the released commit, never unreleased main HEAD.
+  deploy-docs:
+    needs: release
+    if: >-
+      needs.release.outputs.release == 'true' &&
+      needs.release.outputs.prerelease == 'false' &&
+      github.event_name != 'pull_request'
+    permissions:
+      contents: write
+    uses: ./.github/workflows/docs-deploy.yml
+    with:
+      ref: "v${{ needs.release.outputs.version }}"

--- a/website/README.md
+++ b/website/README.md
@@ -49,12 +49,21 @@ harness.
 
 ## Deployment
 
-- **`docs-deploy.yml`** — fires when a stable GitHub Release is published (not
-  pre-releases). Checks out the release tag commit, injects `DOCS_VERSION` from
-  `manifest.json`, and publishes to the root of the `gh-pages` branch. The live site
-  is therefore always pinned to the latest stable release — users never see docs for
-  unreleased features. A `workflow_dispatch` trigger is available for emergency manual
-  deploys (e.g. an urgent typo fix that can't wait for the next release).
+- **`docs-deploy.yml`** — a reusable workflow (`workflow_call`) invoked by
+  `release.yml`'s `deploy-docs` job after a **stable** release is cut. It checks out
+  the release tag passed in via the `ref` input, injects `DOCS_VERSION` from
+  `manifest.json` (surfaced as the navbar version badge), and publishes to the root of
+  the `gh-pages` branch. The live site is therefore always pinned to the latest stable
+  release — users never see docs for unreleased features.
+  - It is **not** triggered by the `release: [released]` event: that release is
+    created by `release.yml` using the default `GITHUB_TOKEN`, and events triggered by
+    `GITHUB_TOKEN` never start a new workflow run (GitHub's anti-recursion safeguard),
+    so the event would silently never fire. Calling the workflow directly runs it
+    inside the same triggering run and sidesteps that restriction.
+  - A `workflow_dispatch` trigger is also available for emergency manual deploys (e.g.
+    an urgent typo fix that can't wait for the next release) and one-time recovery.
+    Pass a `ref` input (e.g. `v0.7.0`) to pin the build to a release tag; omit it to
+    build from the branch HEAD.
 - **`docs-preview.yml`** — on pull requests, builds a preview and publishes it under
   `pr-preview/pr-<n>/` on the `gh-pages` branch, posting a sticky comment with the
   preview URL. Previews are torn down when the PR closes.


### PR DESCRIPTION
## Problem

The docs site (https://prestomation.github.io/ha-home-keeper/) stopped updating after **June 24** — including across the **v0.7.0 stable release** cut on June 30.

### Root cause

PR #84 switched `docs-deploy.yml` from a `push: [main]` trigger to `release: types: [released]`. But that release is created by `release.yml` using the default `GITHUB_TOKEN`, and **events triggered by `GITHUB_TOKEN` never start a new workflow run** (GitHub's anti-recursion safeguard). So the `released` event was silently suppressed and `docs-deploy.yml` never fired.

Evidence:
- `docs-deploy.yml` run history: 7 runs, **all `push` events**, last on 2026-06-24. Zero `release`-triggered runs.
- The v0.7.0 release exists (`prerelease: false`) but its author/uploader is `github-actions[bot]` — i.e. created by `release.yml`'s token.

The version badge in the navbar (`docusaurus.config.ts`, driven by `DOCS_VERSION`) was also added in #84, so it never shipped either — it'll start showing `v0.7.0` once this deploys.

## Fix

Make `docs-deploy.yml` a **reusable workflow** (`workflow_call`) invoked directly by a new `deploy-docs` job in `release.yml`. A `workflow_call` runs inside the same triggering run, so the `GITHUB_TOKEN` restriction doesn't apply. The "deploy only stable, pinned to the release tag" guarantee is preserved.

- **`docs-deploy.yml`**: replace the `release` trigger with `workflow_call` (+ optional `ref` input); add an optional `ref` input to `workflow_dispatch`; checkout `ref: ${{ inputs.ref || github.ref }}`; drop the prerelease `if:` guard (the caller now decides when to deploy).
- **`release.yml`**: promote step outputs to job outputs; add a `deploy-docs` job (`needs: release`) gated on `release == 'true' && prerelease == 'false' && event != pull_request` that calls `./.github/workflows/docs-deploy.yml` with `ref: v<version>`.
- **`website/README.md`**: update the Deployment section to document the new mechanism.

## One-time recovery

After merge, manually dispatch `docs-deploy.yml` with `ref: v0.7.0` to un-stick the live site immediately. Every stable release after that deploys automatically.

## Testing

- Both workflow YAMLs validated (`yaml.safe_load`).
- CI-only change — no app/panel UI code, so no screenshot gate.
- End-to-end verification (dispatched run + next stable release) happens post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VqVAbAwAZ3cS9qcVDpdefz)_