### PR TITLE
fix(ci): restore real signal to the HA beta nightly and the mypy gate

### DIFF
--- a/.amazonq/rules/testing-and-workflow.md
+++ b/.amazonq/rules/testing-and-workflow.md
@@ -186,6 +186,18 @@ gate); CI publishes it to the job summary.
 - Run it locally before pushing: `pip install mypy homeassistant && mypy
   custom_components/home_keeper`. The pure modules (`models.py`, `recurrence.py`,
   `events.py`) stay HA-free and type-check standalone.
+- **Run it on a Python at or above Home Assistant's own floor** (>=3.14.2 since HA
+  2026.3). On an older interpreter `pip install homeassistant` does not fail — it
+  backtracks to the last HA that supported it, so mypy checks a months-old API and
+  passes. Both mypy jobs therefore run `python ci/check-ha-version.py`, which
+  compares the installed version against PyPI and fails on a stale resolve (#199).
+- **`[tool.mypy] python_version` tracks HA's floor, not the integration's.** HA's
+  source uses syntax from its own minimum Python (2026.8 uses PEP 758
+  parenthesis-free `except A, B:`); targeting anything older makes mypy bail on a
+  syntax error inside HA, reporting nothing about our code.
+- **Read the HA version from `homeassistant.const.__version__`.**
+  `homeassistant.__version__` does not exist — `homeassistant/__init__.py` is a
+  one-line docstring — so a step reading it dies with an `AttributeError`.
 
 ## Quality scale
 - Home Keeper targets **Platinum** (`manifest.json` `quality_scale`), with the

--- a/.github/workflows/ha-beta.yml
+++ b/.github/workflows/ha-beta.yml
@@ -66,9 +66,13 @@ jobs:
           (cd tests/integration && docker compose logs)
           exit 1
 
+      # Informational only: `continue-on-error` so a broken diagnostic can never
+      # again abort the suite it precedes, which is exactly how #199 hid a whole
+      # nightly's worth of signal behind a one-line version print.
       - name: Report the version actually tested
+        continue-on-error: true
         working-directory: tests/integration
-        run: docker compose exec -T homeassistant python -c "import homeassistant;print('HA',homeassistant.__version__)"
+        run: docker compose exec -T homeassistant python -c "from homeassistant.const import __version__; print('HA', __version__)"
 
       - name: Run integration tests
         run: bash ci/test-python-integration.sh
@@ -161,17 +165,23 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Must be at or above Home Assistant's own Python floor (>=3.14.2 since HA
+      # 2026.3). Pin it too low and pip quietly backtracks to the last release that
+      # still supported it rather than failing, and this job type-checks an HA from
+      # six months ago — see ci/check-ha-version.py.
       - uses: actions/setup-python@v7
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       # The cheapest early warning there is: upstream deprecations and signature
       # changes surface as type errors well before they surface as broken behaviour.
       - name: Install pre-release Home Assistant
         run: pip install --pre mypy homeassistant Babel
 
-      - name: Report the version actually tested
-        run: python -c "import homeassistant;print('HA',homeassistant.__version__)"
+      # Not `continue-on-error`: for *this* job the version under test is the whole
+      # point, so a stale resolve is a real failure rather than a lost diagnostic.
+      - name: Report and verify the version actually tested
+        run: python ci/check-ha-version.py --pre
 
       - name: Run mypy
         run: mypy custom_components/home_keeper

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,15 +25,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      # Must be at or above Home Assistant's own Python floor (>=3.14.2 since HA
+      # 2026.3), otherwise pip backtracks to the last HA that supported this
+      # version instead of failing, and the gate silently checks a stale API.
       - uses: actions/setup-python@v7
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       # Install Home Assistant so its own types resolve — strict typing against the
       # real HA API is the Platinum quality-scale gate (quality_scale.yaml). Also
       # install the integration's own runtime requirements (manifest.json) so their
       # imports resolve too.
       - name: Install mypy + Home Assistant + integration requirements
         run: pip install mypy homeassistant Babel
+      - name: Report and verify the Home Assistant version being checked
+        run: python ci/check-ha-version.py
       - name: Mypy (strict typing)
         run: mypy custom_components/home_keeper
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -368,3 +368,18 @@ siblings instead of their fakes.
   against the same config dir so HA runs its own migration in between. Stage its
   fixtures with `bash ci/fetch-glues.sh` first. The pre-split pin is frozen on
   purpose — bumping it changes what the test means.
+- **Any job that `pip install`s Home Assistant must run on a Python at or above HA's
+  own floor, and must verify what pip actually resolved.** When the runner's Python
+  is too old, pip does not fail — it quietly backtracks to the last HA release that
+  supported it, and the job goes green having checked an API nobody runs. HA 2026.3
+  moved to Python >=3.14.2, which silently pinned both mypy jobs to HA 2026.2.3 for
+  months (#199). Every such job runs `python ci/check-ha-version.py` (add `--pre`
+  when installing with `pip install --pre`), which fails on a stale resolve.
+- **`[tool.mypy] python_version` tracks HA's floor, not ours.** HA's source uses
+  syntax from its own minimum Python (2026.8 uses PEP 758 parenthesis-free
+  `except A, B:`); target anything older and mypy cannot parse HA at all — it exits
+  on a syntax error having checked nothing.
+- **A diagnostic step must never be able to fail the suite it precedes.** The
+  version-report steps in `ha-beta.yml` are informational, so they carry
+  `continue-on-error: true`. #199 was a one-line version `print` that aborted a whole
+  nightly and filed a regression issue against a Home Keeper that was working fine.

--- a/ci/check-ha-version.py
+++ b/ci/check-ha-version.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Report the installed Home Assistant version; fail if pip backtracked to an old one.
+
+Two traps this exists to catch, both of which fail *silently* and leave a green job:
+
+1. ``homeassistant.__version__`` does not exist and never has —
+   ``homeassistant/__init__.py`` is a one-line docstring. The version lives in
+   ``homeassistant.const``. A workflow step that reads the wrong attribute dies with
+   an ``AttributeError`` and takes the suite that follows it down with it (#199).
+
+2. ``pip install homeassistant`` silently resolves to an *ancient* release when the
+   runner's Python predates Home Assistant's floor. HA 2026.3 moved to Python
+   >=3.14.2, so a 3.13 runner backtracked to 2026.2.3 — six months stale — and mypy
+   dutifully type-checked against an API no user runs. Nothing in the log said so.
+
+Usage:
+    python3 ci/check-ha-version.py            # newest stable is expected
+    python3 ci/check-ha-version.py --pre      # newest pre-release is expected
+
+Exit status is 1 when the installed version is older than the newest one PyPI offers
+for the requested channel, 0 otherwise. When PyPI is unreachable the version is still
+reported and the check is skipped — this must not turn a network blip into a red CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import urllib.error
+import urllib.request
+
+from packaging.version import InvalidVersion, Version
+
+_PYPI = "https://pypi.org/pypi/homeassistant/json"
+
+
+def _installed() -> Version:
+    # The whole point of the script: read it from where it actually lives.
+    from homeassistant.const import __version__
+
+    return Version(__version__)
+
+
+def newest(releases: dict[str, list[dict]], allow_prerelease: bool) -> Version | None:
+    """Pick the newest installable version from a PyPI ``releases`` mapping.
+
+    Kept pure and separate from the fetch so it is unit-testable — a version check
+    that is itself wrong fails exactly as silently as the bug it guards against.
+    """
+    candidates = []
+    for raw, files in releases.items():
+        # A fileless or fully-yanked release cannot be what pip installed.
+        if not files or all(f.get("yanked") for f in files):
+            continue
+        try:
+            version = Version(raw)
+        except InvalidVersion:
+            continue
+        if version.is_prerelease and not allow_prerelease:
+            continue
+        candidates.append(version)
+
+    return max(candidates, default=None)
+
+
+def _newest_on_pypi(allow_prerelease: bool) -> Version | None:
+    try:
+        with urllib.request.urlopen(_PYPI, timeout=30) as response:
+            releases = json.load(response)["releases"]
+    except (urllib.error.URLError, TimeoutError, ValueError, KeyError) as err:
+        print(f"Could not reach PyPI to verify the version ({err}) — skipping check.")
+        return None
+
+    return newest(releases, allow_prerelease)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--pre",
+        action="store_true",
+        help="expect the newest pre-release (for jobs using `pip install --pre`)",
+    )
+    args = parser.parse_args()
+
+    installed = _installed()
+    latest = _newest_on_pypi(args.pre)
+
+    channel = "pre-release" if args.pre else "stable"
+    if latest is None:
+        print(f"HA {installed}")
+        return 0
+
+    print(f"HA {installed} (newest {channel} on PyPI: {latest})")
+    if installed < latest:
+        print(
+            f"::error::pip resolved Home Assistant {installed}, but {latest} is "
+            f"the newest {channel}. This job is testing a stale Home Assistant. "
+            "The usual cause is the runner's Python being older than Home "
+            "Assistant's floor, which makes pip backtrack instead of failing."
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,10 +80,13 @@ break = 80
 # Strict typing is a Platinum quality-scale gate (see custom_components/home_keeper/
 # quality_scale.yaml). CI runs `mypy custom_components/home_keeper` with Home
 # Assistant installed so HA's own types resolve; keep the integration error-free.
-# Target 3.13 to match modern Home Assistant (it uses 3.13-only typing syntax, so a
-# lower target makes mypy fail to even parse HA's own sources).
 [tool.mypy]
-python_version = "3.13"
+# Tracks the Python floor Home Assistant itself requires, not the integration's.
+# HA's source uses syntax from its own minimum Python — 2026.3 raised the floor to
+# 3.14.2, and 2026.8 uses PEP 758 parenthesis-free `except A, B:` — which mypy
+# cannot even *parse* when targeting an older version. It bails with a syntax error
+# inside HA and reports nothing about our code, so this silently stops being a gate.
+python_version = "3.14"
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
 check_untyped_defs = true

--- a/tests/unit/test_ci_check_ha_version.py
+++ b/tests/unit/test_ci_check_ha_version.py
@@ -1,0 +1,86 @@
+"""Unit tests for ``ci/check-ha-version.py``'s release selection.
+
+The script guards against a CI job silently type-checking a months-old Home
+Assistant (#199). A guard that picks the wrong "newest" would fail just as
+quietly as the bug it exists to catch, so the selection is pure and tested here.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+from packaging.version import Version
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "ci" / "check-ha-version.py"
+
+
+def _load():
+    # The filename has a hyphen, so it is not importable as a module name.
+    spec = importlib.util.spec_from_file_location("check_ha_version", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+newest = _load().newest
+
+
+def _files(*, yanked: bool = False) -> list[dict]:
+    return [{"filename": "homeassistant-x-py3-none-any.whl", "yanked": yanked}]
+
+
+def test_picks_the_highest_stable_and_ignores_prereleases() -> None:
+    releases = {
+        "2026.2.3": _files(),
+        "2026.8.0b6": _files(),
+        "2026.8.1": _files(),
+    }
+    assert newest(releases, allow_prerelease=False) == Version("2026.8.1")
+
+
+def test_prerelease_channel_can_outrank_the_newest_stable() -> None:
+    releases = {"2026.8.1": _files(), "2026.9.0b1": _files()}
+
+    assert newest(releases, allow_prerelease=True) == Version("2026.9.0b1")
+    # Without --pre the beta must not be expected, or every stable job goes red.
+    assert newest(releases, allow_prerelease=False) == Version("2026.8.1")
+
+
+def test_version_ordering_is_numeric_not_lexicographic() -> None:
+    # "2026.10.0" sorts *below* "2026.9.0" as a string — the trap this guard
+    # would fall into if it compared the raw keys.
+    releases = {"2026.9.0": _files(), "2026.10.0": _files()}
+    assert newest(releases, allow_prerelease=False) == Version("2026.10.0")
+
+
+@pytest.mark.parametrize(
+    ("label", "bad"),
+    [("fileless", []), ("fully yanked", _files(yanked=True))],
+    ids=["fileless", "fully-yanked"],
+)
+def test_uninstallable_releases_are_skipped(label: str, bad: list[dict]) -> None:
+    releases = {"2026.8.1": _files(), "2026.9.0": bad}
+    assert newest(releases, allow_prerelease=False) == Version("2026.8.1"), label
+
+
+def test_partially_yanked_release_still_counts() -> None:
+    # One yanked wheel among several does not make the release uninstallable.
+    releases = {
+        "2026.8.1": _files(),
+        "2026.9.0": [{"yanked": True}, {"yanked": False}],
+    }
+    assert newest(releases, allow_prerelease=False) == Version("2026.9.0")
+
+
+def test_unparseable_versions_are_ignored() -> None:
+    releases = {"2026.8.1": _files(), "not-a-version": _files()}
+    assert newest(releases, allow_prerelease=False) == Version("2026.8.1")
+
+
+def test_no_installable_release_yields_none() -> None:
+    # Signals "cannot verify" to the caller rather than failing the job.
+    assert newest({}, allow_prerelease=False) is None
+    assert newest({"2026.8.0b1": _files()}, allow_prerelease=False) is None


### PR DESCRIPTION
Fixes #199

## There is no Home Assistant regression

The nightly filed #199 having tested nothing. Home Keeper is fine against the beta — verified locally:

- `bash ci/test-python-integration.sh` against `HA_TAG=beta` (currently 2026.8.1): **99 passed**
- `mypy custom_components/home_keeper` against HA 2026.8.1: **Success, no issues in 39 source files**

Three CI bugs produced the false alarm. The second had been quietly degrading a PR gate for months.

## 1. The version print that killed the nightly

`homeassistant.__version__` does not exist and never has — `homeassistant/__init__.py` is a one-line docstring, and the version lives in `homeassistant.const`. So the "Report the version actually tested" step failed with an `AttributeError` on the nightly's **very first scheduled run** (`run_number: 1`).

That step sits *before* the real work, so it took down:

- the `integration` job, before `ci/test-python-integration.sh` ran
- the `typing` job, before `mypy` ran

`e2e` and `upgrade` have no such step and passed — which is why only two jobs are red in the run.

Fixed by reading `homeassistant.const.__version__`, and by marking the informational steps `continue-on-error: true` so a diagnostic can never again abort the suite it precedes.

## 2. Both mypy jobs were checking a six-month-old Home Assistant

HA 2026.3 raised its floor to Python `>=3.14.2`. Both mypy jobs pinned Python 3.13, so `pip install homeassistant` **did not fail** — it backtracked to `2026.2.3`, the last release supporting 3.13. The install log in the failing run shows exactly that.

The consequence is worse than the nightly outage:

- `ha-beta.yml` → `typing`, the job whose entire purpose is early warning about upstream API changes, was type-checking an HA **older than the one users run**.
- `lint.yml` → `mypy`, a gate on **every PR**, was doing the same.

Bug 1 masked this: a working version print would have shown `HA 2026.2.3` in the log.

Fixed by moving both jobs to Python 3.14 and adding `ci/check-ha-version.py`, which compares the resolved version against PyPI and fails loudly on a stale resolve rather than passing quietly. `--pre` selects the pre-release channel for the nightly. A PyPI outage reports the version and skips the check — a network blip must not redden CI.

## 3. mypy could not parse Home Assistant at all

`[tool.mypy] python_version` was `3.13`. HA 2026.8's source uses PEP 758 parenthesis-free `except A, B:`, which mypy cannot parse when targeting an older version:

```
homeassistant/config_entries.py:903: error: Except expressions without parentheses are
only supported in Python 3.14 and greater  [syntax]
Found 1 error in 1 file (errors prevented further checking)
```

"errors prevented further checking" means **none of our code was checked**. So even with fix 2 alone, the gate would have stayed hollow. Targeting 3.14 makes it pass cleanly with 39 files actually checked.

## Verification

| Check | Result |
| --- | --- |
| Integration suite vs `HA_TAG=beta` (2026.8.1) | 99 passed |
| `mypy` vs HA 2026.8.1, `python_version = 3.14` | clean, 39 files |
| Unit tests | 779 passed, 1 skipped |
| `ruff check` / `ruff format --check` | clean |
| Guard vs current HA / stale 2026.2.3 / PyPI outage | exit 0 / exit 1 / exit 0 |
| Both workflow YAMLs parse | ok |

## Notes

- The new guard's release selection is pure and unit-tested (`tests/unit/test_ci_check_ha_version.py`, 8 cases covering prerelease channels, numeric-vs-lexicographic ordering, yanked and fileless releases). A version check that is itself wrong fails exactly as silently as the bug it guards against.
- All three lessons are recorded as conventions in `AGENTS.md` and `.amazonq/rules/testing-and-workflow.md`, per the project rule that a convention is not real until it is written into the rules.
- No `CHANGELOG.md` entry and no beta bump: this is developer-only CI/config work with no user-facing change. No panel UI touched, so the screenshot and walkthrough gates do not apply.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCiNZxVtUSoXzH791Vz5Z4)_