### PR TITLE
Cut 0.11.0 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Home Keeper are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
 
-## [0.11.0b1]
+## [0.11.0] - 2026-08-03
 
 ### Added
 

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor", "number"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.11.0b1"
+PANEL_VERSION = "0.11.0"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "Babel>=2.12"
   ],
-  "version": "0.11.0b1"
+  "version": "0.11.0"
 }


### PR DESCRIPTION
## Summary

Cuts the `0.11.0` stable release per `RELEASE.md`. `0.11.0b1` has been out as the
only beta since `0.10.0` shipped, carrying a single feature, so this closes it out
as stable with no further changes:

- `custom_components/home_keeper/manifest.json` — `version` → `0.11.0`
- `custom_components/home_keeper/const.py` — `PANEL_VERSION` → `0.11.0`
- `CHANGELOG.md` — `## [0.11.0b1]` → `## [0.11.0] - 2026-08-03`

No `### Fixed` section: no GitHub issues were closed by commits since `0.10.0`
(only PR #176, the dashboard-card hide-when-empty toggle, already reflected in the
`0.11.0b1` Added section).

No UI changes in this diff (pure version/changelog bump), so the screenshots and
walkthrough gates don't apply.

## Test plan

- [x] `pytest tests/unit -v` — 692 passed, 1 skipped
- [x] On merge, `release.yml` will verify `manifest.json`/`const.py` versions match
      the `## [0.11.0]` CHANGELOG section, tag `v0.11.0`, and publish the stable
      GitHub Release with `home_keeper.zip` attached


---
_Generated by [Claude Code](https://claude.ai/code/session_01PvURwsQCmxKWTnQiU5Jw58)_