### PR TITLE
release: 0.14.0b4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Home Keeper are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
 
-## [Unreleased]
+## [0.14.0b4]
 
 ### Fixed
 

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor", "number"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.14.0b3"
+PANEL_VERSION = "0.14.0b4"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "Babel>=2.12"
   ],
-  "version": "0.14.0b3"
+  "version": "0.14.0b4"
 }


### PR DESCRIPTION
## Summary

Cuts the next beta, `0.14.0b4`, bumping `manifest.json` and `const.py`
(`PANEL_VERSION`) and renaming the `## [Unreleased]` CHANGELOG section.

The only change since `0.14.0b3` is the form-focus fix from #208:

### Fixed

- **Typing a name into the add-task or add-appliance form no longer sets off Home
  Assistant's keyboard shortcuts.** The first character rebuilt the form, which took
  focus off the field you were typing in, so the rest of the word reached HA's global
  single-letter shortcuts instead: the device or entity search popped up, and sometimes
  Assist opened. The form now rebuilds only when the fields it shows actually change.

This is a bug-fix-only version bump — no new user-facing feature, so no
`preview-release` label or walkthrough-video changes are needed.

## Test plan

- [x] No code changes beyond version strings and CHANGELOG — nothing new to unit test
- [ ] CI: lint, unit tests, HACS validation, hassfest
- [ ] CI: mutation gate (no mutable-surface code changed, should no-op/pass)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SuGmZ2Ctuh3NqfD9ov9GRB)_