### PR TITLE
release: 0.8.0 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,63 @@ All notable changes to Home Keeper are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas).
 
+## [0.8.0] - 2026-07-04
+
+### Added
+
+- **Discover known companions from the panel.** The **Settings → Companions** section
+  now links out to the docs catalog of integrations and glue that work with Home
+  Keeper, so you can browse the full list even when nothing is detected on your setup.
+  The docs page also invites you to open a GitHub issue to suggest a companion (or
+  glue) integration that should be listed.
+- **In-form help for creating tasks.** The task editor now explains itself as you fill
+  it in: every field carries concise helper text, a **?** icon by the form title links
+  straight to the docs, and **sensor-based** tasks gain a short primer plus a **live,
+  computed hint** that reads the bound sensor and spells out what happens next — e.g.
+  *"This sensor reads 660 h now. The task becomes due at 760 h, then every 100 h after
+  each completion."* This clears up the most common confusion with usage-meter tasks:
+  the target counts usage **from the sensor's current reading**, not from zero, and the
+  count restarts after each completion.
+- **Product URL on replaceable parts.** A part can now carry a link to where you buy
+  it (e.g. an Amazon listing). When set, the part's name in the appliance detail page
+  becomes a clickable link that opens the product page in a new tab, so reordering a
+  worn or consumed part is one click away. (Fixes #118)
+- **Attach a file to a replaceable part.** A part can now carry a single attached
+  file (a receipt, spec sheet, or photo) alongside its product URL — upload it from
+  the part's editor and open or remove it later, the same secure upload/storage path
+  appliance documents already use.
+- **A linked task's "Consumable link" points straight at the part's product page.**
+  When a maintenance task is tied to a part that has a product URL, that link now
+  opens the product page directly — in the panel's task detail and on the dashboard
+  card's task row — instead of just naming the part.
+- **Auto-create a "buy" task when a spare part runs low.** A replaceable part that
+  tracks stock with a reorder threshold can now opt into an automatic shopping
+  reminder: enable **Auto-create buy task** on the part, and whenever its stock drops
+  to (or below) the reorder point Home Keeper adds a one-off **"Buy {part}"** task —
+  on the appliance's device page, the to-do list, and the panel. The reminder clears
+  itself once the part is restocked above the threshold (or you turn the option off).
+  Completing the reminder **restocks the part** by a configurable **Restock quantity**
+  (default 1), closing the low → buy → restocked loop with no automation to write.
+
+### Changed
+
+- **A task's appliance links now render as chips, inline with the rest.** On the
+  dashboard card, a task's document/metadata links, uploaded files, and a linked
+  part's product URL previously appeared as plain blue links in a separate row below
+  the task's chips, which read inconsistently. They now render as primary-tinted
+  link-chips in the same chip row as the status, area, and label chips — one tidy,
+  wrapping row — while still opening in a new tab on tap.
+
+### Fixed
+
+- **Auto-generated maintenance task names now follow your Home Assistant language.**
+  The name Home Keeper generates for a wear part (e.g. "Replace {part} ({appliance})")
+  was always English; it's now translated into your configured language across every
+  surface — the panel, the to-do list, the calendar, notifications, and the device
+  pages — and updates automatically if you change the language. (Fixes #119)
+- Fixed a batch of bugs found during an in-depth code review (correctness,
+  security, and reliability), plus internal maintainability cleanups.
+
 ## [0.8.0b5]
 
 ### Changed

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor", "number"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.8.0b5"
+PANEL_VERSION = "0.8.0"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -15,5 +15,5 @@
   "issue_tracker": "https://github.com/prestomation/ha-home-keeper/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "0.8.0b5"
+  "version": "0.8.0"
 }


### PR DESCRIPTION
## Summary

Cuts the stable **0.8.0** release, rolling up the `0.8.0b1`–`0.8.0b5` betas per [RELEASE.md](../blob/main/RELEASE.md):

- `custom_components/home_keeper/manifest.json` — `version` bumped to `0.8.0`
- `custom_components/home_keeper/const.py` — `PANEL_VERSION` bumped to `0.8.0`
- `CHANGELOG.md` — new `## [0.8.0] - 2026-07-04` section describing what changed since the last stable release (`0.7.0`), superseding the beta-by-beta entries below it

### What's in this release (since 0.7.0)

**Added**
- Discover known companions from the panel (Settings → Companions docs link)
- In-form help text + live sensor hint on the task editor
- Product URL on replaceable parts, clickable in the appliance detail page (Fixes #118)
- Attach a file to a replaceable part
- A linked task's "Consumable link" opens straight to the part's product page
- Auto-create a "buy" task when a spare part runs low, with configurable restock on completion

**Changed**
- Task appliance/document links render as chips inline in the card's chip row, instead of a separate row of plain links

**Fixed**
- Auto-generated maintenance task names now follow the configured HA language instead of always English (Fixes #119)
- A batch of bugs found during an in-depth code review (correctness, security, reliability), plus maintainability cleanups

## Test plan

- [x] `pytest tests/unit -v` — 501 passed, 1 skipped
- [x] Verified no other stray `0.8.0b5` version references remain in the repo
- [ ] CI: lint, full test suite, HACS validation, hassfest
- [ ] On merge, `release.yml` tags `v0.8.0`, builds `home_keeper.zip`, and publishes the GitHub Release (non-prerelease) from the changelog section


---
_Generated by [Claude Code](https://claude.ai/code/session_012diojKTXaaV5snxnU5xHY8)_