### PR TITLE
release: 0.13.0b2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to Home Keeper are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
 
+## [0.13.0b2]
+
+### Fixed
+
+- **Assets with existing devices are now healed after a Home Assistant 2026.8
+  upgrade, not just tasks.** The previous beta healed task device_ids that pointed
+  at dead composite devices, but assets of kind "existing" also carry a device_id
+  that became stale. Left unrepaired, asset metadata entities landed on a
+  non-existent device and the UI showed raw GUIDs instead of device names. The
+  heal now covers assets and reuses the task healing mapping when both share the
+  same dead composite.
+
+- **Garbage-collected composite devices no longer silently skip healing.** When
+  Home Assistant removes the composite after all halves are re-homed,
+  `async_get_devices_for_composite_device_id` returns nothing and the repair
+  previously skipped the device. Home Keeper now falls back to the asset's stored
+  identifiers/connections snapshot to find the live successor device.
+
 ## [0.13.0b1]
 
 ### Fixed

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor", "number"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.13.0b1"
+PANEL_VERSION = "0.13.0b2"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "Babel>=2.12"
   ],
-  "version": "0.13.0b1"
+  "version": "0.13.0b2"
 }


### PR DESCRIPTION
## Release 0.13.0b2

Beta release with two bug fixes for the HA 2026.8 device-split repair:

### Fixed

- **Assets with existing devices are now healed after a Home Assistant 2026.8 upgrade, not just tasks.** The previous beta healed task device_ids that pointed at dead composite devices, but assets of kind "existing" also carry a device_id that became stale. Left unrepaired, asset metadata entities landed on a non-existent device and the UI showed raw GUIDs instead of device names. The heal now covers assets and reuses the task healing mapping when both share the same dead composite.

- **Garbage-collected composite devices no longer silently skip healing.** When Home Assistant removes the composite after all halves are re-homed, `async_get_devices_for_composite_device_id` returns nothing and the repair previously skipped the device. Home Keeper now falls back to the asset's stored identifiers/connections snapshot to find the live successor device.

### Depends on

- PR #194 (fix: heal asset device_ids after HA 2026.8 composite GC)

Merge #194 first, then this release PR.