### PR TITLE
Mutation pass over the pure Python core (79.4% → 84.2%)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,12 @@ include = ["home_keeper*"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+# Make `from asserts import raises_exactly` (tests/unit/asserts.py) resolve
+# explicitly. Without it the import works only by accident — pytest's default
+# import mode puts each test file's own directory on sys.path, so it would break
+# the moment a unit test moved into a subdirectory. This adds no *source* path,
+# so it doesn't affect how mutmut derives a mutant's module name.
+pythonpath = ["tests/unit"]
 markers = [
     "real_ha: marks tests that use real HA modules (not mocked)",
 ]

--- a/tests/unit/asserts.py
+++ b/tests/unit/asserts.py
@@ -1,0 +1,29 @@
+"""Shared assertion helpers for the pure unit tier.
+
+Kept out of ``conftest.py`` so it stays a plain importable module: the unit
+tests import it as ``from asserts import raises_exactly`` (pytest puts each test
+file's directory on ``sys.path``).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import pytest
+
+
+def raises_exactly(exception: type[BaseException], message: str) -> Any:
+    """``pytest.raises`` that pins the **whole** error message.
+
+    Home Keeper's validation messages are contract, not decoration: the service
+    layer re-raises them to the user as ``ServiceValidationError`` and the panel
+    shows them verbatim, so a test that asserts only "something was raised"
+    lets the wrong message — or an empty one — ship unnoticed.
+
+    Anchored and escaped on purpose. ``pytest.raises(match=...)`` is a
+    *search* over a regex, so an unanchored pattern passes on a message with
+    anything bolted onto either end, and a message containing ``(`` or ``.``
+    would otherwise be read as a pattern rather than as text.
+    """
+    return pytest.raises(exception, match=f"^{re.escape(message)}$")

--- a/tests/unit/test_assets.py
+++ b/tests/unit/test_assets.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta, timezone
 
 import hk_assets as a
 import pytest
+from asserts import raises_exactly
 
 TZ = timezone(timedelta(hours=-4))
 NOW = datetime(2026, 6, 13, 10, tzinfo=TZ)
@@ -100,12 +101,12 @@ def test_asset_device_identifier_is_prefixed():
 
 
 def test_build_virtual_asset_requires_name():
-    with pytest.raises(a.AssetValidationError):
+    with raises_exactly(a.AssetValidationError, "missing required field: 'name'"):
         a.build_asset({"manufacturer": "X"}, now=NOW)
 
 
 def test_build_existing_asset_requires_device_id():
-    with pytest.raises(a.AssetValidationError):
+    with raises_exactly(a.AssetValidationError, "missing required field: 'device_id'"):
         a.build_asset({"kind": "existing"}, now=NOW)
 
 
@@ -128,7 +129,7 @@ def test_build_existing_asset_keeps_device_id_no_identifier():
 
 
 def test_build_asset_rejects_bad_kind():
-    with pytest.raises(a.AssetValidationError):
+    with raises_exactly(a.AssetValidationError, "invalid kind: 'imaginary'"):
         a.build_asset({"name": "x", "kind": "imaginary"}, now=NOW)
 
 
@@ -168,7 +169,7 @@ def test_metadata_entries_normalized():
 
 
 def test_metadata_requires_label():
-    with pytest.raises(a.AssetValidationError):
+    with raises_exactly(a.AssetValidationError, "metadata label must not be empty"):
         a.build_asset(
             {"name": "Furnace", "metadata": [{"type": "text", "value": "orphan"}]},
             now=NOW,
@@ -176,7 +177,7 @@ def test_metadata_requires_label():
 
 
 def test_metadata_rejects_bad_type():
-    with pytest.raises(a.AssetValidationError):
+    with raises_exactly(a.AssetValidationError, "invalid metadata type: 'number'"):
         a.build_asset(
             {
                 "name": "Furnace",
@@ -198,7 +199,10 @@ def test_metadata_empty_date_is_blank():
 
 
 def test_metadata_bad_date_raises():
-    with pytest.raises(a.AssetValidationError):
+    with raises_exactly(
+        a.AssetValidationError,
+        "invalid date for 'Warranty': 'not-a-date' (expected YYYY-MM-DD)",
+    ):
         a.build_asset(
             {
                 "name": "Furnace",
@@ -211,7 +215,7 @@ def test_metadata_bad_date_raises():
 
 
 def test_metadata_link_rejects_non_http():
-    with pytest.raises(a.AssetValidationError):
+    with raises_exactly(a.AssetValidationError, "Bad must be an http(s) URL"):
         a.build_asset(
             {
                 "name": "Furnace",
@@ -226,12 +230,12 @@ def test_metadata_link_rejects_non_http():
 def test_cost_coerced_and_bad_cost_raises():
     asset = a.build_asset({"name": "Furnace", "cost": "1299.99"}, now=NOW)
     assert asset["cost"] == pytest.approx(1299.99)
-    with pytest.raises(a.AssetValidationError):
+    with raises_exactly(a.AssetValidationError, "cost must be a number"):
         a.build_asset({"name": "Furnace", "cost": "free"}, now=NOW)
 
 
 def test_negative_cost_raises():
-    with pytest.raises(a.AssetValidationError):
+    with raises_exactly(a.AssetValidationError, "cost must not be negative"):
         a.build_asset({"name": "Furnace", "cost": "-5"}, now=NOW)
 
 
@@ -264,7 +268,9 @@ def test_document_link_name_falls_back_to_host():
 
 def test_document_link_rejects_non_http_scheme():
     for bad in ("javascript:alert(1)", "ftp://example.com", "/relative"):
-        with pytest.raises(a.AssetValidationError):
+        with raises_exactly(
+            a.AssetValidationError, "document url must be an http(s) URL"
+        ):
             a.build_asset(
                 {"name": "Furnace", "documents": [{"kind": "link", "url": bad}]},
                 now=NOW,
@@ -365,7 +371,9 @@ def test_merge_update_documents_are_upload_only_for_files():
 
 def test_documents_count_is_capped():
     too_many = [{"kind": "link", "url": f"https://ex.com/{i}"} for i in range(51)]
-    with pytest.raises(a.AssetValidationError):
+    with raises_exactly(
+        a.AssetValidationError, "an appliance can have at most 50 documents"
+    ):
         a.build_asset({"name": "Furnace", "documents": too_many}, now=NOW)
 
 
@@ -387,7 +395,9 @@ def test_merge_update_caps_merged_documents_total():
         )
     # A generic edit sending 30 links: 30 files + 30 links = 60 > _MAX_DOCUMENTS (50).
     incoming = [{"kind": "link", "url": f"https://ex.com/{i}"} for i in range(30)]
-    with pytest.raises(a.AssetValidationError):
+    with raises_exactly(
+        a.AssetValidationError, "an appliance can have at most 50 documents"
+    ):
         a.merge_update(asset, {"documents": incoming}, now=NOW)
     # A payload that keeps the merged total within the cap is accepted (30 + 15 = 45).
     fifteen = [{"kind": "link", "url": f"https://ex.com/{i}"} for i in range(15)]
@@ -412,11 +422,11 @@ def test_duplicate_document_ids_are_regenerated():
 
 def test_merge_update_validates_documents_and_cost():
     asset = a.build_asset({"name": "Furnace"}, now=NOW)
-    with pytest.raises(a.AssetValidationError):
+    with raises_exactly(a.AssetValidationError, "document url must be an http(s) URL"):
         a.merge_update(
             asset, {"documents": [{"kind": "link", "url": "javascript:bad"}]}, now=NOW
         )
-    with pytest.raises(a.AssetValidationError):
+    with raises_exactly(a.AssetValidationError, "cost must not be negative"):
         a.merge_update(asset, {"cost": -1}, now=NOW)
     ok = a.merge_update(
         asset, {"documents": [{"kind": "link", "url": "http://ok.example"}]}, now=NOW
@@ -491,10 +501,10 @@ def test_update_document_rejects_bad_url_and_missing_id():
     entry = a.append_document(
         asset, {"kind": "link", "url": "https://ex.com/m"}, created=""
     )
-    with pytest.raises(a.AssetValidationError):
+    with raises_exactly(a.AssetValidationError, "document url must be an http(s) URL"):
         a.update_document(asset, entry["id"], {"url": "javascript:alert(1)"})
     # A non-dict change set is rejected; an unknown document id returns None.
-    with pytest.raises(a.AssetValidationError):
+    with raises_exactly(a.AssetValidationError, "document changes must be an object"):
         a.update_document(asset, entry["id"], "nope")
     assert a.update_document(asset, "missing", {"name": "x"}) is None
 
@@ -558,7 +568,7 @@ def test_icon_valid_and_invalid():
         == "mdi:piano"
     )
     assert a.build_asset({"name": "Piano"}, now=NOW)["icon"] == ""
-    with pytest.raises(a.AssetValidationError):
+    with raises_exactly(a.AssetValidationError, "icon must look like 'mdi:name'"):
         a.build_asset({"name": "Piano", "icon": "not an icon"}, now=NOW)
 
 
@@ -602,7 +612,7 @@ def test_parts_normalized_with_ids_and_types():
 
 def test_part_url_rejects_non_http_scheme_and_allows_empty():
     for bad in ("javascript:alert(1)", "ftp://example.com", "not a url"):
-        with pytest.raises(a.AssetValidationError):
+        with raises_exactly(a.AssetValidationError, "part url must be an http(s) URL"):
             a.build_asset(
                 {"name": "Furnace", "parts": [{"name": "Filter", "url": bad}]},
                 now=NOW,
@@ -614,14 +624,14 @@ def test_part_url_rejects_non_http_scheme_and_allows_empty():
 
 
 def test_part_requires_name_and_valid_type():
-    with pytest.raises(a.AssetValidationError):
+    with raises_exactly(a.AssetValidationError, "part name must not be empty"):
         a.build_asset({"name": "X", "parts": [{"name": ""}]}, now=NOW)
-    with pytest.raises(a.AssetValidationError):
+    with raises_exactly(a.AssetValidationError, "invalid part type: 'bogus'"):
         a.build_asset({"name": "X", "parts": [{"name": "p", "type": "bogus"}]}, now=NOW)
 
 
 def test_part_bad_interval_unit_rejected():
-    with pytest.raises(a.AssetValidationError):
+    with raises_exactly(a.AssetValidationError, "invalid replace_unit: 'eons'"):
         a.build_asset(
             {
                 "name": "X",
@@ -814,7 +824,9 @@ def test_part_rejects_future_last_replaced():
     # a date one day past NOW is rejected deterministically regardless of when the
     # test runs.
     future = (NOW.date() + timedelta(days=1)).isoformat()
-    with pytest.raises(a.AssetValidationError):
+    with raises_exactly(
+        a.AssetValidationError, "last_replaced must not be in the future"
+    ):
         a.build_asset(
             {"name": "Boiler", "parts": [{"name": "Anode", "last_replaced": future}]},
             now=NOW,
@@ -830,7 +842,9 @@ def test_part_last_replaced_validated_against_injected_now_not_wall_clock():
         "name": "Boiler",
         "parts": [{"name": "Anode", "last_replaced": day_after_now}],
     }
-    with pytest.raises(a.AssetValidationError):
+    with raises_exactly(
+        a.AssetValidationError, "last_replaced must not be in the future"
+    ):
         a.build_asset(payload, now=NOW)
     # Advancing ``now`` past that date makes the same payload valid.
     asset = a.build_asset(payload, now=NOW + timedelta(days=2))
@@ -851,7 +865,9 @@ def test_merge_update_rejects_future_part_last_replaced():
     # The merge_update entry point threads the injected clock too.
     asset = a.build_asset({"name": "Boiler"}, now=NOW)
     future = (NOW.date() + timedelta(days=5)).isoformat()
-    with pytest.raises(a.AssetValidationError):
+    with raises_exactly(
+        a.AssetValidationError, "last_replaced must not be in the future"
+    ):
         a.merge_update(
             asset,
             {"parts": [{"name": "Anode", "last_replaced": future}]},
@@ -875,7 +891,7 @@ def test_duplicate_part_ids_are_regenerated():
 
 
 def test_oversized_replace_interval_rejected():
-    with pytest.raises(a.AssetValidationError):
+    with raises_exactly(a.AssetValidationError, "replace_interval must be <= 10000"):
         a.build_asset(
             {
                 "name": "Box",
@@ -890,7 +906,7 @@ def test_related_device_ids_listified():
         {"name": "Piano", "related_device_ids": ["dev_a", "dev_b", ""]}, now=NOW
     )
     assert asset["related_device_ids"] == ["dev_a", "dev_b"]
-    with pytest.raises(a.AssetValidationError):
+    with raises_exactly(a.AssetValidationError, "related_device_ids must be a list"):
         a.build_asset({"name": "Piano", "related_device_ids": "notalist"}, now=NOW)
 
 
@@ -926,17 +942,17 @@ def test_part_stock_defaults_none_and_untracked():
 
 
 def test_negative_stock_rejected():
-    with pytest.raises(a.AssetValidationError):
+    with raises_exactly(a.AssetValidationError, "stock must not be negative"):
         a.build_asset({"name": "X", "parts": [{"name": "F", "stock": -1}]}, now=NOW)
 
 
 def test_non_integer_stock_rejected():
-    with pytest.raises(a.AssetValidationError):
+    with raises_exactly(a.AssetValidationError, "stock must be an integer"):
         a.build_asset({"name": "X", "parts": [{"name": "F", "stock": "lots"}]}, now=NOW)
 
 
 def test_oversized_stock_rejected():
-    with pytest.raises(a.AssetValidationError):
+    with raises_exactly(a.AssetValidationError, "reorder_at must be <= 10000"):
         a.build_asset(
             {"name": "X", "parts": [{"name": "F", "reorder_at": 10**9}]}, now=NOW
         )
@@ -997,7 +1013,9 @@ def test_part_auto_buy_defaults_off():
 
 
 def test_negative_restock_quantity_rejected():
-    with pytest.raises(a.AssetValidationError):
+    with raises_exactly(
+        a.AssetValidationError, "restock_quantity must not be negative"
+    ):
         a.build_asset(
             {"name": "X", "parts": [{"name": "F", "restock_quantity": -2}]}, now=NOW
         )
@@ -1119,3 +1137,98 @@ def test_merge_update_sets_part_stock_from_incoming():
     )
     assert updated["parts"][0]["stock"] == 5
     assert updated["parts"][0]["reorder_at"] == 2
+
+
+# ── merge_update carry-forward contract ──────────────────────────────────────
+# `merge_update` builds a candidate from `updates.get(field, existing.get(field))`
+# for every editable field, then re-validates the whole record. Every field a
+# caller *omits* therefore has to survive untouched — the panel's edit form sends
+# a partial payload and a service caller may send a single key.
+#
+# Testing one field at a time is what makes this real: merging a full payload
+# cannot tell the carry-forward apart from the update itself.
+
+# An asset with every independently-editable field set to a distinctive value.
+FULLY_SET_ASSET = {
+    "name": "Kitchen fridge",
+    "manufacturer": "Frigidaire",
+    "model": "FGHB2868TF",
+    "serial_number": "SN-12345",
+    "notes": "Coils need brushing every spring",
+    "area_id": "area-kitchen",
+    "cost": 1499.0,
+    "icon": "mdi:fridge",
+    "metadata": [{"kind": "text", "label": "Provider", "value": "Acme"}],
+    "documents": [{"kind": "link", "name": "Manual", "url": "https://example.com/m"}],
+}
+
+# (field, new value, expected value after normalization).
+ASSET_MERGE_CASES = [
+    ("name", "Garage fridge", "Garage fridge"),
+    ("manufacturer", "Bosch", "Bosch"),
+    ("model", "B36CT80SNS", "B36CT80SNS"),
+    ("serial_number", "SN-99999", "SN-99999"),
+    ("notes", "Moved to the garage", "Moved to the garage"),
+    ("area_id", "area-garage", "area-garage"),
+    ("cost", 1799.5, 1799.5),
+    ("icon", "mdi:fridge-outline", "mdi:fridge-outline"),
+]
+
+# Fields that must be identical before and after a merge that didn't mention them.
+ASSET_CARRIED_FIELDS = [
+    "name",
+    "manufacturer",
+    "model",
+    "serial_number",
+    "notes",
+    "area_id",
+    "cost",
+    "icon",
+    "metadata",
+    "documents",
+    "parts",
+]
+
+
+def test_asset_merge_cases_cover_the_carried_fields():
+    # Guard the fixtures: a new editable field must show up here rather than
+    # silently going untested on both the update and the carry-forward side.
+    assert {field for field, _, _ in ASSET_MERGE_CASES} <= set(ASSET_CARRIED_FIELDS)
+    assert set(FULLY_SET_ASSET) <= set(ASSET_CARRIED_FIELDS)
+
+
+@pytest.mark.parametrize(("field", "value", "expected"), ASSET_MERGE_CASES)
+def test_merge_update_applies_one_field_and_carries_the_rest(field, value, expected):
+    asset = a.build_asset(FULLY_SET_ASSET, now=NOW)
+    updated = a.merge_update(asset, {field: value}, now=NOW)
+
+    assert updated[field] == expected
+    for other in ASSET_CARRIED_FIELDS:
+        if other != field:
+            assert updated[other] == asset[other], f"{other} was not carried forward"
+
+
+def test_merge_update_with_an_empty_payload_changes_nothing():
+    # The degenerate case, and the cheapest proof that every default in the
+    # candidate dict reads from `existing`.
+    asset = a.build_asset(FULLY_SET_ASSET, now=NOW)
+    assert a.merge_update(asset, {}, now=NOW) == asset
+
+
+def test_merge_update_carries_identity_fields():
+    # `id`, `created` and the provisioning anchors are never in the candidate
+    # dict; they survive because the merge starts from `dict(existing)`.
+    asset = a.build_asset(FULLY_SET_ASSET, now=NOW)
+    updated = a.merge_update(asset, {"name": "Renamed"}, now=NOW)
+    for field in ("id", "created", "kind", "identifiers"):
+        assert updated[field] == asset[field], f"{field} was not preserved"
+
+
+def test_merge_update_clearing_a_text_field_is_honoured():
+    # The carry-forward must not swallow a deliberate blanking: an explicit ""
+    # is a value, not an omission.
+    asset = a.build_asset(FULLY_SET_ASSET, now=NOW)
+    updated = a.merge_update(asset, {"serial_number": "", "notes": ""}, now=NOW)
+    assert updated["serial_number"] == ""
+    assert updated["notes"] == ""
+    assert updated["manufacturer"] == "Frigidaire"  # untouched neighbour

--- a/tests/unit/test_completion_metadata.py
+++ b/tests/unit/test_completion_metadata.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta, timezone
 import hk_events as events
 import hk_models as m
 import hk_recurrence as r
-import pytest
+from asserts import raises_exactly
 
 TZ = timezone(timedelta(hours=-4))
 NOW = datetime(2026, 6, 13, 10, tzinfo=TZ)
@@ -35,9 +35,9 @@ def test_normalize_metadata_empty_inputs():
 
 
 def test_normalize_metadata_rejects_bad_cost():
-    with pytest.raises(m.TaskValidationError):
+    with raises_exactly(m.TaskValidationError, "cost must be a number"):
         m.normalize_completion_metadata({"cost": "free"})
-    with pytest.raises(m.TaskValidationError):
+    with raises_exactly(m.TaskValidationError, "cost must be >= 0"):
         m.normalize_completion_metadata({"cost": -1})
 
 
@@ -58,7 +58,10 @@ def test_normalize_metadata_rejects_unsafe_photo_urls():
     # javascript:/data: URIs and protocol-relative URLs are stored-XSS vectors when
     # the panel renders `photo` into an href/img src.
     for bad in ("javascript:alert(1)", "data:text/html,<script>", "//evil.com/x"):
-        with pytest.raises(m.TaskValidationError):
+        with raises_exactly(
+            m.TaskValidationError,
+            "photo must be an http(s) URL or a site-relative path",
+        ):
             m.normalize_completion_metadata({"photo": bad})
 
 
@@ -146,7 +149,7 @@ def test_update_completion_reports_replaced_photo():
 def test_update_completion_unknown_ts_raises():
     task = _floating_task()
     r.apply_completion(task, NOW, now=NOW)
-    with pytest.raises(ValueError):
+    with raises_exactly(ValueError, "no completion at '2000-01-01T00:00:00+00:00'"):
         r.update_completion(task, "2000-01-01T00:00:00+00:00", {}, fields=FIELDS)
 
 
@@ -205,7 +208,9 @@ def test_optional_mode_clears_required_fields():
 
 
 def test_invalid_capture_mode_rejected():
-    with pytest.raises(m.TaskValidationError):
+    with raises_exactly(
+        m.TaskValidationError, "invalid completion_detail: 'sometimes'"
+    ):
         m.build_task(
             {
                 "name": "x",

--- a/tests/unit/test_documents.py
+++ b/tests/unit/test_documents.py
@@ -10,7 +10,7 @@ import os
 from pathlib import Path
 
 import hk_documents as d
-import pytest
+from asserts import raises_exactly
 from hk_assets import AssetValidationError
 
 PDF = b"%PDF-1.7\n..."
@@ -58,13 +58,16 @@ def test_validate_upload_accepts_pdf_and_returns_sniffed_type():
 
 
 def test_validate_upload_rejects_empty_oversized_and_unknown():
-    with pytest.raises(AssetValidationError):
+    with raises_exactly(AssetValidationError, "uploaded file is empty"):
         d.validate_upload("x.pdf", b"")
-    with pytest.raises(AssetValidationError):
+    with raises_exactly(
+        AssetValidationError,
+        "unsupported file type (allowed: PDF, PNG, JPEG, WebP, GIF)",
+    ):
         d.validate_upload("x.exe", b"MZ\x90\x00garbage")
     # Declared via the stream variant so the ceiling can be exercised without
     # allocating MAX_DOCUMENT_BYTES of ballast in the test process.
-    with pytest.raises(AssetValidationError):
+    with raises_exactly(AssetValidationError, "file exceeds the 100 MB limit"):
         d.validate_upload_stream("big.pdf", PDF, d.MAX_DOCUMENT_BYTES + 1)
 
 
@@ -74,9 +77,12 @@ def test_validate_upload_stream_matches_the_in_memory_variant():
     assert d.validate_upload_stream("manual.pdf", PDF, len(PDF)) == d.validate_upload(
         "manual.pdf", PDF
     )
-    with pytest.raises(AssetValidationError):
+    with raises_exactly(AssetValidationError, "uploaded file is empty"):
         d.validate_upload_stream("x.pdf", PDF, 0)
-    with pytest.raises(AssetValidationError):
+    with raises_exactly(
+        AssetValidationError,
+        "unsupported file type (allowed: PDF, PNG, JPEG, WebP, GIF)",
+    ):
         d.validate_upload_stream("x.exe", b"MZ\x90\x00garbage", 64)
 
 
@@ -147,7 +153,7 @@ def test_safe_segment_reduces_or_rejects():
     assert d.safe_segment("a/b") == "b"
     # Pure traversal / empty markers have no usable basename — rejected outright.
     for bad in ("..", ".", "", "/", "../.."):
-        with pytest.raises(AssetValidationError):
+        with raises_exactly(AssetValidationError, "invalid document path"):
             d.safe_segment(bad)
 
 
@@ -169,7 +175,7 @@ def test_resolve_under_root_blocks_escape(tmp_path: Path):
         assert ".." not in p.parts
     # A pure traversal/empty marker has no usable basename — rejected outright.
     for asset_id in ("..", ".", ""):
-        with pytest.raises(AssetValidationError):
+        with raises_exactly(AssetValidationError, "invalid document path"):
             d.resolve_under_root(root, asset_id, "doc__x.pdf")
 
 

--- a/tests/unit/test_inventory.py
+++ b/tests/unit/test_inventory.py
@@ -9,6 +9,7 @@ import csv
 import io
 
 import hk_inventory as inv
+import pytest
 
 
 def _asset(**kw):
@@ -186,3 +187,92 @@ def test_spares_total_does_not_drift_from_per_row_rounding():
     # Each row rounds 0.005 -> 0.01 (banker's rounding may give 0.0), but the total is
     # round(0.005 + 0.005) == 0.01 regardless.
     assert report["totals"]["spares_value"] == 0.01
+
+
+def test_row_is_exactly_the_documented_shape():
+    # The row dict *is* the export contract — the CSV writer and the panel both
+    # index it by key, and an insurance export is the one artefact a user hands
+    # to a third party. Asserting a handful of fields lets a renamed or dropped
+    # key through, so assert the whole dict.
+    report = inv.build_inventory(
+        [
+            _asset(
+                area_id="garage",
+                serial_number="SN-TOP",
+                parts=[{"name": "Anode rod", "cost": 30.0, "stock": 2}],
+            )
+        ],
+        area_names={"garage": "Garage"},
+    )
+    assert report["assets"] == [
+        {
+            "id": "a1",
+            "name": "Water heater",
+            "kind": "virtual",
+            "area": "Garage",
+            "manufacturer": "Rheem",
+            "model": "XE50",
+            "serial_number": "SN-TOP",
+            "cost": 900.0,
+            "spares_value": 60.0,
+            "part_count": 1,
+            "details": "Serial: SN-1; Warranty expiry: 2030-01-01",
+        }
+    ]
+
+
+def test_absent_text_fields_become_empty_strings_not_none():
+    # A CSV cell of "None" would be visible nonsense in the export, so the row
+    # coalesces missing text to "". `cost` deliberately stays None — blank is
+    # meaningfully different from zero for an insurance value.
+    report = inv.build_inventory(
+        [
+            {
+                "id": "a2",
+                "kind": "virtual",
+                "name": None,
+                "metadata": [],
+                "parts": [],
+            }
+        ]
+    )
+    row = report["assets"][0]
+    assert row["name"] == ""
+    assert row["manufacturer"] == ""
+    assert row["model"] == ""
+    assert row["serial_number"] == ""
+    assert row["cost"] is None
+    assert row["area"] is None
+
+
+@pytest.mark.parametrize(
+    ("unit_cost", "stock", "expected"),
+    [
+        # Chosen so the answer differs at 2dp from both 0dp and 3dp: the row is
+        # money, so "round to cents" has to be exactly that.
+        (1.0625, 2, 2.12),  # 2.125 -> 2.12, not 2 and not 2.125
+        (0.625, 3, 1.88),  # 1.875 -> 1.88, not 2 and not 1.875
+    ],
+)
+def test_spares_value_rounds_to_cents(unit_cost, stock, expected):
+    report = inv.build_inventory(
+        [
+            _asset(
+                cost=None, parts=[{"name": "Filter", "cost": unit_cost, "stock": stock}]
+            )
+        ]
+    )
+    assert report["assets"][0]["spares_value"] == expected
+    # The totals round independently of the row, so pin them too.
+    assert report["totals"]["spares_value"] == expected
+    assert report["totals"]["grand_total"] == expected
+
+
+def test_area_is_looked_up_by_id_not_carried_through():
+    # The row must carry the resolved *name*; leaking the raw id into an export
+    # a human reads would be a regression even though both are strings.
+    report = inv.build_inventory(
+        [_asset(area_id="garage")], area_names={"garage": "Garage"}
+    )
+    assert report["assets"][0]["area"] == "Garage"
+    assert report["assets"][0].get("area_id") is None

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 
 import hk_models as m
 import pytest
+from asserts import raises_exactly
 
 TZ = timezone(timedelta(hours=-4))
 NOW = datetime(2026, 6, 13, 10, tzinfo=TZ)
@@ -82,7 +83,9 @@ def test_build_floating_task_seed_naive_is_qualified():
 
 
 def test_build_task_rejects_bad_last_completed():
-    with pytest.raises(m.TaskValidationError):
+    with raises_exactly(
+        m.TaskValidationError, "invalid last_completed datetime: 'not-a-date'"
+    ):
         m.build_task(
             {
                 "name": "x",
@@ -133,14 +136,14 @@ def test_build_fixed_task_normalizes_naive_anchor():
 
 
 def test_build_task_rejects_missing_name():
-    with pytest.raises(m.TaskValidationError):
+    with raises_exactly(m.TaskValidationError, "missing required field: 'name'"):
         m.build_task(
             {"recurrence_type": "floating", "interval": 1, "unit": "days"}, now=NOW
         )
 
 
 def test_build_task_rejects_bad_unit():
-    with pytest.raises(m.TaskValidationError):
+    with raises_exactly(m.TaskValidationError, "invalid unit: 'lightyears'"):
         m.build_task(
             {
                 "name": "x",
@@ -153,7 +156,7 @@ def test_build_task_rejects_bad_unit():
 
 
 def test_build_task_rejects_bad_interval():
-    with pytest.raises(m.TaskValidationError):
+    with raises_exactly(m.TaskValidationError, "interval must be >= 1"):
         m.build_task(
             {"name": "x", "recurrence_type": "floating", "interval": 0, "unit": "days"},
             now=NOW,
@@ -163,7 +166,7 @@ def test_build_task_rejects_bad_interval():
 def test_build_task_rejects_oversized_interval():
     # An absurd interval must be a clean validation error, not a timedelta
     # OverflowError that surfaces as a 500.
-    with pytest.raises(m.TaskValidationError):
+    with raises_exactly(m.TaskValidationError, "interval must be <= 10000"):
         m.build_task(
             {
                 "name": "x",
@@ -178,7 +181,7 @@ def test_build_task_rejects_oversized_interval():
 def test_build_task_rejects_non_numeric_interval():
     # Websocket payloads aren't coerced, so a non-numeric interval must raise a
     # validation error (not a raw ValueError that crashes the command).
-    with pytest.raises(m.TaskValidationError):
+    with raises_exactly(m.TaskValidationError, "interval must be a valid integer"):
         m.build_task(
             {
                 "name": "x",
@@ -194,13 +197,15 @@ def test_completion_metadata_rejects_nan_infinity_cost():
     # NaN passes every < / <= comparison, so a bare float() would let it persist (and
     # NaN serializes to null on the JSON round-trip). Reject non-finite numbers.
     for bad in (float("nan"), float("inf"), "nan", "inf"):
-        with pytest.raises(m.TaskValidationError):
+        with raises_exactly(m.TaskValidationError, "cost must be a finite number"):
             m.normalize_completion_metadata({"cost": bad})
 
 
 def test_build_sensor_task_rejects_nan_target():
     for bad in (float("nan"), float("inf")):
-        with pytest.raises(m.TaskValidationError):
+        with raises_exactly(
+            m.TaskValidationError, "sensor.target must be a finite number"
+        ):
             m.build_task(
                 {
                     "name": "x",
@@ -455,7 +460,11 @@ def test_deletion_not_blocked_for_unmanaged_task():
 def test_build_task_rejects_deletion_protected_without_config_entry_id():
     # Protection without a config_entry_id would be a permanent trap (orphan
     # detection couldn't fire), so creation must be rejected.
-    with pytest.raises(m.TaskValidationError):
+    with raises_exactly(
+        m.TaskValidationError,
+        "managed_by.deletion_protected requires config_entry_id so the task can "
+        "still be cleaned up if the managing integration is removed",
+    ):
         m.build_task(
             {
                 "name": "Buddy: Medicine",
@@ -492,7 +501,7 @@ def test_build_task_allows_deletion_protected_with_config_entry_id():
 
 
 def test_build_task_rejects_non_mapping_managed_by():
-    with pytest.raises(m.TaskValidationError):
+    with raises_exactly(m.TaskValidationError, "managed_by must be a mapping"):
         m.build_task(
             {
                 "name": "X",
@@ -691,7 +700,7 @@ def test_build_one_off_task_qualifies_naive_due():
 
 
 def test_build_one_off_task_rejects_invalid_due():
-    with pytest.raises(m.TaskValidationError):
+    with raises_exactly(m.TaskValidationError, "invalid due datetime: 'not-a-date'"):
         m.build_task(
             {"name": "Bad", "recurrence_type": "one-off", "due": "not-a-date"},
             now=NOW,
@@ -841,7 +850,7 @@ def test_build_task_defaults_labels_to_empty():
 
 
 def test_build_task_rejects_non_list_labels():
-    with pytest.raises(m.TaskValidationError):
+    with raises_exactly(m.TaskValidationError, "labels must be a list of label ids"):
         m.build_task(
             {
                 "name": "Bad",
@@ -908,12 +917,14 @@ def test_normalize_card_links_defaults_empty():
 
 
 def test_normalize_card_links_rejects_non_list():
-    with pytest.raises(m.TaskValidationError):
+    with raises_exactly(m.TaskValidationError, "card_links must be a list"):
         m.normalize_card_links({"asset_id": "a1", "entry_id": "d1"})
 
 
 def test_normalize_card_links_rejects_non_object_entry():
-    with pytest.raises(m.TaskValidationError):
+    with raises_exactly(
+        m.TaskValidationError, "each card_links entry must be an object"
+    ):
         m.normalize_card_links(["a1:d1"])
 
 
@@ -1103,3 +1114,145 @@ def test_merge_update_clears_task_chips_when_sent_empty():
 def test_normalize_task_chips_rejects_mdi_empty_suffix():
     with pytest.raises(m.TaskValidationError, match="non-empty name"):
         m.normalize_task_chips([{"label": "x", "icon": "mdi:"}])
+
+
+# ── merge_update carry-forward contract ──────────────────────────────────────
+# `merge_update` builds a candidate from `updates.get(field, existing.get(field))`
+# for every editable field, then re-normalizes the whole thing. That means every
+# field a caller *omits* has to survive the round trip untouched — the panel's
+# edit form sends a partial payload, and a service caller may send a single key.
+#
+# Testing one field at a time is what makes this real: a suite that only ever
+# merges a full payload cannot tell the carry-forward apart from the update.
+
+# A task with every independently-editable field set to a distinctive value.
+FULLY_SET_TASK = {
+    "name": "Furnace filter",
+    "notes": "Behind the return vent",
+    "recurrence_type": "floating",
+    "interval": 3,
+    "unit": "months",
+    "device_id": "dev-furnace",
+    "area_id": "area-basement",
+    "enabled": True,
+    "completion_detail": "required",
+    "completion_required_fields": ["note", "cost"],
+}
+
+# (field, new value, expected value after normalization, other fields the change
+# is *supposed* to move). The last element documents a real coupling rather than
+# weakening the carry-forward assertion to accommodate it.
+MERGE_UPDATE_CASES = [
+    ("name", "Renamed filter", "Renamed filter", {}),
+    ("notes", "Now in the loft", "Now in the loft", {}),
+    ("interval", 6, 6, {}),
+    ("unit", "weeks", "weeks", {}),
+    ("device_id", "dev-other", "dev-other", {}),
+    ("area_id", "area-attic", "area-attic", {}),
+    ("enabled", False, False, {}),
+    # Turning capture off makes a mandatory-field list meaningless, so it clears.
+    ("completion_detail", "optional", "optional", {"completion_required_fields": []}),
+    ("completion_detail", "none", "none", {"completion_required_fields": []}),
+]
+
+# Fields whose value must be identical before and after a merge that didn't
+# mention them. `next_due` is deliberately absent: changing the cadence is
+# *supposed* to move it, and that is covered by its own tests.
+CARRIED_FIELDS = [
+    "name",
+    "notes",
+    "recurrence_type",
+    "interval",
+    "unit",
+    "device_id",
+    "area_id",
+    "enabled",
+    "completion_detail",
+    "completion_required_fields",
+]
+
+
+def test_merge_update_cases_cover_the_carried_fields():
+    # Guard the fixtures above: a new editable field must show up here rather
+    # than silently going untested on both the update and the carry-forward side.
+    assert {case[0] for case in MERGE_UPDATE_CASES} <= set(CARRIED_FIELDS)
+    assert set(FULLY_SET_TASK) - {"recurrence_type"} <= set(CARRIED_FIELDS)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected", "also_changes"), MERGE_UPDATE_CASES
+)
+def test_merge_update_applies_one_field_and_carries_the_rest(
+    field, value, expected, also_changes
+):
+    task = m.build_task(FULLY_SET_TASK, now=NOW)
+    updated = m.merge_update(task, {field: value}, now=NOW)
+
+    assert updated[field] == expected
+    for other in CARRIED_FIELDS:
+        if other == field:
+            continue
+        if other in also_changes:
+            assert updated[other] == also_changes[other], f"{other} coupling changed"
+        else:
+            assert updated[other] == task[other], f"{other} was not carried forward"
+
+
+def test_merge_update_with_an_empty_payload_changes_nothing():
+    # The degenerate case, and the cheapest possible proof that every default in
+    # the candidate dict reads from `existing`.
+    task = m.build_task(FULLY_SET_TASK, now=NOW)
+    updated = m.merge_update(task, {}, now=NOW)
+    assert updated == task
+
+
+def test_merge_update_carries_identity_and_history_fields():
+    # Fields the candidate dict never mentions still have to survive, because the
+    # merge starts from `dict(existing)` rather than building a fresh task.
+    task = m.build_task(FULLY_SET_TASK, now=NOW)
+    task["completions"] = [{"ts": NOW.isoformat()}]
+    task["last_completed"] = NOW.isoformat()
+    updated = m.merge_update(task, {"name": "Renamed"}, now=NOW)
+    assert updated["id"] == task["id"]
+    assert updated["completions"] == task["completions"]
+    assert updated["last_completed"] == task["last_completed"]
+
+
+def test_merge_update_locked_fields_leaves_the_rest_of_the_payload_intact():
+    # Stripping locked keys must filter `updates`, not discard it: an update
+    # carrying both a locked and an unlocked field has to apply the unlocked one.
+    task = m.build_task(
+        {
+            **FULLY_SET_TASK,
+            "managed_by": {
+                "integration": "x",
+                "display_name": "X",
+                "locked_fields": ["name"],
+            },
+        },
+        now=NOW,
+    )
+    updated = m.merge_update(
+        task,
+        {"name": "Hacked", "notes": "Legitimate edit", "area_id": "area-new"},
+        now=NOW,
+    )
+    assert updated["name"] == "Furnace filter"
+    assert updated["notes"] == "Legitimate edit"
+    assert updated["area_id"] == "area-new"
+
+
+def test_merge_update_with_empty_locked_fields_applies_everything():
+    task = m.build_task(
+        {
+            **FULLY_SET_TASK,
+            "managed_by": {
+                "integration": "x",
+                "display_name": "X",
+                "locked_fields": [],
+            },
+        },
+        now=NOW,
+    )
+    updated = m.merge_update(task, {"name": "Renamed"}, now=NOW)
+    assert updated["name"] == "Renamed"

--- a/tests/unit/test_models_sensor.py
+++ b/tests/unit/test_models_sensor.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 
 import hk_models as m
 import pytest
+from asserts import raises_exactly
 
 TZ = timezone(timedelta(hours=-4))
 NOW = datetime(2026, 6, 13, 10, tzinfo=TZ)
@@ -99,7 +100,9 @@ def test_invalid_sensor_config_rejected(sensor):
 
 
 def test_missing_sensor_block_rejected():
-    with pytest.raises(m.TaskValidationError):
+    with raises_exactly(
+        m.TaskValidationError, "a sensor task requires a sensor configuration"
+    ):
         m.build_task({"name": "T", "recurrence_type": "sensor"}, now=NOW)
 
 

--- a/tests/unit/test_move_completion.py
+++ b/tests/unit/test_move_completion.py
@@ -12,7 +12,7 @@ transiently look like "history now empty" and get re-armed.
 from datetime import datetime, timedelta, timezone
 
 import hk_recurrence as r
-import pytest
+from asserts import raises_exactly
 
 TZ = timezone(timedelta(hours=-4))
 
@@ -28,7 +28,7 @@ def test_move_completion_missing_old_ts_raises():
         "unit": "months",
         "completions": [{"ts": dt(2026, 6, 1).isoformat()}],
     }
-    with pytest.raises(ValueError):
+    with raises_exactly(ValueError, "no completion at '2020-01-01T00:00:00-04:00'"):
         r.move_completion(
             task,
             dt(2020, 1, 1).isoformat(),

--- a/tests/unit/test_recurrence_floating.py
+++ b/tests/unit/test_recurrence_floating.py
@@ -3,6 +3,7 @@
 from datetime import datetime, timedelta, timezone
 
 import hk_recurrence as r
+from asserts import raises_exactly
 
 TZ = timezone(timedelta(hours=-4))
 
@@ -33,11 +34,10 @@ def test_add_months_handles_negative_across_year_boundary():
 
 
 def test_add_interval_rejects_bad_input():
-    import pytest
 
-    with pytest.raises(ValueError):
+    with raises_exactly(ValueError, "interval must be >= 1, got 0"):
         r.add_interval(dt(2026, 1, 1), 0, "days")
-    with pytest.raises(ValueError):
+    with raises_exactly(ValueError, "unknown unit: 'fortnights'"):
         r.add_interval(dt(2026, 1, 1), 1, "fortnights")
 
 


### PR DESCRIPTION
## What

A full mutation pass over the Python surface — the follow-up to #190, which added the gate but left the existing debt in place. `--all` was failing at **79.42%**, just under the 80% threshold; it now passes at **84.21%**.

**5,136 mutants. 4,079 detected → 4,325.** 246 killed, 748 unit tests passing (up from 717). Tests only; no production code changed.

## What the survivors were telling us

The 1,057 survivors weren't scattered. Four systematic gaps accounted for most of them, each the same shape: a test that *runs* code without *asserting* on what it produced.

### 1. Validation messages were never checked — 60 sites, ~245 mutants

Every `pytest.raises(TaskValidationError)` in the unit tier asserted only that *something* was raised. mutmut could blank a message to `None`, upper-case it, or wrap it in junk, and nothing failed. Those strings are contract: the service layer re-raises them to the user as `ServiceValidationError`, and the panel shows them verbatim.

All 60 now go through a shared helper:

```python
def raises_exactly(exception, message):
    return pytest.raises(exception, match=f"^{re.escape(message)}$")
```

Both the anchoring and the escaping earn their keep. `pytest.raises(match=...)` is a **search**, so an unanchored pattern passes happily on `"XXname must not be emptyXX"` — I hit exactly that in the template's equivalent pass. And messages like `"invalid date for 'Warranty': 'not-a-date' (expected YYYY-MM-DD)"` contain regex metacharacters that would otherwise be interpreted rather than matched.

The 60 expected messages were captured mechanically rather than hand-written, by temporarily wrapping `pytest.raises` in a throwaway plugin to record what each site actually raised — so they document current behaviour rather than my guess at it.

### 2. `merge_update`'s carry-forward was never exercised one field at a time — ~70 mutants

`models.merge_update` and `assets.merge_update` both build a candidate from `updates.get(field, existing.get(field))` across every editable field, then re-normalise. So **every field a caller omits has to survive untouched** — the panel's edit form sends a partial payload, and a service caller may send a single key.

Merging a full payload, which is all the suite did, structurally cannot tell the carry-forward apart from the update. Both are now parameterised over the field list, with a guard test that a newly added editable field must appear in the fixtures rather than silently going untested. Plus the degenerate empty-payload case, and the identity/history fields (`id`, `created`, `completions`, `identifiers`) that survive only because the merge starts from `dict(existing)`.

That work surfaced a real coupling worth naming: switching `completion_detail` away from `required` **clears** `completion_required_fields`. That's correct — a mandatory-field list is meaningless when capture is off — so the test data documents it as an expected knock-on rather than the assertion being weakened to tolerate it.

### 3. The inventory row shape was only spot-checked — ~22 mutants

That dict *is* the export contract: the CSV writer and the panel index it by key, and the inventory export is the one artefact a user hands to a third party (an insurer). Asserting a handful of fields let a renamed or dropped key through. It now asserts the whole row, that absent text coalesces to `""` rather than a literal `"None"` in a CSV cell, and that money rounds to cents — with values chosen so 2dp differs from **both** 0dp and 3dp, which the previous assertions couldn't distinguish (`round(9.999, 2) == round(9.999) == 10`).

## What remains, and why I stopped here

**811 mutants are still undetected**, concentrated in `assets` (296), `models` (168), `notifications` (92) and `recurrence` (81). I stopped deliberately: after these four sweeps the remainder are individual gaps rather than a fifth pattern, so they want a considered follow-up pass rather than another mechanical sweep, and a 4,000-line diff of one-off tests would not be reviewable.

The gate is unaffected either way — it's diff-scoped, so a PR is judged on the functions it touches, not on this backlog.

## Verification

```console
$ bash ci/test-mutation-python.sh --all
**Mutation score: 84.21%** (4325 detected / 5136 scored) — threshold 80% — ✅ pass

$ python -m pytest tests/unit -q          # 748 passed, 1 skipped (was 717)
$ ruff check custom_components tests ci   # clean
$ ruff format --check custom_components tests ci   # 111 files already formatted
```

## Notes

- Developer-facing, tests only: no CHANGELOG entry, no beta bump, no UI touched.
- Stacked on the same `main` as #191 (the gate fix); no conflict between them.

---
_Generated by [Claude Code](https://claude.ai/code/session_011FSVAV9NUEmLS79voYAEja)_