### PR TITLE
Cut 0.10.0b1 beta after 0.9.0 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ versioning (with PEP 440 pre-release suffixes — `bN`/`aN`/`rcN` — for betas)
 
 ## [Unreleased]
 
+## [0.10.0b1]
+
 ### Fixed
 
 - **Notification action buttons and text were hardcoded in English.** The "Mark

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor", "number"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.9.0"
+PANEL_VERSION = "0.10.0b1"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "Babel>=2.12"
   ],
-  "version": "0.9.0"
+  "version": "0.10.0b1"
 }


### PR DESCRIPTION
## Summary

- Bumps `manifest.json` `version` and `const.py` `PANEL_VERSION` from `0.9.0` to `0.10.0b1`, per the AGENTS.md rule to move `main` to the next beta after a stable release ships.
- Renames the `CHANGELOG.md` `## [Unreleased]` section to `## [0.10.0b1]`, rolling in the localization fixes (#150, follow-up audit) merged to `main` since `0.9.0` shipped.

This is a version/changelog housekeeping change only — no functional code changes. Developer-only, so no screenshots/walkthrough/beta-testing docs are needed.

## Test plan

- [x] `pytest tests/unit -v` — 677 passed, 1 skipped
- [x] Verified `manifest.json` is valid JSON
- [x] Confirmed no other stray `0.9.0` version references need bumping

---
_Generated by [Claude Code](https://claude.ai/code/session_013EyZ66djHj9ug7Hffbae9o)_