### PR TITLE
release: 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Home Keeper are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
 
-## [0.15.0b1]
+## [0.15.0] - 2026-08-20
 
 ### Added
 

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor", "number"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.15.0b1"
+PANEL_VERSION = "0.15.0"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -20,5 +20,5 @@
   "requirements": [
     "Babel>=2.12"
   ],
-  "version": "0.15.0b1"
+  "version": "0.15.0"
 }


### PR DESCRIPTION
## Summary

Cuts the `0.15.0b1` beta to stable `0.15.0`.

- `custom_components/home_keeper/manifest.json` — `version` `0.15.0b1` → `0.15.0`
- `custom_components/home_keeper/const.py` — `PANEL_VERSION` `0.15.0b1` → `0.15.0`
- `CHANGELOG.md` — `## [0.15.0b1]` → `## [0.15.0] - 2026-08-20`

Everything shipped in this beta was the NFC/RFID tag task-completion feature
(Fixes #211), so the stable section keeps the existing `### Added` content
as-is — nothing else landed since `0.14.0`.

## Test plan

- [x] `python3 -c "import json; json.load(open('custom_components/home_keeper/manifest.json'))"`
- [x] Confirmed `manifest.json` `version` and `const.py` `PANEL_VERSION` match
- [x] Confirmed a matching `## [0.15.0]` section exists in `CHANGELOG.md`
- [ ] CI (`release.yml` tags `v0.15.0` and publishes the GitHub release + HACS asset on merge)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XQ2yJa4Bq6SV58aXazYEvH)_