### PR TITLE
Stop the mutation gate failing a comment-only edit to a mutable file

### DIFF
--- a/ci/mutation_report.py
+++ b/ci/mutation_report.py
@@ -256,22 +256,24 @@ def main() -> int:
     passed = scored == 0 or percent >= threshold
     emit(render(args.title, tally, survivors, percent, hits, misses, threshold, passed))
 
-    if scored == 0 and args.require_mutants:
-        # The caller only gets here having asked for a non-empty scope, so zero
-        # scored mutants means the run did not do its job — every mutant errored,
-        # the filters matched nothing, or the tool died part-way. Treating that as
-        # a pass is the one failure mode worse than a false red.
+    if scored == 0 and tally and args.require_mutants:
+        # Mutants existed and not one of them was scored: they all errored out,
+        # or the filters matched nothing runnable. That is a run which tested
+        # nothing while looking like a pass — the one failure mode worse than a
+        # false red.
+        #
+        # An empty tally is the *opposite* case and must pass: the scoped lines
+        # genuinely hold no mutants. A comment-only edit inside a mutable file
+        # produces exactly that — real changed line ranges, nothing to mutate.
         print(
-            f"[mutation] no mutants were scored, but {len(tally)} outcome(s) were "
-            "reported and a scope was requested — the run did not test anything.",
+            f"[mutation] {sum(tally.values())} mutant(s) were reported but none "
+            "could be scored — the run did not test anything.",
             file=sys.stderr,
         )
         return 1
 
     if scored == 0:
-        print(
-            "[mutation] no mutants were scored — nothing to gate on.", file=sys.stderr
-        )
+        print("[mutation] no mutants in scope — nothing to gate on.", file=sys.stderr)
     return 0 if passed or not args.gate else 1
 
 


### PR DESCRIPTION
## What

A one-condition fix to `ci/mutation_report.py`, from #190. Ports [ha-integration-template#28](https://github.com/prestomation/ha-integration-template/pull/28)'s fix for the same bug.

`--require-mutants` exists to catch a run that tested nothing while *looking* like a pass — mutmut exiting 0 with every mutant "not checked", or filters matching nothing runnable. It was also firing on the opposite case:

> a PR touches only **comment** lines inside a file on the mutable surface → `ci/mutation_scope.py` emits genuine changed line ranges → the tool runs cleanly → it correctly finds **zero mutants** in those lines → the job fails.

That's nothing to gate on, not a broken run. The flag now fires only when mutants *were* reported and none of them could be scored.

This is a false failure on ordinary PRs — any comment or docstring edit inside `recurrence.py`, `models.py`, `forms.ts` and friends would hit it — so it's worth landing before the mutation-pass PRs, which is exactly how it was found (that PR's diff was comments-only inside `i18n.ts` and went red).

## Verification

Both directions, locally:

```console
$ printf '  a.b.x_f__mutmut_1: not checked\n' | python3 ci/mutation_report.py \
    --format mutmut --title T --gate --require-mutants
[mutation] 1 mutant(s) were reported but none could be scored — the run did not test anything.
exit 1                                            # the protection still bites

$ echo "" | python3 ci/mutation_report.py --format mutmut --title T --gate --require-mutants
[mutation] no mutants in scope — nothing to gate on.
exit 0                                            # the false failure is gone
```

`ruff check ci` / `ruff format --check ci` clean.

## Notes

CI-only, developer-facing: no CHANGELOG entry, no beta bump, no UI touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_011FSVAV9NUEmLS79voYAEja)_