### PR TITLE
release: 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,25 @@ All notable changes to Home Keeper are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
 
-## [0.14.0b4]
-
-### Fixed
-
-- **Typing a name into the add-task or add-appliance form no longer sets off Home
-  Assistant's keyboard shortcuts.** The first character rebuilt the form, which took
-  focus off the field you were typing in, so the rest of the word reached HA's global
-  single-letter shortcuts instead: the device or entity search popped up, and sometimes
-  Assist opened. The form now rebuilds only when the fields it shows actually change.
-
-## [0.14.0b3]
+## [0.14.0] - 2026-08-18
 
 ### Added
 
+- **Undoing a completion now tells companion integrations which one you undid.** The
+  `home_keeper_task_uncompleted` event carries the removed completion's `ts`, and
+  `delete_completion` takes the same optional `origin` marker `complete_task` already
+  accepts. Together these let an integration that mirrors your completions (Pawsistant,
+  for one) remove its own copy when you correct a mistaken "done", instead of leaving a
+  pet-care entry behind that no longer matches Home Keeper. See
+  [docs/INTEGRATING.md](docs/INTEGRATING.md).
+- **You can put a task in a room.** The task form has an **Area** field, so a task that
+  isn't attached to a device can still be placed: *water the plants* in the Living room,
+  *clean the windows* in the Bedroom. A task's area has always been part of the store
+  and the `add_task` / `update_task` services, and the panel already grouped and
+  filtered on it, but nothing in the UI could set it. A device-less task was stuck
+  under **Unassigned** for good. Choosing an area overrides the one a task would inherit
+  from its device. Clearing it hands the task back to the device's. The task detail page
+  now names the area it ended up in, next to the device chip. (Fixes #204)
 - **Sensor-based tasks can now be driven by a binary sensor**, through a new **State**
   mode. Plenty of hardware never publishes a number: a robot vacuum reports *water tank
   low*, a device reports `battery_almost_empty` instead of a battery percentage, a leak
@@ -37,6 +42,15 @@ versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
   the task by itself once the condition goes away, recording a completion so the history
   still shows it. It's off by default, so tasks keep waiting for you unless you say
   otherwise. A bound entity going unavailable is deliberately not treated as a recovery.
+
+### Changed
+
+- **The Home Keeper panel now requires an administrator account.** Managing your home
+  is administration, and Home Assistant reserves that for admins, so the panel follows
+  the same rule its own Settings does. Everyone else in the household keeps the to-do
+  list, the calendar, the device-page buttons and the dashboard card, and can still
+  complete, snooze, skip and add tasks. The new
+  [security model](docs/SECURITY.md) page spells out where the line falls.
 
 ### Security
 
@@ -64,40 +78,6 @@ versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
   almost everywhere. Escaping alone doesn't defuse a `javascript:` link, and some links
   reach Home Keeper from other integrations.
 
-### Changed
-
-- **The Home Keeper panel now requires an administrator account.** Managing your home
-  is administration, and Home Assistant reserves that for admins, so the panel follows
-  the same rule its own Settings does. Everyone else in the household keeps the to-do
-  list, the calendar, the device-page buttons and the dashboard card, and can still
-  complete, snooze, skip and add tasks. The new
-  [security model](docs/SECURITY.md) page spells out where the line falls.
-
-## [0.14.0b2]
-
-### Added
-
-- **You can put a task in a room.** The task form has an **Area** field, so a task that
-  isn't attached to a device can still be placed: *water the plants* in the Living room,
-  *clean the windows* in the Bedroom. A task's area has always been part of the store
-  and the `add_task` / `update_task` services, and the panel already grouped and
-  filtered on it, but nothing in the UI could set it. A device-less task was stuck
-  under **Unassigned** for good. Choosing an area overrides the one a task would inherit
-  from its device. Clearing it hands the task back to the device's. The task detail page
-  now names the area it ended up in, next to the device chip. (Fixes #204)
-
-## [0.14.0b1]
-
-### Added
-
-- **Undoing a completion now tells companion integrations which one you undid.** The
-  `home_keeper_task_uncompleted` event carries the removed completion's `ts`, and
-  `delete_completion` takes the same optional `origin` marker `complete_task` already
-  accepts. Together these let an integration that mirrors your completions (Pawsistant,
-  for one) remove its own copy when you correct a mistaken "done", instead of leaving a
-  pet-care entry behind that no longer matches Home Keeper. See
-  [docs/INTEGRATING.md](docs/INTEGRATING.md).
-
 ### Fixed
 
 - **Undoing a completion that was already gone no longer announces an undo.** Removing
@@ -107,6 +87,11 @@ versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
 - **`docs/INTEGRATING.md` said no event fires when you delete a task in Home Keeper.**
   `home_keeper_task_deleted` has fired on every deletion path for a while; the
   lifecycle section now says so.
+- **Typing a name into the add-task or add-appliance form no longer sets off Home
+  Assistant's keyboard shortcuts.** The first character rebuilt the form, which took
+  focus off the field you were typing in, so the rest of the word reached HA's global
+  single-letter shortcuts instead: the device or entity search popped up, and sometimes
+  Assist opened. The form now rebuilds only when the fields it shows actually change.
 
 ## [0.13.0] - 2026-08-12
 

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor", "number"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.14.0b4"
+PANEL_VERSION = "0.14.0"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "Babel>=2.12"
   ],
-  "version": "0.14.0b4"
+  "version": "0.14.0"
 }


### PR DESCRIPTION
## Summary

Cuts stable `0.14.0`, condensing the `0.14.0b1`-`b4` beta work into one changelog
entry per the release process in `RELEASE.md` / `AGENTS.md`. Bumps `manifest.json`
and `const.py` (`PANEL_VERSION`) from `0.14.0b4` → `0.14.0`, and replaces the four
beta `## [0.14.0bN]` CHANGELOG sections with a single `## [0.14.0] - 2026-08-18`
section, rolled up as someone upgrading from the last stable (`0.13.0`) would
perceive it — no beta-to-beta framing.

### Added

- **Undoing a completion now tells companion integrations which one you undid.**
- **You can put a task in a room** — a new **Area** field on the task form.
  (Fixes #204)
- **Sensor-based tasks can now be driven by a binary sensor**, through a new
  **State** mode, plus **Clear when back to normal** for State/Threshold tasks.

### Changed

- **The Home Keeper panel now requires an administrator account.**

### Security

- Closed a service/websocket admin-gate mismatch on settings, inventory export,
  and appliance writes.
- Non-admin appliance reads are now projected to only what the dashboard card
  needs.
- `home_keeper.notify` / saved notifications now refuse any `target:` outside
  `mobile_app_*` and `persistent_notification`.
- Only the built panel bundle is served, not the whole frontend source tree.
- Link rendering goes through a scheme check everywhere, not just escaping.

### Fixed

- Undoing an already-removed completion no longer fires a spurious event.
- `docs/INTEGRATING.md`'s task-deletion event claim corrected.
- The add-task/add-appliance form no longer trips HA's global keyboard
  shortcuts on the first keystroke.

Merging this triggers `release.yml` to tag `v0.14.0` and publish a **stable**
(non-prerelease) GitHub Release with `home_keeper.zip`, which HACS offers to all
users — left as a draft pending your go-ahead to merge.

## Test plan

- [x] No source changes beyond version strings and CHANGELOG — nothing new to unit test
- [ ] CI: lint, unit tests, HACS validation, hassfest
- [ ] CI: mutation gate (no mutable-surface code changed)
- [ ] `release.yml` validates `manifest.json` version matches a `## [0.14.0]` CHANGELOG entry

---
_Generated by [Claude Code](https://claude.ai/code/session_01SuGmZ2Ctuh3NqfD9ov9GRB)_