### PR TITLE
Mutation pass over the frontend (58.3% → 74.9%)

### DIFF
--- a/custom_components/home_keeper/frontend/test/card-filter-profile.test.js
+++ b/custom_components/home_keeper/frontend/test/card-filter-profile.test.js
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import { DUE_SOON_DAYS, profileMatches } from '../src/card-filter.ts';
+
+// `profileMatches` decides which tasks a notification profile sends. It has to
+// agree with the backend's windows exactly, or a digest reports a different set
+// than the panel previews. `card-filter.test.js` covers the card's own filters;
+// this covers the profile predicate, which nothing exercised directly.
+
+const DAY_MS = 86_400_000;
+const NOW = Date.parse('2026-06-13T10:00:00Z');
+const at = (offsetDays) => new Date(NOW + offsetDays * DAY_MS).toISOString();
+
+const task = (over = {}) => ({
+  id: 't1',
+  name: 'Filter',
+  enabled: true,
+  next_due: at(-1),
+  ...over,
+});
+
+describe('profileMatches gating', () => {
+  it('excludes disabled tasks', () => {
+    expect(profileMatches(task(), {}, {}, {}, NOW)).toBe(true);
+    expect(profileMatches(task({ enabled: false }), {}, {}, {}, NOW)).toBe(false);
+  });
+
+  it('treats an absent `enabled` as enabled', () => {
+    // Only an explicit `false` disables; `undefined` is an older record.
+    const t = task();
+    delete t.enabled;
+    expect(profileMatches(t, {}, {}, {}, NOW)).toBe(true);
+  });
+
+  it('excludes undated tasks', () => {
+    expect(profileMatches(task({ next_due: null }), {}, {}, {}, NOW)).toBe(false);
+    expect(profileMatches(task({ next_due: '' }), {}, {}, {}, NOW)).toBe(false);
+  });
+
+  it('excludes problem-sensor tasks', () => {
+    // These are driven by a binary sensor, not a schedule; notifying on them
+    // would duplicate the sensor's own alert.
+    expect(profileMatches(task({ source: { problem_sensor: 'binary_sensor.x' } }), {}, {}, {}, NOW)).toBe(
+      false,
+    );
+    // A source of another shape must not be swept up with them.
+    expect(profileMatches(task({ source: { part: { asset_id: 'a1' } } }), {}, {}, {}, NOW)).toBe(
+      true,
+    );
+    expect(profileMatches(task({ source: null }), {}, {}, {}, NOW)).toBe(true);
+  });
+});
+
+describe('profileMatches status windows', () => {
+  it('defaults to overdue when no status is set', () => {
+    // The default has to be `overdue`, not "everything": an empty profile that
+    // matched every dated task would notify on the whole list.
+    expect(profileMatches(task({ next_due: at(-1) }), {}, {}, {}, NOW)).toBe(true);
+    expect(profileMatches(task({ next_due: at(1) }), {}, {}, {}, NOW)).toBe(false);
+    expect(profileMatches(task({ next_due: at(1) }), { status: '' }, {}, {}, NOW)).toBe(false);
+  });
+
+  it('overdue means due at or before now, inclusive', () => {
+    const f = { status: 'overdue' };
+    expect(profileMatches(task({ next_due: at(-1) }), f, {}, {}, NOW)).toBe(true);
+    expect(profileMatches(task({ next_due: new Date(NOW).toISOString() }), f, {}, {}, NOW)).toBe(
+      true,
+    );
+    expect(profileMatches(task({ next_due: at(0.001) }), f, {}, {}, NOW)).toBe(false);
+  });
+
+  it('due_soon spans overdue through the window edge, inclusive', () => {
+    const f = { status: 'due_soon' };
+    expect(profileMatches(task({ next_due: at(-5) }), f, {}, {}, NOW)).toBe(true);
+    expect(profileMatches(task({ next_due: at(DUE_SOON_DAYS) }), f, {}, {}, NOW)).toBe(true);
+    // One millisecond past the window is out — this is what pins the boundary
+    // as `>` rather than `>=`.
+    const justPast = new Date(NOW + DUE_SOON_DAYS * DAY_MS + 1).toISOString();
+    expect(profileMatches(task({ next_due: justPast }), f, {}, {}, NOW)).toBe(false);
+  });
+
+  it('all accepts any dated, enabled task', () => {
+    const f = { status: 'all' };
+    expect(profileMatches(task({ next_due: at(-30) }), f, {}, {}, NOW)).toBe(true);
+    expect(profileMatches(task({ next_due: at(365) }), f, {}, {}, NOW)).toBe(true);
+    expect(profileMatches(task({ next_due: null }), f, {}, {}, NOW)).toBe(false);
+  });
+});
+
+describe('profileMatches area and device filters', () => {
+  const devices = { d1: { area_id: 'kitchen' }, d2: { area_id: 'garage' } };
+
+  it('an empty list means "no constraint", not "match nothing"', () => {
+    const t = task({ area_id: 'kitchen', device_id: 'd1' });
+    expect(profileMatches(t, { areas: [], devices: [], labels: [] }, devices, {}, NOW)).toBe(true);
+    // Absent behaves the same as empty.
+    expect(profileMatches(t, {}, devices, {}, NOW)).toBe(true);
+  });
+
+  it('filters by the task area', () => {
+    const t = task({ area_id: 'kitchen' });
+    expect(profileMatches(t, { areas: ['kitchen'] }, devices, {}, NOW)).toBe(true);
+    expect(profileMatches(t, { areas: ['garage'] }, devices, {}, NOW)).toBe(false);
+    expect(profileMatches(t, { areas: ['garage', 'kitchen'] }, devices, {}, NOW)).toBe(true);
+  });
+
+  it('falls back to the device area when the task has none', () => {
+    const t = task({ device_id: 'd2' });
+    expect(profileMatches(t, { areas: ['garage'] }, devices, {}, NOW)).toBe(true);
+    expect(profileMatches(t, { areas: ['kitchen'] }, devices, {}, NOW)).toBe(false);
+  });
+
+  it('an area-less task matches no area filter', () => {
+    // It must not slip through by comparing against a placeholder that happens
+    // to be absent from the wanted list.
+    const t = task();
+    expect(profileMatches(t, { areas: ['kitchen'] }, devices, {}, NOW)).toBe(false);
+  });
+
+  it('filters by device', () => {
+    expect(profileMatches(task({ device_id: 'd1' }), { devices: ['d1'] }, devices, {}, NOW)).toBe(
+      true,
+    );
+    expect(profileMatches(task({ device_id: 'd1' }), { devices: ['d2'] }, devices, {}, NOW)).toBe(
+      false,
+    );
+    // A device-less task matches no device filter.
+    expect(profileMatches(task(), { devices: ['d1'] }, devices, {}, NOW)).toBe(false);
+  });
+
+  it('applies area and device filters together', () => {
+    const t = task({ area_id: 'kitchen', device_id: 'd1' });
+    expect(profileMatches(t, { areas: ['kitchen'], devices: ['d1'] }, devices, {}, NOW)).toBe(true);
+    expect(profileMatches(t, { areas: ['kitchen'], devices: ['d2'] }, devices, {}, NOW)).toBe(false);
+    expect(profileMatches(t, { areas: ['garage'], devices: ['d1'] }, devices, {}, NOW)).toBe(false);
+  });
+});

--- a/custom_components/home_keeper/frontend/test/documents-shape.test.js
+++ b/custom_components/home_keeper/frontend/test/documents-shape.test.js
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertNever,
+  documentIcon,
+  documentLabel,
+  isDisplayableDocument,
+  signedFileKey,
+} from '../src/documents.ts';
+
+// The link-vs-file branch lives in exactly one place (see the module header) so
+// the panel and the card can't drift. `documents.test.js` covers SignedUrlCache;
+// these are the small discriminated-union helpers around it, which nothing
+// exercised — and which decide whether a manual shows up at all.
+
+describe('isDisplayableDocument', () => {
+  it('needs a URL for a link and a filename for a file', () => {
+    expect(isDisplayableDocument({ kind: 'link', url: 'https://example.com' })).toBe(true);
+    expect(isDisplayableDocument({ kind: 'file', filename: 'manual.pdf' })).toBe(true);
+  });
+
+  it('rejects a document missing the field its kind needs', () => {
+    // The two kinds key off *different* fields; a link with only a filename (or
+    // vice versa) is data that would render an un-openable affordance.
+    expect(isDisplayableDocument({ kind: 'link' })).toBe(false);
+    expect(isDisplayableDocument({ kind: 'link', url: '' })).toBe(false);
+    expect(isDisplayableDocument({ kind: 'link', filename: 'manual.pdf' })).toBe(false);
+    expect(isDisplayableDocument({ kind: 'file' })).toBe(false);
+    expect(isDisplayableDocument({ kind: 'file', filename: '' })).toBe(false);
+    expect(isDisplayableDocument({ kind: 'file', url: 'https://example.com' })).toBe(false);
+  });
+});
+
+describe('documentLabel', () => {
+  it('prefers the display name', () => {
+    expect(documentLabel({ kind: 'link', name: 'Manual', url: 'https://x/y' })).toBe('Manual');
+    expect(documentLabel({ kind: 'file', name: 'Manual', filename: 'm.pdf' })).toBe('Manual');
+  });
+
+  it('falls back to what the document points at', () => {
+    expect(documentLabel({ kind: 'link', url: 'https://x/y' })).toBe('https://x/y');
+    expect(documentLabel({ kind: 'file', filename: 'm.pdf' })).toBe('m.pdf');
+    // An empty name is a fallback trigger, not a label.
+    expect(documentLabel({ kind: 'link', name: '', url: 'https://x/y' })).toBe('https://x/y');
+  });
+
+  it('is an empty string, never undefined, when there is nothing to show', () => {
+    // The label goes straight into the DOM; "undefined" would render literally.
+    expect(documentLabel({ kind: 'link' })).toBe('');
+    expect(documentLabel({ kind: 'file' })).toBe('');
+  });
+
+  it('does not use the other kind field as a fallback', () => {
+    expect(documentLabel({ kind: 'link', filename: 'm.pdf' })).toBe('');
+    expect(documentLabel({ kind: 'file', url: 'https://x/y' })).toBe('');
+  });
+});
+
+describe('documentIcon', () => {
+  it('gives each kind its own icon', () => {
+    expect(documentIcon({ kind: 'link', url: 'https://x/y' })).toBe('mdi:link-variant');
+    expect(documentIcon({ kind: 'file', filename: 'm.pdf' })).toBe('mdi:file-document-outline');
+  });
+});
+
+describe('assertNever', () => {
+  it('throws, naming the value it did not expect', () => {
+    // It is the runtime half of a compile-time exhaustiveness guard: adding a
+    // document kind and forgetting a `case` has to fail loudly, not return
+    // undefined into a template. The message carries the offending value so the
+    // report says which kind.
+    expect(() => assertNever({ kind: 'sticky-note' })).toThrow(
+      /Unexpected document kind: \{"kind":"sticky-note"\}/,
+    );
+  });
+
+  it('is reached by every helper for an unknown kind', () => {
+    const unknown = { kind: 'sticky-note' };
+    expect(() => isDisplayableDocument(unknown)).toThrow(/Unexpected document kind/);
+    expect(() => documentLabel(unknown)).toThrow(/Unexpected document kind/);
+    expect(() => documentIcon(unknown)).toThrow(/Unexpected document kind/);
+  });
+});
+
+describe('signedFileKey', () => {
+  it('joins kind, asset and id in that order', () => {
+    expect(signedFileKey({ kind: 'document', assetId: 'a1', id: 'd1' })).toBe(
+      'document:a1:d1',
+    );
+    expect(signedFileKey({ kind: 'part', assetId: 'a1', id: 'p1' })).toBe('part:a1:p1');
+  });
+
+  it('separates the two namespaces', () => {
+    // A document and a part can share an id; keying without the kind would make
+    // one file's signed URL serve the other.
+    expect(signedFileKey({ kind: 'document', assetId: 'a1', id: 'x' })).not.toBe(
+      signedFileKey({ kind: 'part', assetId: 'a1', id: 'x' }),
+    );
+    expect(signedFileKey({ kind: 'document', assetId: 'a1', id: 'x' })).not.toBe(
+      signedFileKey({ kind: 'document', assetId: 'a2', id: 'x' }),
+    );
+  });
+});

--- a/custom_components/home_keeper/frontend/test/forms-helpers.test.js
+++ b/custom_components/home_keeper/frontend/test/forms-helpers.test.js
@@ -1,0 +1,300 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  DEFAULT_BACKSTOP_INTERVAL,
+  backstopEnabled,
+  cardLinkTokens,
+  cardLinksFromTokens,
+  consumableLinkToken,
+  haDateTimeToIso,
+  isoToHaDateTime,
+  profileFormData,
+  profileFormToProfile,
+  profileSchema,
+  selArea,
+  selBool,
+  selDate,
+  selDateTime,
+  selDevice,
+  selEntity,
+  selIcon,
+  selLabel,
+  selNumber,
+  selSelect,
+  selText,
+} from '../src/forms.ts';
+import { setLanguage } from '../src/i18n.ts';
+
+// `forms.ts` is the panel's whole edit surface: selector factories that decide
+// what `ha-form` renders, the datetime bridge between HA's local-string format
+// and the ISO we persist, and the token round-trips behind card links and
+// profiles. `completion.test.js` and `sensor-form.test.js` cover the task schema
+// and payload; these are the helpers underneath them, which nothing exercised.
+
+beforeEach(() => setLanguage('en'));
+
+describe('selector factories', () => {
+  // A selector object is a contract with `ha-form`: the wrong shape silently
+  // renders the wrong control (or none). Assert the exact object, not just that
+  // the right key is present.
+  it('builds single-line and multiline text selectors', () => {
+    expect(selText()).toEqual({ text: {} });
+    expect(selText(false)).toEqual({ text: {} });
+    expect(selText(true)).toEqual({ text: { multiline: true } });
+  });
+
+  it('builds a boxed number selector with a floor', () => {
+    expect(selNumber()).toEqual({ number: { min: 0, mode: 'box' } });
+    expect(selNumber(1)).toEqual({ number: { min: 1, mode: 'box' } });
+    expect(selNumber(-5)).toEqual({ number: { min: -5, mode: 'box' } });
+  });
+
+  it('builds the parameterless selectors', () => {
+    expect(selBool()).toEqual({ boolean: {} });
+    expect(selDate()).toEqual({ date: {} });
+    expect(selDateTime()).toEqual({ datetime: {} });
+    expect(selIcon()).toEqual({ icon: {} });
+  });
+
+  // Registry pickers default to single-select; `multiple` is opt-in, and an
+  // empty object is *not* the same as `{multiple: false}` to ha-form.
+  it.each([
+    ['device', selDevice],
+    ['area', selArea],
+    ['label', selLabel],
+  ])('builds a %s picker that is single-select by default', (key, factory) => {
+    expect(factory()).toEqual({ [key]: {} });
+    expect(factory(false)).toEqual({ [key]: {} });
+    expect(factory(true)).toEqual({ [key]: { multiple: true } });
+  });
+
+  it('builds an entity selector carrying its filter through', () => {
+    expect(selEntity({ domain: 'sensor' })).toEqual({
+      entity: { filter: { domain: 'sensor' }, multiple: false },
+    });
+    expect(selEntity({ device_class: 'problem' }, true)).toEqual({
+      entity: { filter: { device_class: 'problem' }, multiple: true },
+    });
+  });
+
+  it('builds an unsorted dropdown so option order is ours', () => {
+    // `sort: false` matters: the options are ordered deliberately (statuses run
+    // worst-first), and letting ha-form sort them alphabetically reorders them.
+    const options = [
+      { value: 'overdue', label: 'Overdue' },
+      { value: 'due', label: 'Due' },
+    ];
+    expect(selSelect(options)).toEqual({
+      select: { mode: 'dropdown', options, sort: false, multiple: false },
+    });
+    expect(selSelect(options, true)).toEqual({
+      select: { mode: 'dropdown', options, sort: false, multiple: true },
+    });
+  });
+});
+
+describe('isoToHaDateTime / haDateTimeToIso', () => {
+  it('formats an ISO timestamp as HA local "YYYY-MM-DD HH:mm:ss"', () => {
+    // Built from local parts so the assertion holds in any TZ the suite runs in.
+    const d = new Date(2026, 5, 13, 9, 8, 7);
+    expect(isoToHaDateTime(d.toISOString())).toBe('2026-06-13 09:08:07');
+  });
+
+  it('zero-pads every component to two digits', () => {
+    // The single-digit month/day/hour/minute/second case is the whole reason
+    // `padStart` is there; a bare template string would emit "2026-6-1 9:8:7".
+    const d = new Date(2026, 0, 2, 3, 4, 5);
+    expect(isoToHaDateTime(d.toISOString())).toBe('2026-01-02 03:04:05');
+  });
+
+  it('uses a 1-based month', () => {
+    const d = new Date(2026, 11, 31, 23, 59, 59);
+    expect(isoToHaDateTime(d.toISOString())).toBe('2026-12-31 23:59:59');
+  });
+
+  it('returns undefined for empty or unparseable input', () => {
+    expect(isoToHaDateTime(undefined)).toBeUndefined();
+    expect(isoToHaDateTime(null)).toBeUndefined();
+    expect(isoToHaDateTime('')).toBeUndefined();
+    expect(isoToHaDateTime('not-a-date')).toBeUndefined();
+  });
+
+  it('parses HA local format back to ISO', () => {
+    const iso = haDateTimeToIso('2026-06-13 09:08:07');
+    expect(iso).toBe(new Date(2026, 5, 13, 9, 8, 7).toISOString());
+  });
+
+  it('returns undefined for empty or unparseable input', () => {
+    expect(haDateTimeToIso(undefined)).toBeUndefined();
+    expect(haDateTimeToIso(null)).toBeUndefined();
+    expect(haDateTimeToIso('')).toBeUndefined();
+    expect(haDateTimeToIso('not-a-date')).toBeUndefined();
+  });
+
+  it('round-trips a value through both directions', () => {
+    const original = new Date(2026, 5, 13, 9, 8, 7).toISOString();
+    expect(haDateTimeToIso(isoToHaDateTime(original))).toBe(original);
+  });
+});
+
+describe('backstopEnabled', () => {
+  it('reads the flat form switch when present', () => {
+    expect(backstopEnabled({ sensor_backstop_on: true })).toBe(true);
+    expect(backstopEnabled({ sensor_backstop_on: false })).toBe(false);
+  });
+
+  it('prefers the flat switch over a stored also_every', () => {
+    // Switching the backstop off in the form must win over the value still on
+    // the task being edited, or a switched-off backstop keeps applying.
+    expect(
+      backstopEnabled({ sensor_backstop_on: false, sensor: { also_every: { interval: 6 } } }),
+    ).toBe(false);
+    expect(backstopEnabled({ sensor_backstop_on: true, sensor: {} })).toBe(true);
+  });
+
+  it('falls back to the stored also_every when the switch is absent', () => {
+    expect(backstopEnabled({ sensor: { also_every: { interval: 6 } } })).toBe(true);
+    expect(backstopEnabled({ sensor: {} })).toBe(false);
+    expect(backstopEnabled({})).toBe(false);
+  });
+
+  it('treats an explicit null switch as absent, not as off', () => {
+    // null means "the form never set this", so the stored task decides — unlike
+    // `false`, which is the user actively switching the backstop off.
+    expect(backstopEnabled({ sensor_backstop_on: null, sensor: {} })).toBe(false);
+    expect(
+      backstopEnabled({ sensor_backstop_on: null, sensor: { also_every: { interval: 6 } } }),
+    ).toBe(true);
+  });
+
+  it('seeds a sensible interval when first switched on', () => {
+    expect(DEFAULT_BACKSTOP_INTERVAL).toBe(6);
+  });
+});
+
+describe('consumableLinkToken', () => {
+  it('joins the asset and part ids', () => {
+    expect(consumableLinkToken({ source: { part: { asset_id: 'a1', part_id: 'p2' } } })).toBe(
+      'a1:p2',
+    );
+  });
+
+  it('is empty when the task has no part source', () => {
+    expect(consumableLinkToken({})).toBe('');
+    expect(consumableLinkToken({ source: {} })).toBe('');
+  });
+});
+
+describe('cardLinkTokens / cardLinksFromTokens', () => {
+  it('renders stored reference objects as tokens', () => {
+    expect(
+      cardLinkTokens({
+        card_links: [
+          { asset_id: 'a1', entry_id: 'e1' },
+          { asset_id: 'a2', entry_id: 'e2' },
+        ],
+      }),
+    ).toEqual(['a1:e1', 'a2:e2']);
+  });
+
+  it('passes through the flat strings the select emits mid-edit', () => {
+    expect(cardLinkTokens({ card_links: ['a1:e1', 'a2:e2'] })).toEqual(['a1:e1', 'a2:e2']);
+  });
+
+  it('drops half-filled objects rather than emitting a broken token', () => {
+    expect(
+      cardLinkTokens({
+        card_links: [{ asset_id: 'a1' }, { entry_id: 'e2' }, {}, { asset_id: 'a3', entry_id: 'e3' }],
+      }),
+    ).toEqual(['a3:e3']);
+  });
+
+  it('is empty for a missing or non-array field', () => {
+    expect(cardLinkTokens({})).toEqual([]);
+    expect(cardLinkTokens({ card_links: null })).toEqual([]);
+    expect(cardLinkTokens({ card_links: 'a1:e1' })).toEqual([]);
+  });
+
+  it('parses tokens back into reference objects', () => {
+    expect(cardLinksFromTokens(['a1:e1', 'a2:e2'])).toEqual([
+      { asset_id: 'a1', entry_id: 'e1' },
+      { asset_id: 'a2', entry_id: 'e2' },
+    ]);
+  });
+
+  it('splits on the first colon only', () => {
+    // Ids are UUIDs and never contain a colon, but splitting on the last one
+    // would corrupt any that ever did — the entry id keeps the remainder.
+    expect(cardLinksFromTokens(['a1:e1:extra'])).toEqual([
+      { asset_id: 'a1', entry_id: 'e1:extra' },
+    ]);
+  });
+
+  it('drops malformed tokens instead of emitting an empty id half', () => {
+    expect(cardLinksFromTokens([':e1', 'a1:', ':', '', 'noseparator'])).toEqual([]);
+  });
+
+  it('round-trips objects through tokens and back', () => {
+    const links = [
+      { asset_id: 'a1', entry_id: 'e1' },
+      { asset_id: 'a2', entry_id: 'e2' },
+    ];
+    expect(cardLinksFromTokens(cardLinkTokens({ card_links: links }))).toEqual(links);
+  });
+});
+
+describe('profile form round-trip', () => {
+  const profile = {
+    id: 'p1',
+    name: 'Overdue in the garage',
+    filter: { status: 'overdue', labels: ['l1'], areas: ['a1'], devices: ['d1'] },
+  };
+
+  it('flattens a profile for ha-form', () => {
+    expect(profileFormData(profile)).toEqual({
+      name: 'Overdue in the garage',
+      status: 'overdue',
+      labels: ['l1'],
+      areas: ['a1'],
+      devices: ['d1'],
+    });
+  });
+
+  it('rebuilds the nested profile, keeping the id', () => {
+    expect(profileFormToProfile('p1', profileFormData(profile))).toEqual(profile);
+  });
+
+  it('trims the name and falls back to a default when blank', () => {
+    expect(profileFormToProfile('p1', { name: '  Trimmed  ' }).name).toBe('Trimmed');
+    for (const blank of ['', '   ', undefined, null]) {
+      expect(profileFormToProfile('p1', { name: blank }).name).toBeTruthy();
+      expect(profileFormToProfile('p1', { name: blank }).name).not.toBe('undefined');
+    }
+  });
+
+  it('defaults the status to overdue and coerces list fields to arrays', () => {
+    const rebuilt = profileFormToProfile('p1', { name: 'x' });
+    expect(rebuilt.filter).toEqual({
+      status: 'overdue',
+      labels: [],
+      areas: [],
+      devices: [],
+    });
+  });
+
+  it('stringifies list members that arrive as non-strings', () => {
+    const rebuilt = profileFormToProfile('p1', { name: 'x', labels: [1, 2], areas: 'nope' });
+    expect(rebuilt.filter.labels).toEqual(['1', '2']);
+    expect(rebuilt.filter.areas).toEqual([]);
+  });
+
+  it('describes every profile field in the schema', () => {
+    expect(profileSchema().map((f) => f.name)).toEqual([
+      'name',
+      'status',
+      'labels',
+      'areas',
+      'devices',
+    ]);
+    expect(profileSchema()[0].required).toBe(true);
+  });
+});

--- a/custom_components/home_keeper/frontend/test/forms-schema.test.js
+++ b/custom_components/home_keeper/frontend/test/forms-schema.test.js
@@ -1,0 +1,319 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  formRecurrenceSummary,
+  notifyFormData,
+  notifyFormToNotification,
+  notificationSchema,
+  taskSchema,
+} from '../src/forms.ts';
+import { setLanguage } from '../src/i18n.ts';
+
+// `taskSchema` decides which fields the edit form offers, and the notification
+// round-trip decides what a delivery actually does. Both are pure structure
+// builders, so their contract is the structure — a missing field is a control
+// the user can't reach, and an extra one is a value a managing integration
+// declared off-limits.
+
+beforeEach(() => setLanguage('en'));
+
+// `ha-form` groups the cadence fields inside an unnamed `grid` container, so a
+// flat `map(f => f.name)` misses exactly the fields these tests care about.
+const names = (fields) =>
+  fields.flatMap((f) => (f.schema ? names(f.schema) : [f.name])).filter(Boolean);
+
+describe('taskSchema by recurrence type', () => {
+  it('offers "every N units" for a floating task', () => {
+    expect(names(taskSchema({ recurrence_type: 'floating' }))).toEqual([
+      'name',
+      'notes',
+      'recurrence_type',
+      'interval',
+      'unit',
+      'last_completed',
+      'device_id',
+      'labels',
+      'completion_detail',
+    ]);
+  });
+
+  it('offers the calendar rule for a fixed task', () => {
+    expect(names(taskSchema({ recurrence_type: 'fixed' }))).toEqual([
+      'name',
+      'notes',
+      'recurrence_type',
+      'interval',
+      'freq',
+      'anchor',
+      'last_completed',
+      'device_id',
+      'labels',
+      'completion_detail',
+    ]);
+  });
+
+  it('offers a single due date for a one-off task', () => {
+    // A do-once task has no cadence at all, and no "last done" seed — it has
+    // never been done, and completing it retires it.
+    expect(names(taskSchema({ recurrence_type: 'one-off' }))).toEqual([
+      'name',
+      'notes',
+      'recurrence_type',
+      'due',
+      'device_id',
+      'labels',
+      'completion_detail',
+    ]);
+  });
+
+  it('swaps the cadence unit for a calendar frequency between the two', () => {
+    const floating = names(taskSchema({ recurrence_type: 'floating' }));
+    const fixed = names(taskSchema({ recurrence_type: 'fixed' }));
+    expect(floating).toContain('unit');
+    expect(floating).not.toContain('freq');
+    expect(fixed).toContain('freq');
+    expect(fixed).not.toContain('unit');
+  });
+
+  it('offers a triggered task only its descriptive fields', () => {
+    // Its state is owned by the integration watching the condition, so there is
+    // no schedule to edit — offering one would let a user arm a dormant task.
+    const got = names(taskSchema({ recurrence_type: 'triggered' }));
+    expect(got).toEqual(['name', 'notes', 'device_id', 'labels']);
+    for (const scheduling of ['interval', 'unit', 'freq', 'anchor', 'due', 'recurrence_type']) {
+      expect(got).not.toContain(scheduling);
+    }
+  });
+});
+
+describe('taskSchema respects locked fields', () => {
+  const locked = (fields) => ({
+    recurrence_type: 'floating',
+    managed_by: { integration: 'x', display_name: 'X', locked_fields: fields },
+  });
+
+  it('omits a locked field entirely rather than showing it disabled', () => {
+    const unlocked = names(taskSchema({ recurrence_type: 'floating' }));
+    const withLock = names(taskSchema(locked(['name'])));
+    expect(unlocked).toContain('name');
+    expect(withLock).not.toContain('name');
+    // Everything else survives — locking one field must not blank the form.
+    expect(withLock.length).toBe(unlocked.length - 1);
+  });
+
+  it('omits several locked fields at once', () => {
+    const got = names(taskSchema(locked(['name', 'notes', 'device_id'])));
+    for (const field of ['name', 'notes', 'device_id']) expect(got).not.toContain(field);
+    // The unlocked remainder is untouched.
+    expect(got).toContain('labels');
+    expect(got).toContain('completion_detail');
+  });
+
+  it('treats an absent or empty locked_fields as nothing locked', () => {
+    const base = names(taskSchema({ recurrence_type: 'floating' }));
+    expect(names(taskSchema(locked([])))).toEqual(base);
+    expect(
+      names(taskSchema({ recurrence_type: 'floating', managed_by: { integration: 'x' } })),
+    ).toEqual(base);
+  });
+
+  it('applies locking to a triggered task too', () => {
+    const got = names(
+      taskSchema({
+        recurrence_type: 'triggered',
+        managed_by: { integration: 'x', locked_fields: ['name', 'notes'] },
+      }),
+    );
+    expect(got).toEqual(['device_id', 'labels']);
+  });
+});
+
+describe('taskSchema card links', () => {
+  const links = [{ value: 'a1:e1', label: 'Manual' }];
+
+  it('offers the picker only when the appliance has links to show', () => {
+    expect(names(taskSchema({ recurrence_type: 'floating' }, [], links))).toContain(
+      'card_links',
+    );
+    // No links means no picker — an empty dropdown is worse than no control.
+    expect(names(taskSchema({ recurrence_type: 'floating' }, [], []))).not.toContain(
+      'card_links',
+    );
+    expect(names(taskSchema({ recurrence_type: 'floating' }))).not.toContain('card_links');
+  });
+
+  it('offers it for every task kind, including triggered', () => {
+    for (const kind of ['floating', 'fixed', 'one-off', 'triggered']) {
+      expect(names(taskSchema({ recurrence_type: kind }, [], links))).toContain('card_links');
+    }
+  });
+
+  it('omits it when locked', () => {
+    const task = {
+      recurrence_type: 'floating',
+      managed_by: { integration: 'x', locked_fields: ['card_links'] },
+    };
+    expect(names(taskSchema(task, [], links))).not.toContain('card_links');
+  });
+});
+
+describe('formRecurrenceSummary', () => {
+  it('is empty without a recurrence type', () => {
+    expect(formRecurrenceSummary({})).toBe('');
+    expect(formRecurrenceSummary({ recurrence_type: '' })).toBe('');
+  });
+
+  it('describes a floating cadence', () => {
+    const summary = formRecurrenceSummary({
+      recurrence_type: 'floating',
+      interval: 3,
+      unit: 'months',
+    });
+    expect(summary).toBeTruthy();
+    expect(summary).toMatch(/3/);
+  });
+
+  it('does not describe a triggered task as a clock schedule', () => {
+    // `buildTaskPayload` drops `recurrence_type` for a triggered task, so without
+    // it being re-attached the summary falls through to the cadence branch and
+    // reads "every day" — confident and wrong.
+    const summary = formRecurrenceSummary({ recurrence_type: 'triggered', name: 'Filter' });
+    expect(summary).not.toMatch(/every day/i);
+  });
+
+  it('never throws on a half-typed form', () => {
+    // The summary renders under a form the user is still filling in, so every
+    // intermediate state has to produce a string rather than an exception.
+    for (const partial of [
+      { recurrence_type: 'floating' },
+      { recurrence_type: 'floating', interval: 'abc' },
+      { recurrence_type: 'fixed' },
+      { recurrence_type: 'fixed', freq: 'nonsense' },
+      { recurrence_type: 'one-off' },
+      { recurrence_type: 'not-a-kind' },
+    ]) {
+      expect(() => formRecurrenceSummary(partial)).not.toThrow();
+      expect(formRecurrenceSummary(partial)).toBeTypeOf('string');
+    }
+  });
+});
+
+describe('notification form round-trip', () => {
+  const notification = {
+    id: 'n1',
+    name: 'Evening walk',
+    profile_id: 'p1',
+    targets: ['mobile_app_phone'],
+    actions: ['complete', 'snooze'],
+    style: 'walk',
+    snooze_hours: 12,
+    auto: { overdue: true, due_soon: false },
+  };
+
+  it('flattens the nested auto block for ha-form', () => {
+    expect(notifyFormData(notification)).toEqual({
+      name: 'Evening walk',
+      profile_id: 'p1',
+      targets: ['mobile_app_phone'],
+      actions: ['complete', 'snooze'],
+      style: 'walk',
+      snooze_hours: 12,
+      auto_overdue: true,
+      auto_due_soon: false,
+    });
+  });
+
+  it('renders a null profile as an empty string for the select', () => {
+    // ha-form's select has no concept of null; it would render "null" as a value.
+    expect(notifyFormData({ ...notification, profile_id: null }).profile_id).toBe('');
+  });
+
+  it('rebuilds the notification, keeping the id', () => {
+    expect(notifyFormToNotification('n1', notifyFormData(notification))).toEqual(notification);
+  });
+
+  it('turns an empty profile selection back into null, not ""', () => {
+    const rebuilt = notifyFormToNotification('n1', { name: 'x', profile_id: '' });
+    expect(rebuilt.profile_id).toBeNull();
+  });
+
+  it('falls back to a name rather than saving a blank one', () => {
+    for (const blank of ['', '   ', undefined, null]) {
+      const rebuilt = notifyFormToNotification('n1', { name: blank });
+      expect(rebuilt.name).toBeTruthy();
+      expect(rebuilt.name.trim()).toBe(rebuilt.name);
+    }
+    expect(notifyFormToNotification('n1', { name: '  Padded  ' }).name).toBe('Padded');
+  });
+
+  it('defaults style and snooze, rejecting unusable values', () => {
+    const rebuilt = notifyFormToNotification('n1', { name: 'x' });
+    expect(rebuilt.style).toBe('walk');
+    expect(rebuilt.snooze_hours).toBe(24);
+    // 0 and NaN would mean "snooze forever" / "snooze never"; both fall back.
+    expect(notifyFormToNotification('n1', { name: 'x', snooze_hours: 0 }).snooze_hours).toBe(24);
+    expect(notifyFormToNotification('n1', { name: 'x', snooze_hours: 'abc' }).snooze_hours).toBe(
+      24,
+    );
+    expect(notifyFormToNotification('n1', { name: 'x', snooze_hours: 6 }).snooze_hours).toBe(6);
+  });
+
+  it('coerces the auto switches to real booleans', () => {
+    const rebuilt = notifyFormToNotification('n1', {
+      name: 'x',
+      auto_overdue: 'yes',
+      auto_due_soon: undefined,
+    });
+    expect(rebuilt.auto).toEqual({ overdue: true, due_soon: false });
+  });
+
+  it('coerces list fields to arrays of strings', () => {
+    const rebuilt = notifyFormToNotification('n1', { name: 'x', targets: 'nope', actions: [1] });
+    expect(rebuilt.targets).toEqual([]);
+    expect(rebuilt.actions).toEqual(['1']);
+  });
+});
+
+describe('notificationSchema', () => {
+  const profiles = [{ id: 'p1', name: 'Overdue' }];
+
+  it('describes every notification field', () => {
+    expect(names(notificationSchema(['mobile_app_phone'], profiles))).toEqual([
+      'name',
+      'profile_id',
+      'targets',
+      'actions',
+      'style',
+      'snooze_hours',
+      'auto_overdue',
+      'auto_due_soon',
+    ]);
+  });
+
+  it('requires a name and a profile', () => {
+    const fields = notificationSchema([], []);
+    const required = fields.filter((f) => f.required).map((f) => f.name);
+    // A delivery with no profile has nothing to send; a nameless one is unpickable.
+    expect(required).toEqual(['name', 'profile_id']);
+  });
+
+  it('populates the profile dropdown from the live profiles', () => {
+    const field = notificationSchema([], profiles).find((f) => f.name === 'profile_id');
+    expect(field.selector.select.options).toEqual([{ value: 'p1', label: 'Overdue' }]);
+  });
+
+  it('populates targets from the live mobile_app list, multi-select', () => {
+    const field = notificationSchema(['mobile_app_a', 'mobile_app_b'], []).find(
+      (f) => f.name === 'targets',
+    );
+    expect(field.selector.select.options).toEqual([
+      { value: 'mobile_app_a', label: 'mobile_app_a' },
+      { value: 'mobile_app_b', label: 'mobile_app_b' },
+    ]);
+    expect(field.selector.select.multiple).toBe(true);
+  });
+
+  it('keeps snooze hours at a minimum of one', () => {
+    const field = notificationSchema([], []).find((f) => f.name === 'snooze_hours');
+    expect(field.selector.number.min).toBe(1);
+  });
+});

--- a/custom_components/home_keeper/frontend/test/utils-resolvers.test.js
+++ b/custom_components/home_keeper/frontend/test/utils-resolvers.test.js
@@ -1,0 +1,227 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  areaName,
+  brandLogoUrl,
+  deviceDomain,
+  deviceName,
+  isArmedTriggered,
+  isHttpUrl,
+  isSafeImageUrl,
+  labelName,
+  randomId,
+  round1,
+  safeHref,
+} from '../src/utils.ts';
+
+// `utils.test.js` covers the summary/label formatters. These are the small
+// resolvers and URL guards underneath the panel: the registry lookups that turn
+// ids into names, and the scheme checks standing between caller-supplied strings
+// and an `href`/`src`.
+
+describe('isHttpUrl / safeHref', () => {
+  it('accepts http and https, case-insensitively', () => {
+    for (const url of ['http://x/y', 'https://x/y', 'HTTPS://X/Y', 'HtTp://x']) {
+      expect(isHttpUrl(url)).toBe(true);
+    }
+  });
+
+  it('rejects every other scheme and non-strings', () => {
+    // `home_keeper.complete_task` takes a caller-supplied photo URL, so these
+    // reach the DOM from outside the panel.
+    for (const url of [
+      'javascript:alert(1)',
+      'JAVASCRIPT:alert(1)',
+      'data:text/html,<script>alert(1)</script>',
+      'vbscript:msgbox(1)',
+      'file:///etc/passwd',
+      '//evil.example.com/x',
+      '/relative/path',
+      'ftp://x/y',
+      'not a url',
+      '',
+      null,
+      undefined,
+      42,
+      { href: 'https://x' },
+    ]) {
+      expect(isHttpUrl(url), String(url)).toBe(false);
+    }
+  });
+
+  it('must anchor at the start, not match a scheme anywhere', () => {
+    expect(isHttpUrl('javascript:void(0)#https://x')).toBe(false);
+    expect(isHttpUrl(' https://x')).toBe(false);
+  });
+
+  it('safeHref escapes an accepted URL and blanks a rejected one', () => {
+    expect(safeHref('https://x/y?a=1&b=2')).toBe('https://x/y?a=1&amp;b=2');
+    expect(safeHref('https://x/"onmouseover="alert(1)')).toBe(
+      'https://x/&quot;onmouseover=&quot;alert(1)',
+    );
+    // Inert rather than dangerous: an empty href, not the original string.
+    expect(safeHref('javascript:alert(1)')).toBe('');
+    expect(safeHref(null)).toBe('');
+  });
+});
+
+describe('isSafeImageUrl', () => {
+  it('accepts http(s) and site-relative paths', () => {
+    expect(isSafeImageUrl('https://x/y.png')).toBe(true);
+    expect(isSafeImageUrl('/api/image/serve/abc/original')).toBe(true);
+  });
+
+  it('rejects protocol-relative URLs', () => {
+    // `//evil.example.com/x` inherits the page scheme and loads off-site — the
+    // reason the relative branch requires a non-slash second character.
+    expect(isSafeImageUrl('//evil.example.com/x.png')).toBe(false);
+    expect(isSafeImageUrl('///evil.example.com/x.png')).toBe(false);
+  });
+
+  it('rejects dangerous schemes, bare paths and non-strings', () => {
+    for (const url of [
+      'javascript:alert(1)',
+      'data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=',
+      'vbscript:msgbox(1)',
+      'relative/no/leading/slash.png',
+      '/',
+      '',
+      null,
+      undefined,
+      7,
+    ]) {
+      expect(isSafeImageUrl(url), String(url)).toBe(false);
+    }
+  });
+});
+
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe('randomId', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('returns a well-formed v4 UUID', () => {
+    expect(randomId()).toMatch(UUID_V4);
+  });
+
+  it('does not repeat', () => {
+    const ids = new Set(Array.from({ length: 50 }, () => randomId()));
+    expect(ids.size).toBe(50);
+  });
+
+  it('still works without crypto.randomUUID (plain-HTTP LAN)', () => {
+    // `crypto.randomUUID` is secure-context only, so it is undefined over
+    // http://192.168.x.x:8123 — calling it there throws and silently breaks
+    // file uploads and link-adds for anyone reaching HA by LAN address.
+    const getRandomValues = globalThis.crypto.getRandomValues.bind(globalThis.crypto);
+    vi.stubGlobal('crypto', { getRandomValues });
+    expect(randomId()).toMatch(UUID_V4);
+  });
+
+  it('still works with no crypto at all', () => {
+    vi.stubGlobal('crypto', undefined);
+    expect(randomId()).toMatch(UUID_V4);
+  });
+
+  it('sets the version and variant bits even on the fallback path', () => {
+    // The fallback hand-builds the UUID, so the RFC 4122 bits are ours to get
+    // right; a plain hex dump would pass a laxer regex but not this one.
+    vi.stubGlobal('crypto', undefined);
+    for (let i = 0; i < 20; i += 1) {
+      const id = randomId();
+      expect(id[14]).toBe('4');
+      expect('89ab').toContain(id[19]);
+    }
+  });
+});
+
+describe('isArmedTriggered', () => {
+  it('is true only for a triggered task with a due date', () => {
+    expect(isArmedTriggered({ recurrence_type: 'triggered', next_due: '2026-01-01' })).toBe(
+      true,
+    );
+    expect(isArmedTriggered({ recurrence_type: 'triggered', next_due: null })).toBe(false);
+    expect(isArmedTriggered({ recurrence_type: 'triggered' })).toBe(false);
+    // A due date on a non-triggered task is the normal case, not "armed".
+    expect(isArmedTriggered({ recurrence_type: 'floating', next_due: '2026-01-01' })).toBe(
+      false,
+    );
+  });
+});
+
+describe('round1', () => {
+  it('keeps at most one decimal', () => {
+    expect(round1(661.4166666)).toBe(661.4);
+    expect(round1(661.45)).toBe(661.5);
+    expect(round1(661)).toBe(661);
+    expect(round1(0)).toBe(0);
+  });
+
+  it('rounds at one decimal, not zero or two', () => {
+    // 661.44 -> 661.4 distinguishes 1dp from both 0dp (661) and 2dp (661.44).
+    expect(round1(661.44)).toBe(661.4);
+    expect(round1(-3.26)).toBe(-3.3);
+  });
+});
+
+describe('registry resolvers', () => {
+  it('deviceName prefers the user name, then the name, then the id', () => {
+    const devices = {
+      d1: { name: 'Fridge', name_by_user: 'Kitchen fridge' },
+      d2: { name: 'Fridge', name_by_user: null },
+      d3: {},
+    };
+    expect(deviceName(devices, 'd1')).toBe('Kitchen fridge');
+    expect(deviceName(devices, 'd2')).toBe('Fridge');
+    expect(deviceName(devices, 'd3')).toBe('d3');
+    // An unknown id shows the id, so a stale reference is still identifiable.
+    expect(deviceName(devices, 'gone')).toBe('gone');
+    expect(deviceName(undefined, 'd1')).toBe('d1');
+  });
+
+  it('deviceName is empty for a missing id, not the string "null"', () => {
+    expect(deviceName({}, null)).toBe('');
+    expect(deviceName({}, undefined)).toBe('');
+    expect(deviceName({}, '')).toBe('');
+  });
+
+  it('deviceDomain prefers the primary config entry', () => {
+    const entryDomains = { e1: 'zha', e2: 'mqtt' };
+    expect(deviceDomain({ primary_config_entry: 'e1', config_entries: ['e2'] }, entryDomains)).toBe(
+      'zha',
+    );
+    expect(deviceDomain({ config_entries: ['e2'] }, entryDomains)).toBe('mqtt');
+    expect(deviceDomain({ config_entries: ['e2', 'e1'] }, entryDomains)).toBe('mqtt');
+  });
+
+  it('deviceDomain is undefined when it cannot resolve', () => {
+    expect(deviceDomain(undefined, { e1: 'zha' })).toBeUndefined();
+    expect(deviceDomain({ primary_config_entry: 'e1' }, undefined)).toBeUndefined();
+    expect(deviceDomain({}, { e1: 'zha' })).toBeUndefined();
+    expect(deviceDomain({ config_entries: [] }, { e1: 'zha' })).toBeUndefined();
+    expect(deviceDomain({ primary_config_entry: 'unknown' }, { e1: 'zha' })).toBeUndefined();
+  });
+
+  it('areaName and labelName fall back to the id', () => {
+    expect(areaName({ a1: { name: 'Kitchen' } }, 'a1')).toBe('Kitchen');
+    expect(areaName({ a1: { name: '' } }, 'a1')).toBe('a1');
+    expect(areaName({}, 'a1')).toBe('a1');
+    expect(areaName(undefined, 'a1')).toBe('a1');
+    expect(areaName({}, null)).toBe('');
+
+    expect(labelName({ l1: { name: 'Seasonal' } }, 'l1')).toBe('Seasonal');
+    expect(labelName({}, 'l1')).toBe('l1');
+    expect(labelName(undefined, 'l1')).toBe('l1');
+    expect(labelName({}, null)).toBe('');
+  });
+});
+
+describe('brandLogoUrl', () => {
+  it('points at the integration brand by default', () => {
+    expect(brandLogoUrl('zha')).toBe('https://brands.home-assistant.io/zha/icon.png');
+  });
+
+  it('uses the generic "_" namespace as the fallback', () => {
+    expect(brandLogoUrl('zha', true)).toBe('https://brands.home-assistant.io/_/zha/icon.png');
+    expect(brandLogoUrl('zha', false)).toBe('https://brands.home-assistant.io/zha/icon.png');
+  });
+});


### PR DESCRIPTION
## What

A mutation pass over the TypeScript surface — the frontend counterpart to #192, and the follow-up to #190 which added the gate but left the existing debt in place.

**1,821 mutants. 1,062 detected → 1,363. 58.32% → 74.85%**, over two rounds. Of the 759 originally undetected, **285 had no coverage at all**: whole exported functions no test ever called. That's down to 86.

| File | Before | After |
| --- | ---: | ---: |
| `forms.ts` | 32.94% | **66.14%** |
| `documents.ts` | 59.83% | **81.20%** |
| `utils.ts` | 79.73% | **84.38%** |
| `card-filter.ts` | 75.69% | 77.19% |
| `markdown.ts` | 80.15% | 80.15% |
| `limits.ts` | 100% | 100% |
| **All files** | **58.32%** | **74.85%** |

**Frontend tests: 333 → 445.** Tests only; no production code changed.

**This is still below the 80% gate**, and I'd rather say so plainly than dress it up — see "What remains" below. The gate is diff-scoped, so it blocks nothing; `--all` is a manual `workflow_dispatch` run.

## What the survivors were telling us

**`forms.ts` is the panel's entire edit surface** (32.94%), and only its task payload was meaningfully tested — `completion.test.js` and `sensor-form.test.js` import three of its ~30 exports.

- **The selector factories**, asserted as whole objects. A selector *is* a contract with `ha-form`: the wrong shape silently renders the wrong control, or none. That includes details that look incidental — `sort: false` on dropdowns matters because the options are ordered deliberately (statuses run worst-first) and letting `ha-form` sort them alphabetically reorders them.
- **`taskSchema` per recurrence type**, asserted as whole field lists: floating gets "every N units", fixed swaps the unit for a calendar frequency plus an anchor, one-off gets a single due date and no cadence or "last done" seed, and triggered gets *only* its descriptive fields — offering it a schedule would let a user arm a dormant task whose state the monitoring integration owns. Locked fields are asserted **omitted**, not shown disabled.
- **The datetime bridge** between HA's local `"YYYY-MM-DD HH:mm:ss"` and the ISO we persist, including the single-digit case that is the only reason `padStart` is there — without it a January date renders `2026-1-2 3:4:5`.
- **`backstopEnabled`**, which keeps the schema, payload and hint from disagreeing about whether a usage task's time backstop applies — the split that shows a switched-off backstop still in force.
- **The notification round-trip's coercions**: a null profile renders as `""` for the select and comes back as `null` rather than the string; a blank name falls back instead of saving empty; snooze hours reject `0` and `NaN`, both of which would otherwise mean "snooze forever" or "snooze never".

**`card-filter.ts`: `profileMatches` decides which tasks a notification profile sends**, and had no direct test. Its windows have to agree with the backend or a digest reports a different set than the panel previewed. [Verified against the Python side](https://github.com/prestomation/ha-home-keeper/pull/193#issuecomment-5251401469): `overdue or (now < due <= now + window)` collapses to `due <= now + 3 days`, matching the frontend's inclusive edge exactly.

**`documents.ts`: the link-vs-file branch lives in exactly one place** so the panel and card can't drift (uploaded files were first missed on the card). Each kind keys off a *different* field, so a link carrying only a `filename` renders an un-openable affordance.

**`utils.ts`: the URL guards.** `isHttpUrl` / `safeHref` / `isSafeImageUrl` stand between a caller-supplied string and an `href`/`src` — `home_keeper.complete_task` takes a photo URL from outside the panel — so they're asserted against `javascript:`, `data:`, `vbscript:` and protocol-relative `//host` payloads, and on **anchoring**: a scheme appearing anywhere in the string must not pass.

`randomId` is tested on its fallback paths, where the interesting bug lives: `crypto.randomUUID` exists only in a secure context, so over a plain-HTTP LAN address it is `undefined` and calling it throws, silently breaking uploads. The hand-built v4 has to set the RFC 4122 version and variant bits itself, so those are asserted directly rather than via a lax hex regex.

## What remains

**458 mutants are still undetected**, 231 of them in `forms.ts` — and unlike the no-coverage bucket these are *covered but unasserted*: `taskSchema`, `buildTaskPayload` and `sensorHintText` run under existing tests that don't check enough of what they produce. Reaching 80% overall needs roughly 94 more kills, almost all there.

I stopped after two rounds because the remainder are individual assertions rather than a third pattern, and each verification run is ~50 minutes over 1,821 mutants, so the iterate-and-measure loop is slow. A third round is worth doing; it isn't worth bundling into an already-large diff.

`markdown.ts` (80.15%) I left alone: it's already at the gate, and its logic is the lazy-registration dance for `<ha-markdown>` — DOM-heavy, better served by the e2e tier. Its user text is `escapeHTML`'d on both the rendered and plain-text branches before reaching `innerHTML`, so the deferral to HA's DOMPurify-in-a-Worker sanitizer is a second layer, not the only one.

## Verification

```console
$ bash ci/test-mutation-frontend.sh --all
All files  |  74.85 |   78.56 |     1360 |         3 |        372 |       86 |        0 |

$ npx vitest run
Test Files  18 passed (18)
     Tests  445 passed (445)
```

Datetime tests confirmed timezone-independent by running them under `Asia/Kathmandu` (+05:45), `Pacific/Chatham`, `Australia/Lord_Howe` (30-minute DST shift), `Pacific/Apia` and `America/New_York` — all green.

## Notes

- Developer-facing, tests only: no CHANGELOG entry, no beta bump, no UI touched.
- Independent of #192; both branch from the same `main`.
- One thing I noticed and deliberately did **not** fix here: the 3-day due-soon window is declared twice — `transitions.DUE_SOON_WINDOW` in Python and `DUE_SOON_DAYS` in `card-filter.ts` — with nothing enforcing they stay equal. Real drift risk, but not a tests-only change.