### PR TITLE
CI: gate pull requests on mutation testing (mutmut + Stryker)

### DIFF
--- a/.amazonq/rules/testing-and-workflow.md
+++ b/.amazonq/rules/testing-and-workflow.md
@@ -44,6 +44,16 @@
 ## Tests (run locally before pushing — never use CI as the test runner)
 - The recurrence engine and model are the correctness core: keep them HA-free and
   thoroughly unit-tested. `pytest tests/unit` must run without the HA harness.
+  `tests/conftest.py` *executes* the pure modules under their real dotted name
+  (`custom_components.home_keeper.<mod>`, with stub parent packages so the
+  HA-importing `__init__.py` never runs) and registers `hk.<mod>` / `hk_<mod>` as
+  aliases. **Two invariants there:** mutmut matches a mutant's path-derived key
+  against the function's `__module__`, so executing them as `hk.<mod>` would make
+  every mutant look untested; and `hk` must stay a *distinct* package object, not
+  an alias of `custom_components.home_keeper`, because `from . import x` resolves
+  through the parent's `__name__` — aliasing them makes the modules
+  `test_coordinator_purge.py` / `test_calendar.py` load as `hk.coordinator` pull
+  in the real HA-importing siblings instead of their fakes.
 - Layers: `tests/unit` (pytest, pure logic), `tests/frontend` +
   `frontend/test` (vitest), `tests/integration` (Docker HA), `tests/e2e`
   (Playwright), `tests/upgrade` (two-phase HA version upgrade). Run e2e/integration
@@ -68,6 +78,39 @@
 - After running the Docker HA container locally, restore the seeded fixtures
   (`tests/integration/ha_config/.storage/{home_keeper,core.config_entries}`);
   don't commit runtime-mutated state.
+
+## Mutation testing (a PR gate)
+Coverage proves a line *ran*; mutation testing proves a test would have *failed*
+had that line been wrong. `mutation.yml` runs on every PR and scores only the code
+the branch touched.
+
+- **Runners:** `ci/test-mutation-python.sh` (mutmut, against `tests/unit`) and
+  `ci/test-mutation-frontend.sh` (Stryker, against vitest). Both take `--changed`
+  (default) or `--all`.
+- **The surface is an allowlist, in one place per language:** `only_mutate` in
+  `[tool.mutmut]` (pyproject.toml) and `mutate` in `stryker.conf.json`. It holds
+  only what the fast tiers cover — the pure core, and the focused frontend modules
+  (`utils`, `forms`, `card-filter`, `documents`, `markdown`, `i18n`, `limits`).
+  Out: everything importing Home Assistant (Docker-tier only), `const.py` /
+  `companions_catalog.py` (data), `backend_i18n.py` (no unit entry point),
+  `testing.py`, and `panel.ts` / `card.ts` / `api.ts` (indirectly covered only).
+- **Diff scoping:** `ci/mutation_scope.py` turns the diff into mutmut mutant-name
+  filters (changed line → enclosing function, decorators included, via `ast`) and
+  Stryker `--mutate` line ranges. Scoping to whole files would fail a PR for
+  pre-existing debt.
+- **The gate is 80%**, in `[tool.mutation-gate] break` and mirrored in
+  `thresholds.break`; both runners fail on a mismatch so they cannot drift.
+  `--all` may sit below it while the surface is being brought up — the PR gate is
+  what must stay green.
+- **Surviving mutants are a test gap, not a formality.** Kill them with a real
+  assertion. For a genuinely *equivalent* mutant, annotate at the source
+  (`# pragma: no mutate`, `// Stryker disable next-line <mutator>`) **with a
+  one-line reason**. Never blanket-disable a file; never lower the threshold.
+- **Tests that read source off disk must be `*-parity.test.js`.** Under Stryker
+  they would read *mutated* text and go red for mutants they never exercised —
+  `forms.ts` is full of `t('…')` call sites, so this inflates the score badly.
+  `vitest.stryker.config.js` excludes that suffix.
+- Label a PR `skip-mutation` to bypass both jobs (revert/infra PRs).
 
 ## Translations (quality gates)
 `strings.json` (backend) and `frontend/src/locales/en.json` are the sources of

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -66,7 +66,9 @@ jobs:
     name: TypeScript
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-mutation') }}
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # Diff-scoped runs take minutes; the headroom is for a manual `--all`, which
+    # is ~40 minutes over the full 1,800-mutant frontend surface.
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,100 @@
+name: Mutation
+
+# Mutation testing on the code a pull request actually changed.
+#
+# Line coverage proves a line ran; it says nothing about whether a test would
+# have failed had that line been wrong. These jobs mutate the changed functions
+# (Python, via mutmut) and the changed line ranges (TypeScript, via Stryker) and
+# fail when too few of those mutants are caught.
+#
+# Scope is deliberately narrow — see `only_mutate` in pyproject.toml and
+# `mutate` in stryker.conf.json. Judging a whole file would fail pull requests
+# for debt they did not introduce, so ci/mutation_scope.py maps the diff onto
+# just the functions/lines it touched.
+#
+# Label a pull request `skip-mutation` to bypass both jobs.
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      scope:
+        description: "changed = diff-scoped, all = the whole configured surface"
+        type: choice
+        default: changed
+        options: [changed, all]
+
+concurrency:
+  group: mutation-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  # `--all` on a manual run, diff-scoped everywhere else.
+  MUTATION_MODE: ${{ inputs.scope == 'all' && '--all' || '--changed' }}
+
+jobs:
+  python:
+    name: Python
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-mutation') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # ci/mutation_scope.py needs the base branch to diff against.
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        # The pure unit tier is all mutmut runs, and it needs no Home Assistant
+        # harness — installing one would only slow every mutant down.
+        run: |
+          pip install -r requirements-test.txt
+          pip install mutmut==3.7.0
+      - name: Mutation test
+        env:
+          MUTATION_BASE_REF: origin/${{ github.base_ref || github.event.repository.default_branch }}
+        run: bash ci/test-mutation-python.sh "$MUTATION_MODE"
+
+  typescript:
+    name: TypeScript
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-mutation') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "22.22.2"
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - name: Set up Python
+        # Only for ci/mutation_scope.py and ci/mutation_report.py.
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        # Root only: vitest, jsdom and Stryker live here, and the tests import
+        # `src/*.ts` directly, so the panel never needs building.
+        run: npm ci
+      - name: Mutation test
+        env:
+          MUTATION_BASE_REF: origin/${{ github.base_ref || github.event.repository.default_branch }}
+        run: bash ci/test-mutation-frontend.sh "$MUTATION_MODE"
+      - name: Upload mutation report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: stryker-report
+          path: reports/mutation/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,12 @@ build/
 tests/upgrade/custom_components/
 tests/upgrade/home_keeper_previous/
 tests/upgrade/home_keeper_working_tree/
+
+# Mutation testing scratch (mutmut copies the project into mutants/; Stryker
+# sandboxes into .stryker-tmp/ and writes its report into reports/).
+mutants/
+.mutmut-cache
+.stryker-tmp/
+stryker.log
+reports/
+.venv/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,9 @@
 - **Always run tests locally before pushing.** Never use CI as the test runner.
   - Pure-logic unit tests need only `pip install pytest`: `pytest tests/unit -v`.
   - Full unit suite uses `pip install pytest-homeassistant-custom-component`.
+- **Mutation testing gates every PR** at an 80% mutation score on the code the PR
+  changed — see "Mutation testing" below. It is too slow for the
+  run-before-you-push loop; run it when you touch the mutable surface.
 - **User-facing prose is linted for AI-tell phrasing.** `lint.yml`'s `vale` job runs
   the [vale-ai-tells](https://github.com/tbhb/vale-ai-tells) Vale style (pinned in
   `.vale.ini`) over `README.md`, `CHANGELOG.md`, the canonical `docs/*.md` (not the
@@ -256,6 +259,64 @@ documented in `docs/INTEGRATING.md`. The fuller dedicated **upsert/reconcile**
 contribution service is still deferred — hook point `const.SIGNAL_TASK_CONTRIBUTION`.
 See IDEAS.md before building it.
 
+## Mutation testing (a PR gate)
+
+Coverage measures that a line *ran*. Mutation testing measures whether a test
+would have **failed** if that line were wrong — the difference between a suite
+that executes the code and one that actually asserts on it.
+
+`mutation.yml` runs on every PR, in two jobs:
+
+```bash
+bash ci/test-mutation-python.sh            # mutmut, changed functions only
+bash ci/test-mutation-python.sh --all      # the whole configured surface
+bash ci/test-mutation-frontend.sh          # Stryker, changed line ranges only
+bash ci/test-mutation-frontend.sh --all
+```
+
+- **It only scores what your branch touched.** `ci/mutation_scope.py` maps the
+  diff to mutmut mutant-name filters (changed line → enclosing function,
+  decorators included, via `ast`) and to Stryker `--mutate` line ranges. Scoping
+  to whole files would fail a PR for debt it didn't create.
+- **The mutable surface is an allowlist**, in exactly one place per language:
+  `only_mutate` in `[tool.mutmut]` (pyproject.toml) and `mutate` in
+  `stryker.conf.json`. It holds the pure Python core (`recurrence`, `models`,
+  `assets`, `reconcile`, `notifications`, `sensor_tasks`, `problem_tasks`,
+  `inventory`, `profiles`, `documents`, `events`, `transitions`) and the focused
+  frontend modules (`utils`, `forms`, `card-filter`, `documents`, `markdown`,
+  `i18n`, `limits`). Excluded on purpose: everything importing Home Assistant
+  (only the Docker tiers cover it — far too slow to run once per mutant),
+  `const.py` / `companions_catalog.py` (data, not logic), `backend_i18n.py` (pure
+  but with no unit-test entry point), `testing.py` (already coverage-omitted), and
+  `panel.ts` / `card.ts` / `api.ts` (only indirectly covered; ~7k lines that would
+  score near zero). Widen the allowlist when you add unit tests that would make
+  the score mean something.
+- **The gate is a mutation score of 80%**, set in `[tool.mutation-gate] break` and
+  mirrored in `thresholds.break` (stryker.conf.json). The two runners compare them
+  and fail on a mismatch, so they cannot drift.
+- **Kill surviving mutants with real assertions.** If a mutant is genuinely
+  *equivalent* — it cannot change observable behaviour — annotate it at the source
+  (`# pragma: no mutate`, `// Stryker disable next-line <mutator>`) with a one-line
+  reason. Never blanket-disable a file, and never lower the threshold to get green.
+- **Tests that read `src/*.ts` off disk belong in a `*-parity.test.js` file.**
+  Inside Stryker's sandbox they read *mutated* source, so any mutant touching a
+  string literal turns them red and is scored as "killed" by a test that never ran
+  the behaviour — `forms.ts` alone has dozens of `t('…')` call sites, so this
+  inflates the score badly. `vitest.stryker.config.js` excludes that suffix; the
+  normal `ci/test-frontend.sh` run still includes it.
+- Label a PR `skip-mutation` to bypass both jobs.
+
+`tests/conftest.py` executes the pure modules under their **real** dotted name
+(`custom_components.home_keeper.<mod>`, with stub parent packages so the
+HA-importing `__init__.py` never runs) and registers `hk.<mod>` / `hk_<mod>` as
+aliases. Keep it that way: mutmut matches a mutant's path-derived key against the
+function's `__module__`, and a mismatch makes every mutant look untested. `hk`
+itself must stay a **distinct** package object, not another alias of
+`custom_components.home_keeper` — `from . import x` resolves through the parent's
+`__name__`, so aliasing the two makes the modules that `test_coordinator_purge.py`
+and `test_calendar.py` load as `hk.coordinator` pull in the real HA-importing
+siblings instead of their fakes.
+
 ## Browser e2e tests (Playwright)
 
 - Location: `tests/e2e/` drives a real browser against the same HA Docker container
@@ -280,6 +341,8 @@ See IDEAS.md before building it.
 
 - `lint.yml` — ruff lint + format check, and **mypy** strict typing (HA installed).
 - `test.yml` — vitest, pytest unit, HACS validation, hassfest.
+- `mutation.yml` — mutation testing (mutmut + Stryker) on the code a PR changed;
+  fails below an 80% mutation score. `skip-mutation` label bypasses it.
 - `integration.yml` — Docker-based integration tests.
 - `e2e.yml` — Docker + Playwright; uploads the Playwright report on failure.
 - `ha-beta.yml` — **nightly early warning**, gates nothing. Runs integration, e2e and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 The project's workflow, conventions, and **hard gates** live in `AGENTS.md`
 (imported above) and `.amazonq/rules/`. Read them before pushing.
 
-Two gates worth repeating because they are easy to miss:
+Three gates worth repeating because they are easy to miss:
 
 - **Every PR that touches the panel UI (`custom_components/home_keeper/frontend/src/`)
   MUST include current screenshots** of the changed surface — captured with the
@@ -21,4 +21,11 @@ Two gates worth repeating because they are easy to miss:
   gitignored (zero repo bloat); capture is a soft gate. Pure bug-fix / styling PRs
   stay on the screenshots gate only.
 
-See AGENTS.md "Workflow" for both.
+- **`mutation.yml` gates every PR at an 80% mutation score on the code it changed**
+  (mutmut for Python, Stryker for TypeScript). A surviving mutant means a test
+  executes that code without asserting anything that would catch it being wrong —
+  kill it with a real assertion, or annotate a genuinely equivalent mutant with a
+  reason. Never lower the threshold to get green. The mutable surface is an
+  allowlist: `only_mutate` in `[tool.mutmut]` and `mutate` in `stryker.conf.json`.
+
+See AGENTS.md "Workflow" for the first two and "Mutation testing" for the third.

--- a/ci/mutation_report.py
+++ b/ci/mutation_report.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Score a mutation-testing run, summarise it, and gate on a threshold.
+
+Two input formats, one output shape:
+
+* ``--format mutmut`` reads ``mutmut results --all=1`` on **stdin**. mutmut has
+  no threshold of its own and exits 0 whether or not mutants survived, so this
+  script owns the Python gate.
+* ``--format stryker`` reads Stryker's JSON report. Stryker already gates via
+  ``thresholds.break``; here the script only renders the summary, and the
+  caller propagates Stryker's exit code.
+
+A mutant counts as **detected** when the suite noticed it (killed, timed out, or
+was rejected by the type checker) and **undetected** when it did not (survived,
+or no test covered it at all). Mutants that were never run — the ones outside a
+diff-scoped filter — are excluded from the score rather than counted as
+failures.
+
+The markdown summary is appended to ``$GITHUB_STEP_SUMMARY`` when that is set,
+and always printed to stdout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import sys
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+DEFAULT_THRESHOLD = 80.0
+
+# How mutmut's own status strings map onto detected / undetected. "suspicious"
+# means mutmut got an exit code it could not classify; counting it as undetected
+# keeps the gate honest instead of quietly discarding an unknown.
+MUTMUT_DETECTED = {"killed", "timeout", "caught by type check"}
+MUTMUT_UNDETECTED = {"survived", "no tests", "suspicious"}
+MUTMUT_IGNORED = {"not checked", "skipped", "check was interrupted by user"}
+
+# Stryker statuses, from the mutation-testing-elements schema.
+STRYKER_DETECTED = {"Killed", "Timeout"}
+STRYKER_UNDETECTED = {"Survived", "NoCoverage"}
+STRYKER_IGNORED = {"CompileError", "RuntimeError", "Ignored", "Pending"}
+
+MAX_LISTED = 40
+
+
+def configured_threshold() -> float:
+    """Read ``[tool.mutation-gate] break`` from pyproject.toml.
+
+    An unreadable pyproject.toml is fatal rather than a quiet fall back to
+    ``DEFAULT_THRESHOLD``: silently substituting a threshold nobody configured is
+    how a gate stops meaning anything.
+    """
+    try:
+        with (ROOT / "pyproject.toml").open("rb") as handle:
+            config = tomllib.load(handle)
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        sys.exit(f"[mutation] cannot read the threshold from pyproject.toml: {exc}")
+    section = config.get("tool", {}).get("mutation-gate", {})
+    return float(section.get("break", DEFAULT_THRESHOLD))
+
+
+def check_thresholds_agree(threshold: float) -> None:
+    """Fail if pyproject.toml and stryker.conf.json disagree on the gate.
+
+    The two live apart because each tool reads its own config, so nothing stops
+    them drifting — and a drift means Python and TypeScript are quietly held to
+    different standards. Cheap to check, so check it every run.
+    """
+    try:
+        config = json.loads((ROOT / "stryker.conf.json").read_text("utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        sys.exit(f"[mutation] cannot read stryker.conf.json: {exc}")
+    stryker = config.get("thresholds", {}).get("break")
+    if stryker is None or float(stryker) != threshold:
+        sys.exit(
+            f"[mutation] threshold mismatch: [tool.mutation-gate] break = "
+            f"{threshold:g} but stryker.conf.json thresholds.break = {stryker}. "
+            "Keep them equal."
+        )
+
+
+def parse_mutmut(
+    stream: list[str], scope: list[str]
+) -> tuple[dict[str, int], list[str]]:
+    """Parse ``mutmut results --all=1`` lines into a status tally and survivor list.
+
+    Each line looks like ``    package.module.x_func__mutmut_3: survived``.
+    When *scope* is non-empty only mutants matching one of its glob filters are
+    counted, so a diff-scoped run is not dragged down by the rest of the file.
+    """
+    tally: dict[str, int] = {}
+    undetected: list[str] = []
+    for raw in stream:
+        line = raw.strip()
+        if not line or ": " not in line:
+            continue
+        name, _, status = line.rpartition(": ")
+        name = name.strip()
+        status = status.strip()
+        if scope and not any(fnmatch.fnmatch(name, pattern) for pattern in scope):
+            continue
+        tally[status] = tally.get(status, 0) + 1
+        if status in MUTMUT_UNDETECTED:
+            undetected.append(f"{name} ({status})")
+    return tally, undetected
+
+
+def parse_stryker(path: Path) -> tuple[dict[str, int], list[str]]:
+    """Parse Stryker's JSON report into a status tally and survivor list."""
+    try:
+        report = json.loads(path.read_text("utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        # A truncated report means the run died mid-write. Say so; do not let a
+        # half-read file be scored as if it were the whole run.
+        sys.exit(f"[mutation] cannot read the Stryker report at {path}: {exc}")
+    tally: dict[str, int] = {}
+    undetected: list[str] = []
+    for file_path, entry in sorted(report.get("files", {}).items()):
+        for mutant in entry.get("mutants", []):
+            status = mutant.get("status", "Pending")
+            tally[status] = tally.get(status, 0) + 1
+            if status in STRYKER_UNDETECTED:
+                line = mutant.get("location", {}).get("start", {}).get("line", "?")
+                undetected.append(
+                    f"{file_path}:{line} {mutant.get('mutatorName', '?')} ({status})"
+                )
+    return tally, undetected
+
+
+def score(
+    tally: dict[str, int], detected: set[str], undetected: set[str]
+) -> tuple[float, int, int]:
+    """Mutation score as a percentage, plus the two counts behind it."""
+    hits = sum(count for status, count in tally.items() if status in detected)
+    misses = sum(count for status, count in tally.items() if status in undetected)
+    total = hits + misses
+    return (100.0 if total == 0 else 100.0 * hits / total), hits, misses
+
+
+def render(
+    title: str,
+    tally: dict[str, int],
+    survivors: list[str],
+    percent: float,
+    hits: int,
+    misses: int,
+    threshold: float,
+    passed: bool,
+) -> str:
+    verdict = "✅ pass" if passed else "❌ below threshold"
+    lines = [
+        f"## {title}",
+        "",
+        f"**Mutation score: {percent:.2f}%** ({hits} detected / {hits + misses} scored)"
+        f" — threshold {threshold:.0f}% — {verdict}",
+        "",
+    ]
+    if tally:
+        lines += ["| Outcome | Mutants |", "| --- | ---: |"]
+        lines += [f"| {status} | {count} |" for status, count in sorted(tally.items())]
+        lines.append("")
+    if survivors:
+        shown = survivors[:MAX_LISTED]
+        lines.append(
+            f"<details><summary>Undetected mutants ({len(survivors)})</summary>"
+        )
+        lines.append("")
+        lines += [f"- `{entry}`" for entry in shown]
+        if len(survivors) > len(shown):
+            lines.append(f"- …and {len(survivors) - len(shown)} more")
+        lines += ["", "</details>", ""]
+    return "\n".join(lines)
+
+
+def emit(markdown: str) -> None:
+    print(markdown)
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a", encoding="utf-8") as handle:
+            handle.write(markdown + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--format", required=True, choices=("mutmut", "stryker"))
+    parser.add_argument(
+        "--input", type=Path, help="Stryker JSON report (stryker format)"
+    )
+    parser.add_argument(
+        "--scope-file", type=Path, help="mutant-name filters, one per line"
+    )
+    parser.add_argument("--title", default="Mutation testing")
+    parser.add_argument("--threshold", type=float, default=None)
+    parser.add_argument(
+        "--gate",
+        action="store_true",
+        help="exit non-zero when the score is below the threshold",
+    )
+    parser.add_argument(
+        "--require-mutants",
+        action="store_true",
+        help="exit non-zero when nothing was scored at all",
+    )
+    args = parser.parse_args()
+
+    # Always compare what the *configs* say, even when --threshold overrides the
+    # value used for this run — the point is to catch the two drifting apart.
+    check_thresholds_agree(configured_threshold())
+    threshold = configured_threshold() if args.threshold is None else args.threshold
+
+    if args.format == "mutmut":
+        scope = []
+        if args.scope_file and args.scope_file.exists():
+            scope = [
+                ln.strip()
+                for ln in args.scope_file.read_text("utf-8").splitlines()
+                if ln.strip()
+            ]
+        tally, survivors = parse_mutmut(sys.stdin.readlines(), scope)
+        percent, hits, misses = score(tally, MUTMUT_DETECTED, MUTMUT_UNDETECTED)
+    else:
+        if not args.input or not args.input.exists():
+            emit(
+                f"## {args.title}\n\n"
+                "⚠️ No Stryker report was produced — the run failed before reporting.\n"
+            )
+            # The caller propagates Stryker's own exit code, so this is already
+            # a failure there; return non-zero anyway so the script is honest
+            # when read on its own.
+            return 1 if args.require_mutants else 0
+        tally, survivors = parse_stryker(args.input)
+        percent, hits, misses = score(tally, STRYKER_DETECTED, STRYKER_UNDETECTED)
+
+    known = (
+        MUTMUT_DETECTED | MUTMUT_UNDETECTED | MUTMUT_IGNORED
+        if args.format == "mutmut"
+        else STRYKER_DETECTED | STRYKER_UNDETECTED | STRYKER_IGNORED
+    )
+    unknown = sorted(set(tally) - known)
+    if unknown:
+        # A status this script does not classify is silently absent from the
+        # score, which would quietly weaken the gate. Say so loudly instead.
+        print(
+            f"[mutation] unclassified outcome(s) {unknown} — not counted in the "
+            "score; teach ci/mutation_report.py about them.",
+            file=sys.stderr,
+        )
+
+    scored = hits + misses
+    passed = scored == 0 or percent >= threshold
+    emit(render(args.title, tally, survivors, percent, hits, misses, threshold, passed))
+
+    if scored == 0 and args.require_mutants:
+        # The caller only gets here having asked for a non-empty scope, so zero
+        # scored mutants means the run did not do its job — every mutant errored,
+        # the filters matched nothing, or the tool died part-way. Treating that as
+        # a pass is the one failure mode worse than a false red.
+        print(
+            f"[mutation] no mutants were scored, but {len(tally)} outcome(s) were "
+            "reported and a scope was requested — the run did not test anything.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if scored == 0:
+        print(
+            "[mutation] no mutants were scored — nothing to gate on.", file=sys.stderr
+        )
+    return 0 if passed or not args.gate else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/mutation_scope.py
+++ b/ci/mutation_scope.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Map a branch's diff onto the mutation-testing surface.
+
+Mutation testing is expensive, and judging a pull request on a whole file's
+score would fail it for debt it did not create. So the PR check mutates only
+what the branch actually touched:
+
+* **Python** — changed lines are mapped, via ``ast``, to the enclosing top-level
+  function or method (decorators included), and printed as mutmut mutant-name
+  filters (``package.module.x_func*``). mutmut only builds mutants for top-level
+  functions and methods, so a changed line outside one — module-level code, a
+  nested closure — contributes no filter. There is nothing to run for those, but
+  it does mean the surface should stay free of significant module-level logic.
+* **TypeScript** — changed hunks are printed directly as Stryker ``--mutate``
+  line ranges (``path/to/file.ts:12-40``).
+
+Either way, only files already on the configured surface are considered: the
+``only_mutate`` list in ``[tool.mutmut]`` for Python and ``mutate`` in
+``stryker.conf.json`` for TypeScript. Those two lists are the single definition
+of what is worth mutating; this script never widens them.
+
+Prints one filter/range per line to stdout. Empty output means "the diff touched
+nothing mutable" — callers should treat that as a pass, not an error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import fnmatch
+import json
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# mutmut mangles a method into ``xǁClassǁmethod`` and a bare function into
+# ``x_function`` (mutmut.mutation.trampoline_templates.CLASS_NAME_SEPARATOR).
+CLASS_NAME_SEPARATOR = "ǁ"
+
+_HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+
+def _git(*args: str) -> str:
+    """Run git in the repo root and return stdout, or fail loudly."""
+    result = subprocess.run(
+        ["git", *args],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.exit(
+            f"[mutation-scope] git {' '.join(args)} failed: {result.stderr.strip()}"
+        )
+    return result.stdout
+
+
+def python_surface() -> list[str]:
+    """The ``only_mutate`` globs from ``[tool.mutmut]``."""
+    try:
+        with (ROOT / "pyproject.toml").open("rb") as handle:
+            config = tomllib.load(handle)
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        sys.exit(f"[mutation-scope] cannot read pyproject.toml: {exc}")
+    return list(config.get("tool", {}).get("mutmut", {}).get("only_mutate", []))
+
+
+def typescript_surface() -> list[str]:
+    """The ``mutate`` globs from ``stryker.conf.json``."""
+    try:
+        config = json.loads((ROOT / "stryker.conf.json").read_text("utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        sys.exit(f"[mutation-scope] cannot read stryker.conf.json: {exc}")
+    return list(config.get("mutate", []))
+
+
+def _on_surface(path: str, surface: list[str]) -> bool:
+    return any(fnmatch.fnmatch(path, pattern) for pattern in surface)
+
+
+def changed_hunks(base: str, surface: list[str]) -> dict[str, list[tuple[int, int]]]:
+    """Return ``{path: [(start, end), ...]}`` for surface files changed since *base*.
+
+    Line numbers are in the *new* file. ``--unified=0`` keeps each hunk tight
+    around the real edit instead of dragging in three lines of context either
+    side, which would pull untouched neighbouring functions into scope.
+    """
+    merge_base = _git("merge-base", base, "HEAD").strip()
+    if not merge_base:
+        sys.exit(f"[mutation-scope] could not find a merge base with {base}")
+    diff = _git(
+        "diff",
+        "--unified=0",
+        "--diff-filter=ACMR",  # skip deletions: there is nothing left to mutate
+        merge_base,
+        "HEAD",
+    )
+
+    hunks: dict[str, list[tuple[int, int]]] = {}
+    current: str | None = None
+    for line in diff.splitlines():
+        if line.startswith("+++ "):
+            target = line[4:].strip()
+            # "+++ b/path/to/file" — or "/dev/null" for a deleted file.
+            path = target[2:] if target.startswith("b/") else target
+            current = path if _on_surface(path, surface) else None
+            continue
+        if current is None or not line.startswith("@@"):
+            continue
+        match = _HUNK_RE.match(line)
+        if not match:
+            # Never silently narrow the scope: an unrecognised header would drop
+            # a real change and quietly turn the gate green.
+            sys.exit(f"[mutation-scope] unparseable hunk header in {current}: {line}")
+        start = int(match.group(1))
+        count = 1 if match.group(2) is None else int(match.group(2))
+        if count == 0:
+            # A pure deletion. `start` is the line *before* the removed block, so
+            # cover both it and the line that followed it — the deleted code sat
+            # between them, and either neighbour may be the enclosing function.
+            hunks.setdefault(current, []).append((start, start + 1))
+            continue
+        hunks.setdefault(current, []).append((start, start + count - 1))
+    return hunks
+
+
+def _module_name(path: str) -> str:
+    return path[: -len(".py")].replace("/", ".")
+
+
+def _definition_span(node: ast.AST) -> tuple[int, int]:
+    """First-to-last line of a definition, decorators included."""
+    start = node.lineno  # type: ignore[attr-defined]
+    for decorator in getattr(node, "decorator_list", []):
+        start = min(start, decorator.lineno)
+    return start, node.end_lineno  # type: ignore[attr-defined]
+
+
+def _overlaps(span: tuple[int, int], ranges: list[tuple[int, int]]) -> bool:
+    start, end = span
+    return any(
+        hunk_start <= end and hunk_end >= start for hunk_start, hunk_end in ranges
+    )
+
+
+def python_filters(hunks: dict[str, list[tuple[int, int]]]) -> list[str]:
+    """Turn changed line ranges into mutmut mutant-name filters."""
+    filters: list[str] = []
+    for path, ranges in sorted(hunks.items()):
+        module = _module_name(path)
+        try:
+            tree = ast.parse((ROOT / path).read_text("utf-8"), filename=path)
+        except (OSError, SyntaxError) as exc:
+            # Failing loudly beats silently emitting no filter for the file:
+            # an empty scope reads as "nothing to test" and would pass the gate.
+            sys.exit(f"[mutation-scope] cannot parse {path}: {exc}")
+        for node in tree.body:
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                if _overlaps(_definition_span(node), ranges):
+                    filters.append(f"{module}.x_{node.name}*")
+            elif isinstance(node, ast.ClassDef):
+                for child in node.body:
+                    if not isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef):
+                        continue
+                    if _overlaps(_definition_span(child), ranges):
+                        sep = CLASS_NAME_SEPARATOR
+                        filters.append(f"{module}.x{sep}{node.name}{sep}{child.name}*")
+    return filters
+
+
+def typescript_ranges(hunks: dict[str, list[tuple[int, int]]]) -> list[str]:
+    """Turn changed line ranges into Stryker ``--mutate`` arguments."""
+    return [
+        f"{path}:{start}-{end}"
+        for path, ranges in sorted(hunks.items())
+        for start, end in ranges
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--language", required=True, choices=("python", "typescript"))
+    parser.add_argument(
+        "--base",
+        default="origin/main",
+        help="branch to diff against (default: origin/main)",
+    )
+    args = parser.parse_args()
+
+    if args.language == "python":
+        surface = python_surface()
+        hunks = changed_hunks(args.base, surface)
+        scope = python_filters(hunks)
+    else:
+        surface = typescript_surface()
+        hunks = changed_hunks(args.base, surface)
+        scope = typescript_ranges(hunks)
+
+    for entry in scope:
+        print(entry)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/test-mutation-frontend.sh
+++ b/ci/test-mutation-frontend.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Mutation testing for the frontend TypeScript, via Stryker.
+#
+#   bash ci/test-mutation-frontend.sh          # only what changed vs the base branch
+#   bash ci/test-mutation-frontend.sh --all    # the whole configured surface
+#
+# The surface and the gate both live in `stryker.conf.json` (`mutate` and
+# `thresholds.break`); Stryker owns the exit code. Set MUTATION_BASE_REF to diff
+# against something other than origin/main.
+#
+# Stryker runs from the repo root against `vitest.stryker.config.js` — the root
+# is where vitest and jsdom are installed, and the tests import `src/*.ts`
+# directly, so no panel build is needed.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+MODE="${1:---changed}"
+BASE="${MUTATION_BASE_REF:-origin/main}"
+REPORT="reports/mutation/mutation.json"
+
+STRYKER_ARGS=()
+
+if [ "$MODE" = "--all" ]; then
+  echo "[mutation] mutating the full TypeScript surface"
+else
+  echo "[mutation] scoping to TypeScript changed against $BASE"
+  SCOPE_FILE="$(mktemp)"
+  trap 'rm -f "$SCOPE_FILE"' EXIT
+  python3 ci/mutation_scope.py --language typescript --base "$BASE" > "$SCOPE_FILE"
+  if [ ! -s "$SCOPE_FILE" ]; then
+    python3 - <<'PY'
+import os
+
+message = (
+    "## Mutation testing (TypeScript)\n\n"
+    "No mutable TypeScript changed in this pull request — nothing to test.\n"
+)
+print(message)
+summary = os.environ.get("GITHUB_STEP_SUMMARY")
+if summary:
+    with open(summary, "a", encoding="utf-8") as handle:
+        handle.write(message + "\n")
+PY
+    exit 0
+  fi
+  echo "[mutation] scope:"
+  sed 's/^/    /' "$SCOPE_FILE"
+  mapfile -t RANGES < "$SCOPE_FILE"
+  STRYKER_ARGS=(--mutate "$(IFS=,; echo "${RANGES[*]}")")
+fi
+
+rm -f "$REPORT"
+
+set +e
+npx stryker run "${STRYKER_ARGS[@]}"
+RUN_STATUS=$?
+set -e
+
+# Summarise regardless of outcome, then hand Stryker's verdict back to the
+# caller — `thresholds.break` in stryker.conf.json is the gate. A Stryker crash
+# that never wrote a report still fails here, because RUN_STATUS carries it.
+python3 ci/mutation_report.py \
+  --format stryker \
+  --input "$REPORT" \
+  --title "Mutation testing (TypeScript)" \
+  --require-mutants
+
+exit "$RUN_STATUS"

--- a/ci/test-mutation-python.sh
+++ b/ci/test-mutation-python.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Mutation testing for the pure Python core, via mutmut.
+#
+#   bash ci/test-mutation-python.sh            # only what changed vs the base branch
+#   bash ci/test-mutation-python.sh --all      # the whole configured surface
+#
+# The surface is `only_mutate` in `[tool.mutmut]` (pyproject.toml) and the gate
+# is `[tool.mutation-gate] break`. Mutants run against the pure unit tier only:
+# it is the one tier fast enough to run thousands of times, and the tier whose
+# assertions the score is actually measuring. Set MUTATION_BASE_REF to diff
+# against something other than origin/main.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+MODE="${1:---changed}"
+BASE="${MUTATION_BASE_REF:-origin/main}"
+MUTMUT=(python -m mutmut)
+
+SCOPE_FILE="$(mktemp)"
+trap 'rm -f "$SCOPE_FILE"' EXIT
+
+if [ "$MODE" = "--all" ]; then
+  echo "[mutation] mutating the full Python surface"
+  : > "$SCOPE_FILE"
+else
+  echo "[mutation] scoping to Python changed against $BASE"
+  python3 ci/mutation_scope.py --language python --base "$BASE" > "$SCOPE_FILE"
+  if [ ! -s "$SCOPE_FILE" ]; then
+    python3 - <<'PY'
+import os
+
+message = (
+    "## Mutation testing (Python)\n\n"
+    "No mutable Python changed in this pull request — nothing to test.\n"
+)
+print(message)
+summary = os.environ.get("GITHUB_STEP_SUMMARY")
+if summary:
+    with open(summary, "a", encoding="utf-8") as handle:
+        handle.write(message + "\n")
+PY
+    exit 0
+  fi
+  echo "[mutation] scope:"
+  sed 's/^/    /' "$SCOPE_FILE"
+fi
+
+# mutmut exits 0 whether or not mutants survived, and non-zero on its own
+# internal errors. Either way we want the report, so capture the status and
+# let ci/mutation_report.py decide the outcome.
+set +e
+if [ "$MODE" = "--all" ]; then
+  "${MUTMUT[@]}" run
+else
+  mapfile -t FILTERS < "$SCOPE_FILE"
+  "${MUTMUT[@]}" run "${FILTERS[@]}"
+fi
+RUN_STATUS=$?
+set -e
+
+if [ "$RUN_STATUS" -ne 0 ]; then
+  echo "[mutation] mutmut exited $RUN_STATUS" >&2
+  exit "$RUN_STATUS"
+fi
+
+"${MUTMUT[@]}" results --all=1 | python3 ci/mutation_report.py \
+  --format mutmut \
+  --scope-file "$SCOPE_FILE" \
+  --title "Mutation testing (Python)" \
+  --gate \
+  --require-mutants

--- a/custom_components/home_keeper/frontend/test/i18n-parity.test.js
+++ b/custom_components/home_keeper/frontend/test/i18n-parity.test.js
@@ -1,0 +1,168 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_LOCALE, LOCALES } from '../src/locales/index.ts';
+import unusedKeysBaseline from './unused-keys-baseline.json';
+
+// Translation quality gates: locale key/placeholder parity, untranslated leaks,
+// key usage and plural completeness. The key-usage gate reads `src/*.ts` off
+// disk and analyses it as text, so this file is deliberately separate from the
+// behavioural `i18n.test.js` and is excluded from the mutation run — under
+// Stryker it would be reading *mutated* source and scoring bogus kills. See
+// `vitest.stryker.config.js`.
+
+// --- Shared helpers for source/value-level guardrails -----------------------
+
+// Strings identical to English by design in every language. `app.title` is the
+// product name, `due.none` is an em dash, and `managed.completionHint` is the
+// bare `{prompt}` placeholder (no translatable text). Keep this tiny.
+const INTENTIONALLY_IDENTICAL = new Set(['app.title', 'due.none', 'managed.completionHint']);
+
+// Per-locale cognates / loanwords whose translation is genuinely identical to
+// English in that language (reviewed individually): German "Name"/"Status",
+// French "Stock"/"Date", Dutch "week"/"Label", universal "Model"/"Link"/"Type".
+// Locale-specific, so the guard stays strict for every other locale.
+// `field.doc_url` is "URL" in every language (a universal token); `field.doc_name`
+// is a cognate ("Name") in the languages noted below.
+const COGNATE_IDENTICAL = {
+  ca: ['field.cost', 'field.doc_url', 'field.model', 'field.notes', 'field.sensor_entity_id', 'meta.seed.notes', 'opt.meta.text', 'section.notes', 'settings.general_heading'],
+  cs: ['field.doc_url', 'field.model', 'opt.meta.text'],
+  da: ['chip.orphaned', 'field.doc_url', 'field.kind', 'field.model', 'field.note', 'field.sensor_entity_id', 'field.type', 'group.integration', 'group.status', 'opt.meta.link'],
+  de: ['chip.orphaned', 'detail.about', 'field.doc_name', 'field.doc_url', 'field.name', 'field.sensor_entity_id', 'group.integration', 'group.status', 'opt.meta.link', 'opt.meta.text'],
+  es: ['field.doc_url', 'field.sensor_entity_id', 'settings.general_heading'],
+  fi: ['field.doc_url'],
+  fr: ['completion.photo', 'field.doc_url', 'field.kind', 'field.note', 'field.notes', 'field.stock', 'field.type', 'meta.seed.notes', 'notify.defaultName', 'notify.heading', 'notify.style', 'opt.meta.date', 'section.notes'],
+  it: ['field.area_id', 'field.doc_url', 'group.area', 'opt.meta.link'],
+  nb: ['field.doc_url', 'field.kind', 'field.sensor_entity_id', 'field.type', 'group.status'],
+  nl: ['detail.about', 'field.doc_url', 'field.kind', 'field.label', 'field.model', 'field.sensor_entity_id', 'field.type', 'group.status', 'opt.meta.link', 'recurrence.unit.week.one', 'section.later'],
+  pl: ['field.doc_url', 'field.model', 'group.status', 'opt.meta.link'],
+  'pt-BR': ['field.doc_url', 'field.sensor_entity_id', 'group.status', 'opt.meta.link'],
+  ru: ['field.doc_url'],
+  sv: ['chip.orphaned', 'field.doc_url', 'field.sensor_entity_id', 'group.integration', 'group.status', 'opt.meta.text'],
+  'zh-Hans': ['field.doc_url'],
+};
+
+// Concatenate all panel TypeScript sources once for static key analysis.
+const SRC = (() => {
+  // CI runs vitest from the repo root; fall back to the frontend dir if invoked
+  // from there directly.
+  const rel = 'custom_components/home_keeper/frontend/src';
+  const dir = existsSync(resolve(process.cwd(), rel)) ? resolve(process.cwd(), rel) : resolve(process.cwd(), 'src');
+  return readdirSync(dir)
+    .filter((f) => f.endsWith('.ts'))
+    .map((f) => readFileSync(`${dir}/${f}`, 'utf8'))
+    .join('\n');
+})();
+
+// Literal keys passed to t()/tn(): `fn('key')`, `fn('key', …)` — quote then ) or ,
+const literalKeys = (fn) =>
+  [...SRC.matchAll(new RegExp(`\\b${fn}\\(\\s*['"]([^'"]+)['"]\\s*[),]`, 'g'))].map((m) => m[1]);
+const T_KEYS = literalKeys('t');
+const TN_KEYS = literalKeys('tn');
+
+// Dynamic key prefixes: `fn('p.' + …)` concat or `fn(\`p.${…}\`)` template.
+const DYN_PREFIXES = [
+  ...new Set([
+    ...[...SRC.matchAll(/\b(?:t|tn)\(\s*['"]([^'"]*)['"]\s*\+/g)].map((m) => m[1]),
+    ...[...SRC.matchAll(/\b(?:t|tn)\(\s*`([^`$]*)\$\{/g)].map((m) => m[1]),
+  ]),
+].filter((p) => p.includes('.'));
+
+// Dotted keys appearing as bare quoted literals (e.g. labelKey lookup tables).
+const QUOTED_KEYS = new Set(
+  [...SRC.matchAll(/['"]([a-z][\w]*(?:\.[\w]+)+)['"]/g)].map((m) => m[1]),
+);
+
+const PLURAL_SUFFIX = /^(.*)\.(one|two|few|many|zero|other)$/;
+
+describe('locale key parity', () => {
+  const enKeys = Object.keys(LOCALES[DEFAULT_LOCALE]).sort();
+  for (const [lang, table] of Object.entries(LOCALES)) {
+    if (lang === DEFAULT_LOCALE) continue;
+    it(`${lang} contains every English key`, () => {
+      const keys = new Set(Object.keys(table));
+      const missing = enKeys.filter((k) => !keys.has(k));
+      expect(missing).toEqual([]);
+    });
+    it(`${lang} preserves placeholder tokens for shared keys`, () => {
+      const tokens = (s) => (s.match(/\{\w+\}/g) || []).sort();
+      for (const key of enKeys) {
+        if (table[key] === undefined) continue;
+        expect(tokens(table[key])).toEqual(tokens(LOCALES[DEFAULT_LOCALE][key]));
+      }
+    });
+  }
+});
+
+describe('untranslated-string guard', () => {
+  // A locale value equal to its English source is almost always an untranslated
+  // leak. The only escape hatch is INTENTIONALLY_IDENTICAL (identical by design).
+  const en = LOCALES[DEFAULT_LOCALE];
+  for (const [lang, table] of Object.entries(LOCALES)) {
+    if (lang === DEFAULT_LOCALE) continue;
+    it(`${lang} ships no English-identical strings`, () => {
+      const allowed = new Set([...INTENTIONALLY_IDENTICAL, ...(COGNATE_IDENTICAL[lang] || [])]);
+      const leaks = Object.keys(en)
+        .filter((k) => table[k] === en[k] && !allowed.has(k))
+        .sort();
+      // Translate these, or (if identical by design) add to the allowlist above.
+      expect(leaks).toEqual([]);
+    });
+  }
+});
+
+describe('key usage', () => {
+  const enKeys = Object.keys(LOCALES[DEFAULT_LOCALE]);
+
+  it('every literal t() key exists in the English table', () => {
+    const missing = T_KEYS.filter((k) => LOCALES[DEFAULT_LOCALE][k] === undefined);
+    expect(missing).toEqual([]);
+  });
+
+  it('every literal tn() base key has at least an .other category', () => {
+    const missing = TN_KEYS.filter((k) => LOCALES[DEFAULT_LOCALE][`${k}.other`] === undefined);
+    expect(missing).toEqual([]);
+  });
+
+  it('no new unused English keys (heuristic; baseline may only shrink)', () => {
+    const tnBase = new Set(TN_KEYS);
+    const isUsed = (key) => {
+      if (T_KEYS.includes(key) || TN_KEYS.includes(key) || QUOTED_KEYS.has(key)) return true;
+      const m = key.match(PLURAL_SUFFIX);
+      if (m && (tnBase.has(m[1]) || QUOTED_KEYS.has(m[1]))) return true;
+      return DYN_PREFIXES.some((p) => key.startsWith(p));
+    };
+    const unused = enKeys.filter((k) => !isUsed(k)).sort();
+    const baseline = new Set(unusedKeysBaseline);
+    const newlyUnused = unused.filter((k) => !baseline.has(k));
+    const nowUsed = [...baseline].filter((k) => !unused.includes(k)).sort();
+    // newlyUnused: wire the key up in the panel, or delete it from en.json.
+    // nowUsed: a baselined key is referenced now — remove it from the baseline.
+    expect({ newlyUnused, nowUsed }).toEqual({ newlyUnused: [], nowUsed: [] });
+  });
+});
+
+describe('plural-category completeness', () => {
+  // tn() falls back to `.other`, but Slavic/Romance grammar needs few/many. For
+  // each locale, every plural base key must define every CLDR category the
+  // locale uses.
+  const en = LOCALES[DEFAULT_LOCALE];
+  const pluralBases = new Set();
+  for (const k of Object.keys(en)) {
+    const m = k.match(PLURAL_SUFFIX);
+    if (m) pluralBases.add(m[1]);
+  }
+  for (const [lang, table] of Object.entries(LOCALES)) {
+    if (lang === DEFAULT_LOCALE) continue;
+    it(`${lang} defines every plural category it uses`, () => {
+      const cats = new Intl.PluralRules(lang).resolvedOptions().pluralCategories;
+      const missing = [];
+      for (const base of pluralBases) {
+        if (en[`${base}.other`] === undefined) continue;
+        for (const c of cats) if (table[`${base}.${c}`] === undefined) missing.push(`${base}.${c}`);
+      }
+      // Add the missing plural form(s) to the locale.
+      expect(missing.sort()).toEqual([]);
+    });
+  }
+});

--- a/custom_components/home_keeper/frontend/test/i18n.test.js
+++ b/custom_components/home_keeper/frontend/test/i18n.test.js
@@ -1,76 +1,15 @@
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { getLanguage, setLanguage, t, tn } from '../src/i18n.ts';
 import { DEFAULT_LOCALE, LOCALES } from '../src/locales/index.ts';
-import unusedKeysBaseline from './unused-keys-baseline.json';
+
+// Behavioural tests for the i18n module. The translation-quality gates (locale
+// parity, untranslated leaks, key usage, plural completeness) live in
+// `i18n-parity.test.js` — they analyse `src/*.ts` as *text* read off disk, which
+// is a different kind of test, and one the mutation run has to skip (see
+// `vitest.stryker.config.js`).
 
 // The i18n module holds global state; reset to the default after every test.
 afterEach(() => setLanguage(DEFAULT_LOCALE));
-
-// --- Shared helpers for source/value-level guardrails -----------------------
-
-// Strings identical to English by design in every language. `app.title` is the
-// product name, `due.none` is an em dash, and `managed.completionHint` is the
-// bare `{prompt}` placeholder (no translatable text). Keep this tiny.
-const INTENTIONALLY_IDENTICAL = new Set(['app.title', 'due.none', 'managed.completionHint']);
-
-// Per-locale cognates / loanwords whose translation is genuinely identical to
-// English in that language (reviewed individually): German "Name"/"Status",
-// French "Stock"/"Date", Dutch "week"/"Label", universal "Model"/"Link"/"Type".
-// Locale-specific, so the guard stays strict for every other locale.
-// `field.doc_url` is "URL" in every language (a universal token); `field.doc_name`
-// is a cognate ("Name") in the languages noted below.
-const COGNATE_IDENTICAL = {
-  ca: ['field.cost', 'field.doc_url', 'field.model', 'field.notes', 'field.sensor_entity_id', 'meta.seed.notes', 'opt.meta.text', 'section.notes', 'settings.general_heading'],
-  cs: ['field.doc_url', 'field.model', 'opt.meta.text'],
-  da: ['chip.orphaned', 'field.doc_url', 'field.kind', 'field.model', 'field.note', 'field.sensor_entity_id', 'field.type', 'group.integration', 'group.status', 'opt.meta.link'],
-  de: ['chip.orphaned', 'detail.about', 'field.doc_name', 'field.doc_url', 'field.name', 'field.sensor_entity_id', 'group.integration', 'group.status', 'opt.meta.link', 'opt.meta.text'],
-  es: ['field.doc_url', 'field.sensor_entity_id', 'settings.general_heading'],
-  fi: ['field.doc_url'],
-  fr: ['completion.photo', 'field.doc_url', 'field.kind', 'field.note', 'field.notes', 'field.stock', 'field.type', 'meta.seed.notes', 'notify.defaultName', 'notify.heading', 'notify.style', 'opt.meta.date', 'section.notes'],
-  it: ['field.area_id', 'field.doc_url', 'group.area', 'opt.meta.link'],
-  nb: ['field.doc_url', 'field.kind', 'field.sensor_entity_id', 'field.type', 'group.status'],
-  nl: ['detail.about', 'field.doc_url', 'field.kind', 'field.label', 'field.model', 'field.sensor_entity_id', 'field.type', 'group.status', 'opt.meta.link', 'recurrence.unit.week.one', 'section.later'],
-  pl: ['field.doc_url', 'field.model', 'group.status', 'opt.meta.link'],
-  'pt-BR': ['field.doc_url', 'field.sensor_entity_id', 'group.status', 'opt.meta.link'],
-  ru: ['field.doc_url'],
-  sv: ['chip.orphaned', 'field.doc_url', 'field.sensor_entity_id', 'group.integration', 'group.status', 'opt.meta.text'],
-  'zh-Hans': ['field.doc_url'],
-};
-
-// Concatenate all panel TypeScript sources once for static key analysis.
-const SRC = (() => {
-  // CI runs vitest from the repo root; fall back to the frontend dir if invoked
-  // from there directly.
-  const rel = 'custom_components/home_keeper/frontend/src';
-  const dir = existsSync(resolve(process.cwd(), rel)) ? resolve(process.cwd(), rel) : resolve(process.cwd(), 'src');
-  return readdirSync(dir)
-    .filter((f) => f.endsWith('.ts'))
-    .map((f) => readFileSync(`${dir}/${f}`, 'utf8'))
-    .join('\n');
-})();
-
-// Literal keys passed to t()/tn(): `fn('key')`, `fn('key', …)` — quote then ) or ,
-const literalKeys = (fn) =>
-  [...SRC.matchAll(new RegExp(`\\b${fn}\\(\\s*['"]([^'"]+)['"]\\s*[),]`, 'g'))].map((m) => m[1]);
-const T_KEYS = literalKeys('t');
-const TN_KEYS = literalKeys('tn');
-
-// Dynamic key prefixes: `fn('p.' + …)` concat or `fn(\`p.${…}\`)` template.
-const DYN_PREFIXES = [
-  ...new Set([
-    ...[...SRC.matchAll(/\b(?:t|tn)\(\s*['"]([^'"]*)['"]\s*\+/g)].map((m) => m[1]),
-    ...[...SRC.matchAll(/\b(?:t|tn)\(\s*`([^`$]*)\$\{/g)].map((m) => m[1]),
-  ]),
-].filter((p) => p.includes('.'));
-
-// Dotted keys appearing as bare quoted literals (e.g. labelKey lookup tables).
-const QUOTED_KEYS = new Set(
-  [...SRC.matchAll(/['"]([a-z][\w]*(?:\.[\w]+)+)['"]/g)].map((m) => m[1]),
-);
-
-const PLURAL_SUFFIX = /^(.*)\.(one|two|few|many|zero|other)$/;
 
 describe('t()', () => {
   it('looks up a key in the active locale', () => {
@@ -146,96 +85,4 @@ describe('setLanguage() locale resolution', () => {
     setLanguage(undefined);
     expect(getLanguage()).toBe(DEFAULT_LOCALE);
   });
-});
-
-describe('locale key parity', () => {
-  const enKeys = Object.keys(LOCALES[DEFAULT_LOCALE]).sort();
-  for (const [lang, table] of Object.entries(LOCALES)) {
-    if (lang === DEFAULT_LOCALE) continue;
-    it(`${lang} contains every English key`, () => {
-      const keys = new Set(Object.keys(table));
-      const missing = enKeys.filter((k) => !keys.has(k));
-      expect(missing).toEqual([]);
-    });
-    it(`${lang} preserves placeholder tokens for shared keys`, () => {
-      const tokens = (s) => (s.match(/\{\w+\}/g) || []).sort();
-      for (const key of enKeys) {
-        if (table[key] === undefined) continue;
-        expect(tokens(table[key])).toEqual(tokens(LOCALES[DEFAULT_LOCALE][key]));
-      }
-    });
-  }
-});
-
-describe('untranslated-string guard', () => {
-  // A locale value equal to its English source is almost always an untranslated
-  // leak. The only escape hatch is INTENTIONALLY_IDENTICAL (identical by design).
-  const en = LOCALES[DEFAULT_LOCALE];
-  for (const [lang, table] of Object.entries(LOCALES)) {
-    if (lang === DEFAULT_LOCALE) continue;
-    it(`${lang} ships no English-identical strings`, () => {
-      const allowed = new Set([...INTENTIONALLY_IDENTICAL, ...(COGNATE_IDENTICAL[lang] || [])]);
-      const leaks = Object.keys(en)
-        .filter((k) => table[k] === en[k] && !allowed.has(k))
-        .sort();
-      // Translate these, or (if identical by design) add to the allowlist above.
-      expect(leaks).toEqual([]);
-    });
-  }
-});
-
-describe('key usage', () => {
-  const enKeys = Object.keys(LOCALES[DEFAULT_LOCALE]);
-
-  it('every literal t() key exists in the English table', () => {
-    const missing = T_KEYS.filter((k) => LOCALES[DEFAULT_LOCALE][k] === undefined);
-    expect(missing).toEqual([]);
-  });
-
-  it('every literal tn() base key has at least an .other category', () => {
-    const missing = TN_KEYS.filter((k) => LOCALES[DEFAULT_LOCALE][`${k}.other`] === undefined);
-    expect(missing).toEqual([]);
-  });
-
-  it('no new unused English keys (heuristic; baseline may only shrink)', () => {
-    const tnBase = new Set(TN_KEYS);
-    const isUsed = (key) => {
-      if (T_KEYS.includes(key) || TN_KEYS.includes(key) || QUOTED_KEYS.has(key)) return true;
-      const m = key.match(PLURAL_SUFFIX);
-      if (m && (tnBase.has(m[1]) || QUOTED_KEYS.has(m[1]))) return true;
-      return DYN_PREFIXES.some((p) => key.startsWith(p));
-    };
-    const unused = enKeys.filter((k) => !isUsed(k)).sort();
-    const baseline = new Set(unusedKeysBaseline);
-    const newlyUnused = unused.filter((k) => !baseline.has(k));
-    const nowUsed = [...baseline].filter((k) => !unused.includes(k)).sort();
-    // newlyUnused: wire the key up in the panel, or delete it from en.json.
-    // nowUsed: a baselined key is referenced now — remove it from the baseline.
-    expect({ newlyUnused, nowUsed }).toEqual({ newlyUnused: [], nowUsed: [] });
-  });
-});
-
-describe('plural-category completeness', () => {
-  // tn() falls back to `.other`, but Slavic/Romance grammar needs few/many. For
-  // each locale, every plural base key must define every CLDR category the
-  // locale uses.
-  const en = LOCALES[DEFAULT_LOCALE];
-  const pluralBases = new Set();
-  for (const k of Object.keys(en)) {
-    const m = k.match(PLURAL_SUFFIX);
-    if (m) pluralBases.add(m[1]);
-  }
-  for (const [lang, table] of Object.entries(LOCALES)) {
-    if (lang === DEFAULT_LOCALE) continue;
-    it(`${lang} defines every plural category it uses`, () => {
-      const cats = new Intl.PluralRules(lang).resolvedOptions().pluralCategories;
-      const missing = [];
-      for (const base of pluralBases) {
-        if (en[`${base}.other`] === undefined) continue;
-        for (const c of cats) if (table[`${base}.${c}`] === undefined) missing.push(`${base}.${c}`);
-      }
-      // Add the missing plural form(s) to the locale.
-      expect(missing.sort()).toEqual([]);
-    });
-  }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "jsdom": "^30.0.1"
       },
       "devDependencies": {
+        "@stryker-mutator/core": "^9.6.1",
+        "@stryker-mutator/vitest-runner": "^9.6.1",
         "@vitest/ui": "^4.1.9",
         "vitest": "^4.1.10"
       }
@@ -45,6 +47,547 @@
       },
       "engines": {
         "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
+      "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
+      "integrity": "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/helper-replace-supers": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz",
+      "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz",
+      "integrity": "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
+      "integrity": "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz",
+      "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-decorators": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.29.7.tgz",
+      "integrity": "sha512-EtU0Hi3GvrTqD56xKmZvV/uCXK2ZbwVNPNLAquVItcAZpUhkXwWlo3Fmj0c2LxgSf2I8IDULeAepwNP1OefLXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/plugin-syntax-decorators": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-decorators": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.29.7.tgz",
+      "integrity": "sha512-9MTTLbF39X6sqM92JPEsoI7++26hjZvzkxKZy64aMhWLH2mPkJ/Q3AV4QLmls3R14FpSpkOwQQfUh962JGQxxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-destructuring": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.29.7.tgz",
+      "integrity": "sha512-iPX8aD6H9zV5s7ZsqTdNocPN/MGQ5sSMnElKrktxjJRMnB2jN/1p2+R7GkfD6CAYoVFqy5A4XnSIUeGgJzIWpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-explicit-resource-management": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.29.7.tgz",
+      "integrity": "sha512-Rstj7coNz8sE+7Ju7ihpHLI564lsK5pUpNNlvptCIC/16E/S5hbl6n3kESPKdNRmqEWlpn5xpS5Q2dvXBsySLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/plugin-transform-destructuring": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz",
+      "integrity": "sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz",
+      "integrity": "sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/plugin-syntax-typescript": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz",
+      "integrity": "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -244,12 +787,399 @@
         }
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.1.tgz",
+      "integrity": "sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
+      "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+      "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.2.2.tgz",
+      "integrity": "sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/external-editor": "^3.0.3",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.1.tgz",
+      "integrity": "sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+      "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.2.tgz",
+      "integrity": "sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.1.1.tgz",
+      "integrity": "sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.1.1.tgz",
+      "integrity": "sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.5.2.tgz",
+      "integrity": "sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^5.2.1",
+        "@inquirer/confirm": "^6.1.1",
+        "@inquirer/editor": "^5.2.2",
+        "@inquirer/expand": "^5.1.1",
+        "@inquirer/input": "^5.1.2",
+        "@inquirer/number": "^4.1.1",
+        "@inquirer/password": "^5.1.1",
+        "@inquirer/rawlist": "^5.3.1",
+        "@inquirer/search": "^4.2.1",
+        "@inquirer/select": "^5.2.1"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.1.tgz",
+      "integrity": "sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.2.1.tgz",
+      "integrity": "sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.1.tgz",
+      "integrity": "sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
@@ -380,9 +1310,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -400,9 +1327,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -420,9 +1344,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -440,9 +1361,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -460,9 +1378,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -480,9 +1395,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -569,12 +1481,153 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@stryker-mutator/api": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/api/-/api-9.6.1.tgz",
+      "integrity": "sha512-g8VNoFWQWbx0pdal3Vt8jVCZW+v3sc3gi94iI0GVtVgUGTqphAjJF6EAruPTx0lqvtonsaAxn5TD36hcG1d6Wg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mutation-testing-metrics": "3.7.3",
+        "mutation-testing-report-schema": "3.7.3",
+        "tslib": "~2.8.0",
+        "typed-inject": "~5.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/core": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/core/-/core-9.6.1.tgz",
+      "integrity": "sha512-WMgnvf+Wyh/yiruhNZwc8w8DlzmmjXhPjSn5MR8RhAXzlnWji8TQrUYgBUkHk9bEgSaIlB3KZHm37iiU5Q2cLQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@inquirer/prompts": "^8.0.0",
+        "@stryker-mutator/api": "9.6.1",
+        "@stryker-mutator/instrumenter": "9.6.1",
+        "@stryker-mutator/util": "9.6.1",
+        "ajv": "~8.18.0",
+        "chalk": "~5.6.0",
+        "commander": "~14.0.0",
+        "diff-match-patch": "1.0.5",
+        "emoji-regex": "~10.6.0",
+        "execa": "~9.6.0",
+        "json-rpc-2.0": "^1.7.0",
+        "lodash.groupby": "~4.6.0",
+        "minimatch": "~10.2.4",
+        "mutation-server-protocol": "~0.4.0",
+        "mutation-testing-elements": "3.7.3",
+        "mutation-testing-metrics": "3.7.3",
+        "mutation-testing-report-schema": "3.7.3",
+        "npm-run-path": "~6.0.0",
+        "progress": "~2.0.3",
+        "rxjs": "~7.8.1",
+        "semver": "^7.6.3",
+        "source-map": "~0.7.4",
+        "tree-kill": "~1.2.2",
+        "tslib": "2.8.1",
+        "typed-inject": "~5.0.0",
+        "typed-rest-client": "~2.3.0"
+      },
+      "bin": {
+        "stryker": "bin/stryker.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/instrumenter/-/instrumenter-9.6.1.tgz",
+      "integrity": "sha512-5K8wH4Pthly25c2uKKik4Dfcoeou7sbJdFS6u3QIYHlulgFVDJwtEMWTZGkZfs7IiUEXIDNa0keRACq5jn5AvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/core": "~7.29.0",
+        "@babel/generator": "~7.29.0",
+        "@babel/parser": "~7.29.0",
+        "@babel/plugin-proposal-decorators": "~7.29.0",
+        "@babel/plugin-transform-explicit-resource-management": "^7.28.0",
+        "@babel/preset-typescript": "~7.28.0",
+        "@stryker-mutator/api": "9.6.1",
+        "@stryker-mutator/util": "9.6.1",
+        "angular-html-parser": "~10.4.0",
+        "semver": "~7.7.0",
+        "tslib": "2.8.1",
+        "weapon-regex": "~1.3.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@stryker-mutator/util": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/util/-/util-9.6.1.tgz",
+      "integrity": "sha512-Lk/ALVctJjFv1vvwR+CFoKzDCWvsBlq7flDUnmnpuwTrGbm156EdZD1Jjq4o8KdOap0ezUZqQNE9OAI1m2+pUQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@stryker-mutator/vitest-runner": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/vitest-runner/-/vitest-runner-9.6.1.tgz",
+      "integrity": "sha512-eyUHTCf3Ui+SUn/tpFJwzw6MV391kyBLZk/cDHFUfKFELqKMLbvd7e81axArlApKqO6cOnLfrxlwED+2SRN0ow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stryker-mutator/api": "9.6.1",
+        "@stryker-mutator/util": "9.6.1",
+        "semver": "^7.7.4",
+        "tslib": "~2.8.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      },
+      "peerDependencies": {
+        "@stryker-mutator/core": "9.6.1",
+        "vitest": ">=2.0.0"
+      }
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
@@ -747,6 +1800,33 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/angular-html-parser": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/angular-html-parser/-/angular-html-parser-10.4.0.tgz",
+      "integrity": "sha512-++nLNyZwRfHqFh7akH5Gw/JYizoFlMRz0KRigfwfsLqV8ZqlcVRb1LkPEWdYvEKDnbktknM2J4BXaYUGrQZPww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -755,6 +1835,29 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.13",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.13.tgz",
+      "integrity": "sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/bidi-js": {
@@ -766,6 +1869,105 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -776,12 +1978,67 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/css-tree": {
       "version": "3.2.1",
@@ -809,11 +2066,40 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "license": "MIT"
+    },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -824,6 +2110,42 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.404",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.404.tgz",
+      "integrity": "sha512-3WJtd7/lVq2Jnuz6wed1l9+1ZD2u2Tet1/1NBc4Iedkmgbu+I7YuAqdAQ8T+VZtnwysMsAf3IqSq9D1gyZjA2g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/entities": {
       "version": "8.0.0",
@@ -837,12 +2159,55 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
@@ -854,6 +2219,33 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -862,6 +2254,57 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
       }
     },
     "node_modules/fdir": {
@@ -889,6 +2332,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/flatted": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
@@ -911,6 +2370,121 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -923,10 +2497,104 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsdom": {
@@ -981,6 +2649,46 @@
       },
       "engines": {
         "node": "^22.14.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-rpc-2.0": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/json-rpc-2.0/-/json-rpc-2.0-1.7.1.tgz",
+      "integrity": "sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/lightningcss": {
@@ -1126,9 +2834,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1150,9 +2855,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1174,9 +2876,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1198,9 +2897,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1256,6 +2952,13 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "11.5.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
@@ -1275,11 +2978,44 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "license": "CC0-1.0"
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/mrmime": {
       "version": "2.0.1",
@@ -1289,6 +3025,60 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mutation-server-protocol": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mutation-server-protocol/-/mutation-server-protocol-0.4.1.tgz",
+      "integrity": "sha512-SBGK0j8hLDne7bktgThKI8kGvGTx3rY3LAeQTmOKZ5bVnL/7TorLMvcVF7dIPJCu5RNUWhkkuF53kurygYVt3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^4.1.12"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mutation-testing-elements": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/mutation-testing-elements/-/mutation-testing-elements-3.7.3.tgz",
+      "integrity": "sha512-SMeIPxngJpfjfNYctFpYQQtlBlZaVO0aoB3FKdwrI8Ee/2bkyUuCZzAOCLv1U9fnmfA37dPFq0Owduoxs2XgGQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/mutation-testing-metrics": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/mutation-testing-metrics/-/mutation-testing-metrics-3.7.3.tgz",
+      "integrity": "sha512-B8QrP0ZomErzTPNlhrzKWPNBln+3afwBZPHv0Q7N8wZZTYxMptzb/Gdm3ExXVmioVYrtZAtsDs7W/T/b2AixOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mutation-testing-report-schema": "3.7.3"
+      }
+    },
+    "node_modules/mutation-testing-report-schema": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/mutation-testing-report-schema/-/mutation-testing-report-schema-3.7.3.tgz",
+      "integrity": "sha512-BHm3MYq+ckO+t5CtlG8zpqxc75rdJCkxVlE+fGuGJM3F7tNCQ/OW2N+TQVHN3BHsYa84+BFc6g3AwDYkUsw2MA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/nanoid": {
@@ -1310,6 +3100,59 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/node-releases": {
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
@@ -1324,6 +3167,19 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse5": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
@@ -1334,6 +3190,16 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pathe": {
@@ -1392,6 +3258,32 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -1399,6 +3291,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/require-from-string": {
@@ -1444,6 +3352,23 @@
         "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -1456,12 +3381,137 @@
         "node": ">=v12.22.7"
       }
     },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/sirv": {
       "version": "3.0.2",
@@ -1476,6 +3526,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/source-map-js": {
@@ -1500,6 +3560,19 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
@@ -1603,13 +3676,66 @@
         "node": ">=20"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/typed-inject": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/typed-inject/-/typed-inject-5.0.0.tgz",
+      "integrity": "sha512-0Ql2ORqBORLMdAW89TQKZsb1PQkFGImFfVmncXWe7a+AA3+7dh7Se9exxZowH4kbnlvKEFkMxUYdHUpjYWFJaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typed-rest-client": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-2.3.1.tgz",
+      "integrity": "sha512-k4kX5Up6qA68D0Cby2AK+6+vM5k3qTxe+/3FqhnHRExjY5cfbOnzjQZbP/LXleF8hVoDvDqxlgk9KK83HoBZlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "6.15.1",
+        "tunnel": "0.0.6",
+        "underscore": "^1.13.8"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "8.9.0",
@@ -1618,6 +3744,50 @@
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+      "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/vite": {
@@ -1800,6 +3970,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/weapon-regex": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/weapon-regex/-/weapon-regex-1.3.6.tgz",
+      "integrity": "sha512-wsf1m1jmMrso5nhwVFJJHSubEBf3+pereGd7+nBKtYJ18KoB/PWJOHS3WRkwS04VrOU0iJr2bZU+l1QaTJ+9nA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -1830,6 +4007,22 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/why-is-node-running": {
@@ -1863,6 +4056,36 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+      "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   },
   "homepage": "https://github.com/prestomation/ha-home-keeper#readme",
   "devDependencies": {
+    "@stryker-mutator/core": "^9.6.1",
+    "@stryker-mutator/vitest-runner": "^9.6.1",
     "@vitest/ui": "^4.1.9",
     "vitest": "^4.1.10"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,39 @@ omit = ["custom_components/home_keeper/testing.py"]
 [tool.coverage.report]
 show_missing = true
 
+# Mutation testing (ci/test-mutation-python.sh). Coverage says a line ran;
+# mutation testing says a test would have *failed* if that line were wrong.
+[tool.mutmut]
+source_paths = ["custom_components/home_keeper"]
+# The mutable surface: the pure core, which the fast `tests/unit` tier covers
+# directly. Everything else in the integration imports Home Assistant and is
+# only exercised by the Docker tiers — far too slow to run once per mutant, and
+# scoring it here would just report noise. Also excluded: const.py and
+# companions_catalog.py (data, not logic), backend_i18n.py (pure but with no
+# unit-test entry point) and testing.py (a helper for *other* integrations'
+# suites, already omitted from coverage).
+only_mutate = [
+    "custom_components/home_keeper/recurrence.py",
+    "custom_components/home_keeper/models.py",
+    "custom_components/home_keeper/assets.py",
+    "custom_components/home_keeper/reconcile.py",
+    "custom_components/home_keeper/notifications.py",
+    "custom_components/home_keeper/sensor_tasks.py",
+    "custom_components/home_keeper/problem_tasks.py",
+    "custom_components/home_keeper/inventory.py",
+    "custom_components/home_keeper/profiles.py",
+    "custom_components/home_keeper/documents.py",
+    "custom_components/home_keeper/events.py",
+    "custom_components/home_keeper/transitions.py",
+]
+pytest_add_cli_args_test_selection = ["tests/unit"]
+
+[tool.mutation-gate]
+# Minimum mutation score, in percent, for both languages. The TypeScript side
+# reads its copy from `thresholds.break` in stryker.conf.json — keep them equal;
+# ci/mutation_report.py fails the run if they drift.
+break = 80
+
 # Strict typing is a Platinum quality-scale gate (see custom_components/home_keeper/
 # quality_scale.yaml). CI runs `mypy custom_components/home_keeper` with Home
 # Assistant installed so HA's own types resolve; keep the integration error-free.

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "./node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "packageManager": "npm",
+  "testRunner": "vitest",
+  "vitest": {
+    "configFile": "vitest.stryker.config.js"
+  },
+  "coverageAnalysis": "perTest",
+  "reporters": ["progress", "clear-text", "json"],
+  "jsonReporter": {
+    "fileName": "reports/mutation/mutation.json"
+  },
+  "tempDirName": ".stryker-tmp",
+  "cleanTempDir": true,
+  "timeoutMS": 15000,
+  "ignorePatterns": [
+    "node_modules",
+    ".git",
+    ".venv",
+    "mutants",
+    "reports",
+    ".stryker-tmp",
+    "docs",
+    "website",
+    "tests/e2e",
+    "tests/upgrade",
+    "tests/integration/ha_config"
+  ],
+  "disableTypeChecks": "custom_components/home_keeper/frontend/src/*.ts",
+  "mutate": [
+    "custom_components/home_keeper/frontend/src/utils.ts",
+    "custom_components/home_keeper/frontend/src/forms.ts",
+    "custom_components/home_keeper/frontend/src/card-filter.ts",
+    "custom_components/home_keeper/frontend/src/documents.ts",
+    "custom_components/home_keeper/frontend/src/markdown.ts",
+    "custom_components/home_keeper/frontend/src/i18n.ts",
+    "custom_components/home_keeper/frontend/src/limits.ts"
+  ],
+  "thresholds": {
+    "high": 90,
+    "low": 80,
+    "break": 80
+  }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,9 +6,19 @@ package. This lets the high-value core tests run without the full HA test harnes
 while still pointing coverage at the real source files in
 ``custom_components/home_keeper``.
 
-Tests that need a real Home Assistant runtime (store, entities, panel
-registration) live under ``tests/integration`` and run against the Docker HA
-container instead.
+The modules are *executed* under their real dotted name
+(``custom_components.home_keeper.<mod>``) with stub parent packages, so the
+package ``__init__.py`` — which does import Home Assistant — never runs.
+``hk.<mod>`` and the flat ``hk_<mod>`` aliases then point at those same module
+objects, which is what the tests import. Executing under the real name matters
+for mutation testing: mutmut derives a mutant's key from the file path and
+matches it against the function's ``__module__``, so a module executed as
+``hk.recurrence`` would leave every mutant looking untested (see
+``ci/test-mutation-python.sh``).
+
+Nothing in the suite imports the real ``custom_components.home_keeper`` package
+in-process — ``tests/integration`` and ``tests/upgrade`` drive a Docker Home
+Assistant over REST/WS — so the stub parents shadow nothing.
 """
 
 from __future__ import annotations
@@ -18,56 +28,72 @@ import sys
 import types
 from pathlib import Path
 
-_COMPONENT_DIR = (
-    Path(__file__).resolve().parent.parent / "custom_components" / "home_keeper"
+_ROOT = Path(__file__).resolve().parent.parent
+_CUSTOM_COMPONENTS_DIR = _ROOT / "custom_components"
+_COMPONENT_DIR = _CUSTOM_COMPONENTS_DIR / "home_keeper"
+
+_PKG = "custom_components.home_keeper"
+_PURE_MODULES = (
+    "const",
+    "recurrence",
+    "models",
+    "assets",
+    "documents",
+    "events",
+    "transitions",
+    "reconcile",
+    "problem_tasks",
+    "sensor_tasks",
+    "inventory",
+    "companions_catalog",
+    "profiles",
+    "notifications",
 )
 
 
+def _stub_package(name: str, path: Path) -> None:
+    """Register an empty package for ``name`` so relative imports resolve.
+
+    Real ``custom_components.home_keeper`` would execute an ``__init__.py`` full
+    of Home Assistant imports; the stub gives the pure modules a parent to hang
+    ``from .const import ...`` off without it.
+    """
+    if name in sys.modules:
+        return
+    pkg = types.ModuleType(name)
+    pkg.__path__ = [str(path)]  # type: ignore[attr-defined]
+    sys.modules[name] = pkg
+
+
 def _load_pure_modules() -> None:
-    """Load const/recurrence/models as an isolated ``hk`` package (no HA imports)."""
+    """Load the pure core as ``hk`` / ``hk_*`` aliases (no HA imports)."""
     if "hk" in sys.modules:
         return
-    pkg = types.ModuleType("hk")
-    pkg.__path__ = [str(_COMPONENT_DIR)]  # type: ignore[attr-defined]
-    sys.modules["hk"] = pkg
-    for name in (
-        "const",
-        "recurrence",
-        "models",
-        "assets",
-        "documents",
-        "events",
-        "transitions",
-        "reconcile",
-        "problem_tasks",
-        "sensor_tasks",
-        "inventory",
-        "companions_catalog",
-        "profiles",
-        "notifications",
-    ):
+    _stub_package("custom_components", _CUSTOM_COMPONENTS_DIR)
+    _stub_package(_PKG, _COMPONENT_DIR)
+    for name in _PURE_MODULES:
         spec = importlib.util.spec_from_file_location(
-            f"hk.{name}", str(_COMPONENT_DIR / f"{name}.py")
+            f"{_PKG}.{name}", str(_COMPONENT_DIR / f"{name}.py")
         )
         assert spec and spec.loader
         module = importlib.util.module_from_spec(spec)
-        sys.modules[f"hk.{name}"] = module
+        sys.modules[f"{_PKG}.{name}"] = module
         spec.loader.exec_module(module)
-    # Convenience top-level aliases for tests.
-    sys.modules["hk_const"] = sys.modules["hk.const"]
-    sys.modules["hk_recurrence"] = sys.modules["hk.recurrence"]
-    sys.modules["hk_models"] = sys.modules["hk.models"]
-    sys.modules["hk_assets"] = sys.modules["hk.assets"]
-    sys.modules["hk_documents"] = sys.modules["hk.documents"]
-    sys.modules["hk_events"] = sys.modules["hk.events"]
-    sys.modules["hk_transitions"] = sys.modules["hk.transitions"]
-    sys.modules["hk_reconcile"] = sys.modules["hk.reconcile"]
-    sys.modules["hk_problem_tasks"] = sys.modules["hk.problem_tasks"]
-    sys.modules["hk_sensor_tasks"] = sys.modules["hk.sensor_tasks"]
-    sys.modules["hk_inventory"] = sys.modules["hk.inventory"]
-    sys.modules["hk_companions_catalog"] = sys.modules["hk.companions_catalog"]
-    sys.modules["hk_profiles"] = sys.modules["hk.profiles"]
-    sys.modules["hk_notifications"] = sys.modules["hk.notifications"]
+    # ``hk.<mod>`` and the flat ``hk_<mod>`` names the tests use are aliases of
+    # the very same module objects, so only one copy of the pure core is loaded.
+    #
+    # ``hk`` stays a *distinct* package object rather than another alias of
+    # ``custom_components.home_keeper``. Python resolves ``from . import x``
+    # through the parent's ``__name__``, so aliasing the two would make a module
+    # loaded as ``hk.coordinator`` (which test_coordinator_purge.py and
+    # test_calendar.py do, against fake ``hk.*`` siblings) reach for
+    # ``custom_components.home_keeper.companions`` and drag in the real
+    # HA-importing module instead of the fake.
+    _stub_package("hk", _COMPONENT_DIR)
+    for name in _PURE_MODULES:
+        module = sys.modules[f"{_PKG}.{name}"]
+        sys.modules[f"hk.{name}"] = module
+        sys.modules[f"hk_{name}"] = module
 
 
 _load_pure_modules()

--- a/vitest.stryker.config.js
+++ b/vitest.stryker.config.js
@@ -1,0 +1,21 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+
+import baseConfig from './vitest.config.js';
+
+// Vitest config used only by Stryker (see stryker.conf.json).
+//
+// It is the normal config minus the `*-parity.test.js` files, which analyse
+// `src/*.ts` as *text* read off disk rather than importing it. Inside Stryker's
+// sandbox they would read *mutated* source, so a mutant that alters any string
+// literal flips them red and gets counted as "killed" by a test that never
+// exercised the behaviour — inflating the score with pure noise. They are
+// parity/lint gates, not behavioural tests, so dropping them here costs no real
+// signal; `ci/test-frontend.sh` still runs them on every PR.
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      exclude: ['**/node_modules/**', '**/*-parity.test.js'],
+    },
+  }),
+);


### PR DESCRIPTION
## What

Adds a `Mutation` workflow that runs on every PR and fails below an **80% mutation score on the code the branch changed** — Python via [mutmut](https://github.com/boxed/mutmut) 3.7, TypeScript via [Stryker](https://stryker-mutator.io/) 9.6.

`pytest_coverage.yml` already tells us a line *ran*. It says nothing about whether a test would have **failed** had that line been wrong. This closes that gap on the correctness core.

Mirrors what just landed in `ha-integration-template` (#26), scaled to this repo's surface.

## Design

**Per-symbol scoping, not per-file.** `ci/mutation_scope.py` reads the diff against the merge base with `--unified=0`, then:

- **Python** — maps each changed line to its enclosing top-level function/method (decorators included) via `ast`, emitting mutmut mutant-name filters (`…recurrence.x_add_months*`; methods as `…xǁClsǁmeth*`).
- **TypeScript** — emits Stryker `--mutate` line ranges (`src/forms.ts:120-148`) directly.

`recurrence.py` alone carries ~1,300 mutants. Scoping to whole files would fail a PR for pre-existing debt it did not introduce; this way a PR is judged only on what it touched.

**The mutable surface is an allowlist**, in exactly one place per language — `only_mutate` in `[tool.mutmut]` and `mutate` in `stryker.conf.json`:

- **Python** (12 modules, ~4,100 lines): `recurrence`, `models`, `assets`, `reconcile`, `notifications`, `sensor_tasks`, `problem_tasks`, `inventory`, `profiles`, `documents`, `events`, `transitions`.
- **TypeScript** (7 modules, ~1,970 lines): `utils`, `forms`, `card-filter`, `documents`, `markdown`, `i18n`, `limits`.

Excluded, deliberately: everything importing Home Assistant (only the Docker tiers cover it — far too slow to run once per mutant), `const.py`/`companions_catalog.py` (data, not logic), `backend_i18n.py` (pure but with no unit-test entry point), `testing.py` (already coverage-omitted), and `panel.ts`/`card.ts`/`api.ts` (~7k lines, only indirectly covered, would score near zero). Widen it as unit tests arrive.

**The gate is 80%**, in `[tool.mutation-gate] break` and mirrored in `thresholds.break`. Both runners compare the two and fail on a mismatch, so they cannot drift apart. Escape hatches: `# pragma: no mutate` / `// Stryker disable next-line` for genuinely equivalent mutants, and a `skip-mutation` PR label.

## Two fixes the tooling forced

Both are real problems with how the tests loaded code, not workarounds:

1. **`tests/conftest.py` now executes the pure modules under their real dotted name.** mutmut matches a mutant's path-derived key against the function's `__module__`; loading them as `hk.recurrence` made *every* mutant look untested and aborted the run outright. The conftest installs stub parent packages (so the HA-importing `__init__.py` still never runs) and keeps `hk.<mod>` / `hk_<mod>` as aliases, so no test import changes.

   **`hk` itself has to stay a distinct package object**, not another alias of `custom_components.home_keeper` — Python resolves `from . import x` through the parent's `__name__`, so aliasing the two made the modules `test_coordinator_purge.py` and `test_calendar.py` load as `hk.coordinator` reach for the real `companions.py` instead of the fake siblings they register. That failed collection on `voluptuous`. Both invariants are now written down in `AGENTS.md` and `.amazonq/rules/testing-and-workflow.md`.

2. **The i18n static-analysis gates split into `i18n-parity.test.js`**, excluded from `vitest.stryker.config.js`. They read `src/*.ts` off disk as text; inside Stryker's sandbox that is *mutated* source. `forms.ts` alone has dozens of `t('…')` call sites, so a StringLiteral mutant there turns the key-usage gate red and is scored as "killed" by a test that never exercised the behaviour — badly inflating the score. `ci/test-frontend.sh` still runs them on every PR; the behavioural `t()`/`tn()`/`setLanguage()` tests stay in `i18n.test.js`.

## Verification

Ran locally, in all directions:

| Scenario | Scope selected | Result |
| --- | --- | ---: |
| This PR's own diff (no mutable source changed) | *empty* | ✅ skipped, exit 0 |
| Scratch commit adding an untested `scratch_bucket()` to `recurrence.py` | `recurrence.x_scratch_bucket*` (14 mutants) | ❌ **0.00%**, exit 1 |
| Scratch commit editing the well-covered `add_months()` body | `recurrence.x_add_months*` (32 mutants, not the file's ~1,300) | ✅ **100.00%**, exit 0 |

Scratch commits were dropped before pushing.

**Full-surface baseline, Python: 79.42%** — 4,079 detected of 5,136 scored (1,028 survived, 29 with no test), in ~2.5 minutes. Just under the gate; the follow-up mutation-pass PR is what closes it. The diff-scoped PR gate is unaffected. TypeScript's full-surface run (1,821 mutants, ~40 min) is finishing as I write this and will be reported in the pass PR.

Pre-existing suites confirmed green after the conftest change: `pytest tests/unit` 717 passed / 1 skipped (bare pytest, no HA harness — matching `main`), `npx vitest run` 333 passed across 13 files, `ruff check`/`ruff format --check` clean over `custom_components tests ci`.

## Notes

- CI-only, developer-facing: no CHANGELOG entry, no beta bump, no `preview-release` label, no UI touched (so no screenshots and no walkthrough edits).
- Conventions recorded in `AGENTS.md`, `CLAUDE.md` and `.amazonq/rules/testing-and-workflow.md`, per the repo's "a convention isn't real until it's in the rules" rule.
- `workflow_dispatch` with `scope: all` runs the full surface on demand. The TypeScript job gets a 75-minute cap for that path; diff-scoped runs take minutes.

---
_Generated by [Claude Code](https://claude.ai/code/session_011FSVAV9NUEmLS79voYAEja)_