### PR TITLE
chore(deps): stop Dependabot from proposing TypeScript major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,8 +22,8 @@ updates:
       # module namespace (e.g. `ts.ScriptTarget` enums), which crashes
       # @rollup/plugin-typescript@12.3.0 (the latest release as of this
       # writing) with "Cannot read properties of undefined (reading
-      # 'ES2015')" during `rollup -c`. See PR #155. Drop this once
-      # @rollup/plugin-typescript ships TS 7 support, then retry the bump.
+      # 'ES2015')" during `rollup -c`. See PR #155 and the "TypeScript 7
+      # upgrade" entry in IDEAS.md for the condition to remove this rule.
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,15 @@ updates:
     schedule:
       interval: weekly
     labels: ["dependencies"]
+    ignore:
+      # TypeScript 7's native-rewrite release changed the shape of the `ts`
+      # module namespace (e.g. `ts.ScriptTarget` enums), which crashes
+      # @rollup/plugin-typescript@12.3.0 (the latest release as of this
+      # writing) with "Cannot read properties of undefined (reading
+      # 'ES2015')" during `rollup -c`. See PR #155. Drop this once
+      # @rollup/plugin-typescript ships TS 7 support, then retry the bump.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: npm
     directory: "/"

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -3,6 +3,18 @@
 A running list of things we deliberately deferred from the first UX prototype, plus
 ideas worth exploring. Nothing here is committed scope; it's a parking lot.
 
+## TypeScript 7 upgrade (blocked on upstream)
+
+> **Status: blocked.** `.github/dependabot.yml` ignores `typescript` major-version
+> bumps in the frontend package until this is resolved.
+
+TypeScript 7.0.2's native-rewrite ("tsgo") release changed the shape of the `ts`
+module's exported enums, which crashes `@rollup/plugin-typescript@12.3.0` (latest
+published as of PR #155) with `Cannot read properties of undefined (reading
+'ES2015')` during `rollup -c`. Revisit once `@rollup/plugin-typescript` publishes a
+release with TS 7 support (`npm view @rollup/plugin-typescript versions`), then
+remove the ignore rule and retry the Dependabot bump.
+
 ## Appliances / assets & device metadata (implemented — see docs/DESIGN.md)
 
 **Status: shipped.** Built as `assets.py` (pure model) + `devices.py` (registry


### PR DESCRIPTION
## Summary

Investigates and addresses the failed Dependabot update in #155
(`typescript` 6.0.3 → 7.0.2, `custom_components/home_keeper/frontend`).

**Root cause:** TypeScript 7.0.2 is the new native-rewrite ("tsgo") release,
which changed the shape of the `ts` module's exported enums. That crashes
`@rollup/plugin-typescript@12.3.0` — the latest version published, and what
we're already on — with:

```
TypeError: Cannot read properties of undefined (reading 'ES2015')
    at .../node_modules/@rollup/plugin-typescript/dist/es/index.js:528:16
```

`bash ci/build-panel.sh` (`rollup -c`) fails as a result, which cascades
into every CI job that builds the panel first: `test`, `integration`, `e2e`,
and `walkthrough` all fail on #155 for this one underlying reason. Jobs that
don't touch the frontend build (`mypy`, `ruff`, `hacs`, `dependabot`,
`release`) pass. There is no newer `@rollup/plugin-typescript` release to
upgrade to yet — 12.3.0 is current on npm — so this is an upstream
incompatibility we can't code around in this repo today.

## Change

Add an `ignore` rule to `.github/dependabot.yml` for `typescript` major-version
bumps in the frontend package, so Dependabot stops reopening this same broken
upgrade every week. The rule is commented with the reason and the condition
for removing it (once `@rollup/plugin-typescript` ships TS 7 support).

PR #155 itself will be closed via a `·@·d·ependabot i·gnore t·his major version`
comment, which is Dependabot's own mechanism for both closing the PR and
honoring the same ignore condition going forward.

## Test plan

- [x] `.github/dependabot.yml` is valid YAML (reviewed by eye — this repo has
      no separate dependabot.yml linter)
- Not applicable: no panel/backend code changed, so no screenshots or CI
  rebuild needed for this developer-only CI-config change.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01MoejQYfmuUY1WunVW9L8kE

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoejQYfmuUY1WunVW9L8kE)_