### PR TITLE
Cut stable 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,32 +4,7 @@ All notable changes to Home Keeper are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas).
 
-## [0.9.0b2]
-
-### Added
-
-- **Back-date or correct a task completion.** The completion dialog now has an
-  optional **Completed at** date/time field (defaults to now) for logging a
-  completion in the past — so a floating task's next-due date measures from when
-  you actually did it, not from when you got around to logging it. The task
-  history list also gains a **move date** action on each completion row to fix an
-  already-recorded entry's timestamp after the fact, without touching its note,
-  cost, photo, or who. Backed by a new `home_keeper.move_completion` service and
-  matching websocket command; automations that already react to
-  `home_keeper_task_completed` / `home_keeper_task_uncompleted` see a move for
-  free. (Fixes #143)
-
-## [0.9.0b1]
-
-### Fixed
-
-- **The task-completion dialog's Save button was invisible.** For a task set to
-  "Ask for details" or "Require details" on completion, tapping **Done** opened a
-  dialog to log a note/cost/who — but its **Mark done**/**Save**, **Skip details**,
-  and **Cancel** buttons never rendered, in the panel or the mobile app, so there was
-  no way to confirm or dismiss it. Home Assistant's `ha-dialog` component changed its
-  internal slot API (action buttons must now be wrapped in `<ha-dialog-footer>`); the
-  panel's completion dialog hadn't been updated to match. (Fixes #144)
+## [0.10.0] - 2026-07-23
 
 ### Added
 
@@ -50,6 +25,26 @@ versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas)
   device's own registry entry — handy since not every integration reports them. Fields
   you've already filled in (or the device doesn't know) are never overwritten, so you
   can freely correct or complete what the device is missing. (Fixes #145)
+- **Back-date or correct a task completion.** The completion dialog now has an
+  optional **Completed at** date/time field (defaults to now) for logging a
+  completion in the past — so a floating task's next-due date measures from when
+  you actually did it, not from when you got around to logging it. The task
+  history list also gains a **move date** action on each completion row to fix an
+  already-recorded entry's timestamp after the fact, without touching its note,
+  cost, photo, or who. Backed by a new `home_keeper.move_completion` service and
+  matching websocket command; automations that already react to
+  `home_keeper_task_completed` / `home_keeper_task_uncompleted` see a move for
+  free. (Fixes #143)
+
+### Fixed
+
+- **The task-completion dialog's Save button was invisible.** For a task set to
+  "Ask for details" or "Require details" on completion, tapping **Done** opened a
+  dialog to log a note/cost/who — but its **Mark done**/**Save**, **Skip details**,
+  and **Cancel** buttons never rendered, in the panel or the mobile app, so there was
+  no way to confirm or dismiss it. Home Assistant's `ha-dialog` component changed its
+  internal slot API (action buttons must now be wrapped in `<ha-dialog-footer>`); the
+  panel's completion dialog hadn't been updated to match. (Fixes #144)
 
 ## [0.8.0] - 2026-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Home Keeper are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas).
 
-## [0.10.0] - 2026-07-23
+## [0.9.0] - 2026-07-23
 
 ### Added
 

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor", "number"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.10.0"
+PANEL_VERSION = "0.9.0"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor", "number"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.9.0b2"
+PANEL_VERSION = "0.10.0"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -15,5 +15,5 @@
   "issue_tracker": "https://github.com/prestomation/ha-home-keeper/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "0.10.0"
+  "version": "0.9.0"
 }

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -15,5 +15,5 @@
   "issue_tracker": "https://github.com/prestomation/ha-home-keeper/issues",
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "0.9.0b2"
+  "version": "0.10.0"
 }


### PR DESCRIPTION
## Summary

Release PR per `RELEASE.md` — contains exactly the three required changes:

- `CHANGELOG.md` — consolidates the `0.9.0b1`/`0.9.0b2` beta work (neither was
  ever stabilized on its own) into a single `## [0.9.0] - 2026-07-23` section
  describing what changed since the last stable release, `0.8.0`:
  - **Added:** notes on problem-sensor tasks; manufacturer/model/serial number
    for existing-device appliances (Fixes #145); back-date or correct a task
    completion (Fixes #143)
  - **Fixed:** the task-completion dialog's Save button was invisible (Fixes #144)
- `custom_components/home_keeper/manifest.json` — `version` → `0.9.0`
- `custom_components/home_keeper/const.py` — `PANEL_VERSION` → `0.9.0`

On merge, `release.yml` tags `v0.9.0` and publishes the GitHub Release with the
changelog section as the body plus `home_keeper.zip`.

## Test plan

- [x] `manifest.json` version and `const.PANEL_VERSION` match (`0.9.0`)
- [x] A `## [0.9.0]` section exists in `CHANGELOG.md`
- N/A — no functional code changes


---
_Generated by [Claude Code](https://claude.ai/code/session_013eMvQShpiYzjcJDXULBViR)_