### PR TITLE
Add GitHub Sponsors + Ko-fi funding links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: prestomation
+ko_fi: prestomation


### PR DESCRIPTION
## Summary
- Add `.github/FUNDING.yml` pointing at GitHub Sponsors (`prestomation`) and Ko-fi (`prestomation`), which enables GitHub's native "Sponsor" button on the repo page.

This is repo metadata only — no application code, CHANGELOG, or panel UI changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_014s2JUeujkEUw8E2Rexgahn)_