### PR TITLE
Docs preview: link to the doc pages a PR changed

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -5,11 +5,16 @@ on:
     types: [opened, reopened, synchronize, closed]
     paths:
       - 'website/**'
-      - 'docs/images/**'
+      # Canonical doc sources: the site content is generated from these, so a
+      # change here changes the rendered pages (see website/scripts/sync-docs.mjs).
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - 'docs/**'
       - '.github/workflows/docs-preview.yml'
 
-# Previews deploy to pr-preview/pr-<n>/ on the gh-pages branch and a sticky
-# comment with the URL is posted on the PR.
+# Previews deploy to pr-preview/pr-<n>/ on the gh-pages branch and two sticky
+# comments are posted on the PR: the preview URL (pr-preview-action) and a list
+# of deep links to the doc pages this PR changed (changed-pages.mjs).
 permissions:
   contents: write
   pull-requests: write
@@ -25,6 +30,9 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Need history back to the PR base so we can diff which docs changed.
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         if: github.event.action != 'closed'
@@ -51,3 +59,47 @@ jobs:
           source-dir: website/build
           preview-branch: gh-pages
           umbrella-dir: pr-preview
+
+      - name: Compute changed doc pages
+        id: changed
+        if: github.event.action != 'closed'
+        env:
+          PREVIEW_BASE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-preview/pr-${{ github.event.number }}/
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          # Files this PR changed (three-dot: since divergence from base).
+          git diff --name-only "$BASE_SHA"...HEAD > /tmp/changed.txt
+          # Base version of the README so section-level changes can be detected.
+          git show "$BASE_SHA:README.md" > /tmp/readme-base.md 2>/dev/null || true
+          CHANGED_FILES="$(cat /tmp/changed.txt)" \
+          README_BASE=/tmp/readme-base.md \
+          README_HEAD=README.md \
+            node website/scripts/changed-pages.mjs > /tmp/changed-pages.md
+          if grep -q '^- \[' /tmp/changed-pages.md; then
+            echo "has_pages=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_pages=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Find existing changed-pages comment
+        id: find
+        if: github.event.action != 'closed'
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- doc-preview-changed-pages -->'
+
+      # Post the list when pages changed, or update an existing comment to "none"
+      # if a later push removed all doc changes. Skip entirely otherwise.
+      - name: Post changed-pages comment
+        if: >
+          github.event.action != 'closed' &&
+          (steps.changed.outputs.has_pages == 'true' ||
+           steps.find.outputs.comment-id != '')
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find.outputs.comment-id }}
+          issue-number: ${{ github.event.number }}
+          body-path: /tmp/changed-pages.md
+          edit-mode: replace

--- a/tests/frontend/changed-pages.test.js
+++ b/tests/frontend/changed-pages.test.js
@@ -1,0 +1,137 @@
+import {describe, it, expect} from 'vitest';
+import {
+  COMMENT_MARKER,
+  readmeChangedHeadings,
+  pagesForChanges,
+  renderComment,
+} from '../../website/scripts/changed-pages.mjs';
+
+const README = `# Home Keeper
+
+Intro preamble paragraph.
+
+## Features at a glance
+
+Feature list here.
+
+## Settings
+
+Settings body.
+
+## Development
+
+Contributor-only notes.
+`;
+
+describe('readmeChangedHeadings', () => {
+  it('flags only the section whose body changed', () => {
+    const head = README.replace('Settings body.', 'Settings body, edited.');
+    expect(readmeChangedHeadings(README, head)).toEqual(['Settings']);
+  });
+
+  it('flags a newly added section', () => {
+    const head = README + '\n## Localization\n\nNew section.\n';
+    expect(readmeChangedHeadings(README, head)).toEqual(['Localization']);
+  });
+
+  it('ignores changes confined to the preamble', () => {
+    const head = README.replace('Intro preamble paragraph.', 'Different intro.');
+    expect(readmeChangedHeadings(README, head)).toEqual([]);
+  });
+
+  it('returns nothing when the body is identical', () => {
+    expect(readmeChangedHeadings(README, README)).toEqual([]);
+  });
+
+  it('treats every section as changed when there is no base', () => {
+    expect(readmeChangedHeadings('', README)).toEqual([
+      'Features at a glance',
+      'Settings',
+      'Development',
+    ]);
+  });
+});
+
+describe('pagesForChanges', () => {
+  it('maps changed README sections to their User Guide routes in sidebar order', () => {
+    const pages = pagesForChanges({
+      changedFiles: ['README.md'],
+      changedReadmeHeadings: ['Settings', 'Features at a glance'],
+    });
+    expect(pages).toEqual([
+      {title: 'Features', route: '/docs/guide/features'},
+      {title: 'Settings', route: '/docs/guide/settings'},
+    ]);
+  });
+
+  it('does not link README sections that are not published (e.g. Development)', () => {
+    const pages = pagesForChanges({
+      changedFiles: ['README.md'],
+      changedReadmeHeadings: ['Development'],
+    });
+    expect(pages).toEqual([]);
+  });
+
+  it('maps developer docs, changelog and hand-authored pages', () => {
+    const pages = pagesForChanges({
+      changedFiles: [
+        'docs/INTEGRATING.md',
+        'docs/EVENTS.md',
+        'CHANGELOG.md',
+        'website/docs/intro.md',
+        'website/src/pages/index.tsx',
+      ],
+    });
+    expect(pages).toEqual([
+      {title: 'Integrating with Home Keeper', route: '/developer/integrating'},
+      {title: 'Events reference', route: '/developer/events'},
+      {title: 'Release Notes', route: '/docs/release-notes'},
+      {title: 'Introduction', route: '/docs/intro'},
+      {title: 'Home (landing page)', route: '/'},
+    ]);
+  });
+
+  it('ignores files with no page mapping', () => {
+    expect(
+      pagesForChanges({changedFiles: ['custom_components/home_keeper/store.py']}),
+    ).toEqual([]);
+  });
+
+  it('de-duplicates repeated routes', () => {
+    const pages = pagesForChanges({
+      changedFiles: ['docs/EVENTS.md', 'docs/EVENTS.md'],
+    });
+    expect(pages).toEqual([
+      {title: 'Events reference', route: '/developer/events'},
+    ]);
+  });
+});
+
+describe('renderComment', () => {
+  const base = 'https://prestomation.github.io/ha-home-keeper/pr-preview/pr-9/';
+
+  it('renders a marked, bulleted list with absolute preview URLs', () => {
+    const body = renderComment(
+      [{title: 'Settings', route: '/docs/guide/settings'}],
+      base,
+    );
+    expect(body).toContain(COMMENT_MARKER);
+    expect(body).toContain(
+      '- [Settings](https://prestomation.github.io/ha-home-keeper/pr-preview/pr-9/docs/guide/settings)',
+    );
+  });
+
+  it('collapses a trailing slash so routes are not doubled', () => {
+    const body = renderComment([{title: 'Home', route: '/'}], base);
+    expect(body).toContain(
+      '- [Home](https://prestomation.github.io/ha-home-keeper/pr-preview/pr-9/)',
+    );
+    expect(body).not.toContain('pr-9//');
+  });
+
+  it('still emits the marker when nothing changed', () => {
+    const body = renderComment([], base);
+    expect(body).toContain(COMMENT_MARKER);
+    expect(body).toContain('No documentation pages changed');
+  });
+});

--- a/website/README.md
+++ b/website/README.md
@@ -64,9 +64,15 @@ harness.
     an urgent typo fix that can't wait for the next release) and one-time recovery.
     Pass a `ref` input (e.g. `v0.7.0`) to pin the build to a release tag; omit it to
     build from the branch HEAD.
-- **`docs-preview.yml`** — on pull requests, builds a preview and publishes it under
-  `pr-preview/pr-<n>/` on the `gh-pages` branch, posting a sticky comment with the
-  preview URL. Previews are torn down when the PR closes.
+- **`docs-preview.yml`** — on pull requests (that touch `website/**` or the canonical
+  doc sources `README.md` / `CHANGELOG.md` / `docs/**`), builds a preview and publishes
+  it under `pr-preview/pr-<n>/` on the `gh-pages` branch, posting a sticky comment with
+  the preview URL. It posts a **second** sticky comment listing deep links to just the
+  doc pages the PR changed — `scripts/changed-pages.mjs` maps the changed sources to
+  their generated routes (README is section-granular, so only the User Guide pages whose
+  `##` section changed are linked), reusing the source→page mapping in
+  `scripts/doc-map.mjs` so it never drifts from `sync-docs.mjs`. Previews are torn down
+  when the PR closes.
 
 Both publish to the `gh-pages` branch, so **GitHub Pages must be set to "Deploy from a
 branch" → `gh-pages` / root** in the repository settings. The production deploy uses

--- a/website/scripts/changed-pages.mjs
+++ b/website/scripts/changed-pages.mjs
@@ -1,0 +1,127 @@
+// Maps a PR's changed files back to the generated documentation pages they
+// affect, and renders a Markdown list of deep links into the PR preview build.
+// Used by `.github/workflows/docs-preview.yml` to post a sticky comment listing
+// exactly which doc pages changed.
+//
+// The canonical → page mapping lives in `doc-map.mjs` (shared with sync-docs so
+// the two never drift). README is section-granular: only the User Guide pages
+// whose `##` section actually changed are linked, not every guide page.
+//
+// The pure functions below are exported for unit testing; the file only touches
+// the filesystem / env when run directly as a script.
+import {readFile} from 'node:fs/promises';
+import {pathToFileURL} from 'node:url';
+import {splitByH2, USER_SECTIONS, DEV_DOCS} from './doc-map.mjs';
+
+// Hidden marker so the workflow can find & update its own sticky comment.
+export const COMMENT_MARKER = '<!-- doc-preview-changed-pages -->';
+
+// Canonical/hand-authored sources that map 1:1 to a single page route.
+// (README is handled separately — it fans out to many section pages.)
+const STATIC_PAGES = {
+  'CHANGELOG.md': {title: 'Release Notes', route: '/docs/release-notes'},
+  // Hand-authored pages under website/ (see website/README.md).
+  'website/docs/intro.md': {title: 'Introduction', route: '/docs/intro'},
+  'website/src/pages/index.tsx': {title: 'Home (landing page)', route: '/'},
+};
+for (const d of DEV_DOCS) {
+  STATIC_PAGES[d.file] = {
+    title: d.title,
+    route: `/developer/${d.out.replace(/\.md$/, '')}`,
+  };
+}
+
+// Given the README before/after, return the list of `##` section headings whose
+// body changed (or were added). A missing/empty base (new file) treats every
+// section as changed. Section titles are compared by heading text, so inserting
+// or reordering a section only flags the ones that actually differ.
+export function readmeChangedHeadings(baseMd, headMd) {
+  const base = new Map(
+    splitByH2(baseMd ?? '').sections.map((s) => [s.title, s.body.join('\n')]),
+  );
+  const changed = [];
+  for (const s of splitByH2(headMd).sections) {
+    const before = base.get(s.title);
+    if (before === undefined || before !== s.body.join('\n')) {
+      changed.push(s.title);
+    }
+  }
+  return changed;
+}
+
+// Resolve the set of affected pages ({title, route}) from the PR's changed files
+// and the README section headings that changed. Output is de-duplicated and
+// ordered: README User Guide pages first (in sidebar order), then the rest.
+export function pagesForChanges({changedFiles, changedReadmeHeadings = []}) {
+  const pages = [];
+  const seen = new Set();
+  const add = (title, route) => {
+    if (seen.has(route)) return;
+    seen.add(route);
+    pages.push({title, route});
+  };
+
+  if (changedFiles.includes('README.md') && changedReadmeHeadings.length) {
+    const changedSet = new Set(changedReadmeHeadings);
+    for (const spec of USER_SECTIONS) {
+      if (changedSet.has(spec.h)) add(spec.title, `/docs/guide/${spec.slug}`);
+    }
+  }
+
+  for (const file of changedFiles) {
+    const page = STATIC_PAGES[file];
+    if (page) add(page.title, page.route);
+  }
+
+  return pages;
+}
+
+// Render the sticky-comment body. Always includes the marker so an existing
+// comment can be updated to reflect the current state (including "none").
+export function renderComment(pages, previewBaseUrl) {
+  const base = (previewBaseUrl ?? '').replace(/\/+$/, '');
+  const lines = [COMMENT_MARKER, ''];
+  if (pages.length) {
+    lines.push('### 📄 Documentation pages changed in this PR');
+    lines.push('');
+    lines.push('Preview the rendered pages you touched:');
+    lines.push('');
+    for (const p of pages) lines.push(`- [${p.title}](${base}${p.route})`);
+  } else {
+    lines.push('_No documentation pages changed in this PR._');
+  }
+  return lines.join('\n') + '\n';
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry — reads the PR context from the environment and prints the comment
+// body to stdout. Inputs:
+//   CHANGED_FILES     newline-separated repo-relative paths changed in the PR
+//   README_BASE       path to the base (pre-PR) README.md (optional)
+//   README_HEAD       path to the head README.md (default: repo README.md)
+//   PREVIEW_BASE_URL  base URL of the deployed PR preview
+// ---------------------------------------------------------------------------
+async function main() {
+  const changedFiles = (process.env.CHANGED_FILES ?? '')
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  let changedReadmeHeadings = [];
+  if (changedFiles.includes('README.md')) {
+    const headPath = process.env.README_HEAD ?? 'README.md';
+    const headMd = await readFile(headPath, 'utf8');
+    let baseMd = '';
+    if (process.env.README_BASE) {
+      baseMd = await readFile(process.env.README_BASE, 'utf8').catch(() => '');
+    }
+    changedReadmeHeadings = readmeChangedHeadings(baseMd, headMd);
+  }
+
+  const pages = pagesForChanges({changedFiles, changedReadmeHeadings});
+  process.stdout.write(renderComment(pages, process.env.PREVIEW_BASE_URL));
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  await main();
+}

--- a/website/scripts/changed-pages.mjs
+++ b/website/scripts/changed-pages.mjs
@@ -23,18 +23,26 @@ const STATIC_PAGES = {
   // Hand-authored pages under website/ (see website/README.md).
   'website/docs/intro.md': {title: 'Introduction', route: '/docs/intro'},
   'website/src/pages/index.tsx': {title: 'Home (landing page)', route: '/'},
+  // Developer Guide docs copied 1:1; the served route drops the `.md` that
+  // sync-docs.mjs writes as the filename under website/developer/.
+  ...Object.fromEntries(
+    DEV_DOCS.map((d) => [
+      d.file,
+      {title: d.title, route: `/developer/${d.out.replace(/\.md$/, '')}`},
+    ]),
+  ),
 };
-for (const d of DEV_DOCS) {
-  STATIC_PAGES[d.file] = {
-    title: d.title,
-    route: `/developer/${d.out.replace(/\.md$/, '')}`,
-  };
-}
 
 // Given the README before/after, return the list of `##` section headings whose
 // body changed (or were added). A missing/empty base (new file) treats every
 // section as changed. Section titles are compared by heading text, so inserting
 // or reordering a section only flags the ones that actually differ.
+//
+// Renames are keyed by heading text, exactly like the generator: sync-docs.mjs
+// also looks sections up by their exact `## ` text (USER_SECTIONS `h`) and skips
+// generating a page whose heading it can't find. So renaming a section without
+// updating USER_SECTIONS drops the page from the site *and* from this list in
+// lockstep — the two never disagree about what exists to link to.
 export function readmeChangedHeadings(baseMd, headMd) {
   const base = new Map(
     splitByH2(baseMd ?? '').sections.map((s) => [s.title, s.body.join('\n')]),

--- a/website/scripts/doc-map.mjs
+++ b/website/scripts/doc-map.mjs
@@ -1,0 +1,67 @@
+// Shared, pure mapping data + helpers describing how the canonical Markdown
+// sources map onto the generated Docusaurus pages. Imported by both
+// `sync-docs.mjs` (which renders the pages) and `changed-pages.mjs` (which maps
+// a PR's changed files back to the pages they affect). Keep it side-effect free
+// so it can be imported anywhere, including unit tests.
+
+// Split Markdown into a preamble and `## ` sections, ignoring fenced code.
+export function splitByH2(md) {
+  const lines = md.split('\n');
+  const preamble = [];
+  const sections = [];
+  let current = null;
+  let inFence = false;
+  let fence = '';
+  for (const line of lines) {
+    const fenceMatch = line.match(/^(```|~~~)/);
+    if (fenceMatch) {
+      if (!inFence) {
+        inFence = true;
+        fence = fenceMatch[1];
+      } else if (line.startsWith(fence)) {
+        inFence = false;
+      }
+    }
+    const h2 = !inFence && line.match(/^## (.+)$/);
+    if (h2) {
+      current = {title: h2[1].trim(), body: []};
+      sections.push(current);
+    } else if (current) {
+      current.body.push(line);
+    } else {
+      preamble.push(line);
+    }
+  }
+  return {preamble: preamble.join('\n'), sections};
+}
+
+// Ordered set of README sections to publish. Sections not listed (e.g.
+// "Integrating with Home Keeper", "Quality scale", "Development") are skipped —
+// they belong to the Developer Guide or only make sense in the repo.
+export const USER_SECTIONS = [
+  {h: 'Features at a glance', slug: 'features', title: 'Features', label: 'Features'},
+  {h: 'Installation', slug: 'installation', title: 'Installation'},
+  {h: 'Concepts', slug: 'concepts', title: 'Core concepts', label: 'Concepts'},
+  {h: 'One-off (do-once) tasks', slug: 'one-off-tasks', title: 'One-off tasks', label: 'One-off tasks'},
+  {h: 'Logging completions (note, cost, photo, who)', slug: 'completions', title: 'Logging completions', label: 'Completions'},
+  {h: 'Condition-driven (triggered) tasks', slug: 'triggered-tasks', title: 'Triggered tasks', label: 'Triggered tasks'},
+  {h: 'Sensor-based tasks (usage meters & thresholds)', slug: 'sensor-tasks', title: 'Sensor-based tasks', label: 'Sensor-based tasks'},
+  {h: 'Settings', slug: 'settings', title: 'Settings'},
+  {h: 'Profiles — saved filters you reuse everywhere', slug: 'profiles', title: 'Profiles', label: 'Profiles'},
+  {h: 'Notifications — actionable reminders on your phone', slug: 'notifications', title: 'Notifications', label: 'Notifications'},
+  {h: 'Dashboard task card', slug: 'dashboard-card', title: 'Dashboard card', label: 'Dashboard card'},
+  {h: 'Appliances & virtual devices', slug: 'appliances', title: 'Appliances', label: 'Appliances'},
+  {h: 'Services', slug: 'services', title: 'Services'},
+  {h: 'Events & automations', slug: 'events', title: 'Events & automations', label: 'Events'},
+  {h: 'Integrations', slug: 'integrations', title: 'Integrations'},
+  {h: 'Localization', slug: 'localization', title: 'Localization'},
+];
+
+// Standalone canonical docs copied 1:1 into the Developer Guide. `out` is the
+// generated filename under `website/developer/`; the served route drops `.md`.
+export const DEV_DOCS = [
+  {file: 'docs/INTEGRATING.md', out: 'integrating.md', title: 'Integrating with Home Keeper', label: 'Integrating', pos: 1},
+  {file: 'docs/GLUE_INTEGRATIONS.md', out: 'glue-integrations.md', title: 'Glue integrations', label: 'Glue integrations', pos: 2},
+  {file: 'docs/EVENTS.md', out: 'events.md', title: 'Events reference', label: 'Events', pos: 3},
+  {file: 'docs/DESIGN.md', out: 'architecture.md', title: 'Architecture', label: 'Architecture', pos: 4},
+];

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -14,6 +14,7 @@ import {readFile, writeFile, mkdir, rm} from 'node:fs/promises';
 import {dirname, resolve} from 'node:path';
 import {posix} from 'node:path';
 import {fileURLToPath} from 'node:url';
+import {splitByH2, USER_SECTIONS, DEV_DOCS} from './doc-map.mjs';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const website = resolve(here, '..');
@@ -94,62 +95,9 @@ function frontmatter({title, label, position}) {
   return lines.join('\n');
 }
 
-// Split Markdown into a preamble and `## ` sections, ignoring fenced code.
-function splitByH2(md) {
-  const lines = md.split('\n');
-  const preamble = [];
-  const sections = [];
-  let current = null;
-  let inFence = false;
-  let fence = '';
-  for (const line of lines) {
-    const fenceMatch = line.match(/^(```|~~~)/);
-    if (fenceMatch) {
-      if (!inFence) {
-        inFence = true;
-        fence = fenceMatch[1];
-      } else if (line.startsWith(fence)) {
-        inFence = false;
-      }
-    }
-    const h2 = !inFence && line.match(/^## (.+)$/);
-    if (h2) {
-      current = {title: h2[1].trim(), body: []};
-      sections.push(current);
-    } else if (current) {
-      current.body.push(line);
-    } else {
-      preamble.push(line);
-    }
-  }
-  return {preamble: preamble.join('\n'), sections};
-}
-
 // ---------------------------------------------------------------------------
 // User Guide — README.md split by section
 // ---------------------------------------------------------------------------
-
-// Ordered set of README sections to publish. Sections not listed (e.g.
-// "Integrating with Home Keeper", "Quality scale", "Development") are skipped —
-// they belong to the Developer Guide or only make sense in the repo.
-const USER_SECTIONS = [
-  {h: 'Features at a glance', slug: 'features', title: 'Features', label: 'Features'},
-  {h: 'Installation', slug: 'installation', title: 'Installation'},
-  {h: 'Concepts', slug: 'concepts', title: 'Core concepts', label: 'Concepts'},
-  {h: 'One-off (do-once) tasks', slug: 'one-off-tasks', title: 'One-off tasks', label: 'One-off tasks'},
-  {h: 'Logging completions (note, cost, photo, who)', slug: 'completions', title: 'Logging completions', label: 'Completions'},
-  {h: 'Condition-driven (triggered) tasks', slug: 'triggered-tasks', title: 'Triggered tasks', label: 'Triggered tasks'},
-  {h: 'Sensor-based tasks (usage meters & thresholds)', slug: 'sensor-tasks', title: 'Sensor-based tasks', label: 'Sensor-based tasks'},
-  {h: 'Settings', slug: 'settings', title: 'Settings'},
-  {h: 'Profiles — saved filters you reuse everywhere', slug: 'profiles', title: 'Profiles', label: 'Profiles'},
-  {h: 'Notifications — actionable reminders on your phone', slug: 'notifications', title: 'Notifications', label: 'Notifications'},
-  {h: 'Dashboard task card', slug: 'dashboard-card', title: 'Dashboard card', label: 'Dashboard card'},
-  {h: 'Appliances & virtual devices', slug: 'appliances', title: 'Appliances', label: 'Appliances'},
-  {h: 'Services', slug: 'services', title: 'Services'},
-  {h: 'Events & automations', slug: 'events', title: 'Events & automations', label: 'Events'},
-  {h: 'Integrations', slug: 'integrations', title: 'Integrations'},
-  {h: 'Localization', slug: 'localization', title: 'Localization'},
-];
 
 async function buildUserGuide() {
   const md = await readFile(resolve(repo, 'README.md'), 'utf8');
@@ -183,13 +131,6 @@ async function buildUserGuide() {
 // ---------------------------------------------------------------------------
 // Developer Guide — standalone docs copied 1:1
 // ---------------------------------------------------------------------------
-
-const DEV_DOCS = [
-  {file: 'docs/INTEGRATING.md', out: 'integrating.md', title: 'Integrating with Home Keeper', label: 'Integrating', pos: 1},
-  {file: 'docs/GLUE_INTEGRATIONS.md', out: 'glue-integrations.md', title: 'Glue integrations', label: 'Glue integrations', pos: 2},
-  {file: 'docs/EVENTS.md', out: 'events.md', title: 'Events reference', label: 'Events', pos: 3},
-  {file: 'docs/DESIGN.md', out: 'architecture.md', title: 'Architecture', label: 'Architecture', pos: 4},
-];
 
 async function buildDeveloperGuide() {
   const outDir = resolve(website, 'developer');


### PR DESCRIPTION
## What & why

The docs-site PR preview posts a single sticky comment with the base preview URL. On a PR that edits documentation, a reviewer still has to hunt through the site to find the pages that actually changed. This adds a **second sticky comment** listing deep links to exactly the generated pages the PR touched, so reviewers can jump straight to the rendered surfaces.

It also closes a gap: the preview only triggered on `website/**` / `docs/images/**`, so edits to the **canonical** doc sources (`README.md`, `docs/*.md`, `CHANGELOG.md`) — from which the site content is generated — built no preview at all. The trigger now covers them.

## How it works

- **`website/scripts/doc-map.mjs`** (new) — the source→page mapping (`splitByH2`, `USER_SECTIONS`, `DEV_DOCS`) extracted from `sync-docs.mjs` into a shared, side-effect-free module so the preview logic and the generator can never drift.
- **`website/scripts/changed-pages.mjs`** (new) — maps a PR's changed files to preview routes and renders the sticky-comment body. README is **section-granular**: it diffs the base vs head README by `##` section and links only the User Guide pages whose section actually changed (skipping unpublished sections like *Development*). Developer docs, the changelog, and the hand-authored landing/intro pages map 1:1.
- **`.github/workflows/docs-preview.yml`** — widened triggers, `fetch-depth: 0` to diff against the PR base, a step that computes the changed pages, and a `find-comment` + `create-or-update-comment` pair that upserts the sticky comment (and updates it to "none" if a later push removes all doc changes).

Mapping (all under `…/pr-preview/pr-<n>/`):

| Source | Page route |
|---|---|
| `README.md` `##` section | `/docs/guide/<slug>` (only changed sections) |
| `docs/INTEGRATING.md` / `EVENTS.md` / `DESIGN.md` / `GLUE_INTEGRATIONS.md` | `/developer/…` |
| `CHANGELOG.md` | `/docs/release-notes` |
| `website/docs/intro.md`, `website/src/pages/index.tsx` | `/docs/intro`, `/` |

## Testing

- `tests/frontend/changed-pages.test.js` — 13 new cases covering section-change detection (edited body, added section, preamble-only change ignored, no-base fallback), file→route mapping (dedup, unpublished sections skipped, non-doc files ignored), and comment rendering (marker, absolute URLs, trailing-slash handling, empty case).
- Full JS suite green (208 tests); `sync-docs.mjs` still generates all pages after the refactor; CLI exercised end-to-end against a simulated README edit.

## Notes

Developer-only change (CI + build tooling), so no CHANGELOG entry, beta bump, or panel screenshots per `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhqE5n3XQcqzT2fvtHwJiZ)_