### PR TITLE
fix(notifications): let "Mark done" work before a task is due (Fixes #216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to Home Keeper are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
 
+## [0.16.0b2]
+
+### Fixed
+
+- **"Mark done" on a notification works before the task is due.** A notification built
+  from a Profile set to **Due soon** (or **All**) shows tasks that aren't overdue yet,
+  and its **Mark done** button did nothing at all when tapped. No completion, nothing in
+  the log, while **Snooze** and **Skip** on the same notification worked. The task then
+  went overdue as if it had been left alone. Tapping the button now completes the task
+  whenever it still reflects the task's current schedule. Taps that no longer do are
+  still ignored, so completing a task somewhere else (or on a second notification
+  covering the same task) can't push it out an extra cycle. (Fixes #216)
+
 ## [0.16.0b1] - 2026-08-21
 
 ### Added

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor", "number"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.16.0b1"
+PANEL_VERSION = "0.16.0b2"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -20,5 +20,5 @@
   "requirements": [
     "Babel>=2.12"
   ],
-  "version": "0.16.0b1"
+  "version": "0.16.0b2"
 }

--- a/custom_components/home_keeper/notifications.py
+++ b/custom_components/home_keeper/notifications.py
@@ -5,7 +5,8 @@ in ``profiles.py`` that decides *which* tasks) by ``profile_id`` and adds *how* 
 deliver them — mobile targets, the button set, snooze duration, style (walk/digest),
 and automatic triggers. This module owns only that delivery concern: notification
 normalization, the mobile-app **payload builders**, and the **action-string**
-encode/decode that routes a notification tap back to the right task and notification.
+encode/decode that routes a notification tap back to the right task and notification
+(and tells a fresh tap from a stale one — see :func:`is_current_action`).
 The filter/queue live in ``profiles.py``; HA-aware sending in ``notifier.py``.
 
 See ``docs/PROFILES_REFACTOR_PLAN.md`` / ``docs/ACTIONABLE_NOTIFICATIONS_PLAN.md``.
@@ -52,36 +53,84 @@ STYLES = (STYLE_WALK, STYLE_DIGEST)
 
 DEFAULT_SNOOZE_HOURS = 24
 
-# Action-string scheme: ``home_keeper::<verb>::<task_id>::<notification_id>``. The
-# action string is the only field reliably echoed back in
-# ``mobile_app_notification_action``, so the verb, task, and notification are all
-# encoded into it. The prefix scopes ours on a global event bus that also carries
-# other integrations' actions.
+# Action-string scheme:
+# ``home_keeper::<verb>::<task_id>::<notification_id>::<due_token>``. The action string
+# is the only field reliably echoed back in ``mobile_app_notification_action``, so the
+# verb, task, notification and a freshness token are all encoded into it. The prefix
+# scopes ours on a global event bus that also carries other integrations' actions.
+#
+# The trailing ``due_token`` is the task's ``next_due`` at send time (see
+# :func:`due_token`), which makes the button a snapshot that can be checked against the
+# live task on tap — see :func:`is_current_action`. Notifications delivered *before*
+# tokens existed carry the older four-field form, which still decodes (with no token)
+# so buttons already sitting on someone's phone keep working.
 _ACTION_PREFIX = "home_keeper"
 _ACTION_SEP = "::"
 
 
-def encode_action(verb: str, task_id: str, notification_id: str) -> str:
-    """Build the action identifier carried on a notification button."""
-    return _ACTION_SEP.join((_ACTION_PREFIX, verb, task_id, notification_id))
+def due_token(task: dict[str, Any]) -> str:
+    """The freshness token for *task* — its ``next_due``, verbatim.
+
+    Raw rather than hashed on purpose: ISO-8601 never contains the ``::`` separator,
+    the values compare as exact strings with no parsing or timezone normalization, and
+    it reads plainly in a debug log or a hand-written test action string.
+    """
+    return str(task.get("next_due") or "")
 
 
-def decode_action(action: str | None) -> tuple[str, str, str] | None:
-    """Parse one of our action strings into ``(verb, task_id, notification_id)``.
+def is_current_action(
+    task: dict[str, Any], token: str | None, *, tokenless_ok: bool
+) -> bool:
+    """Whether a tapped action still matches the task state its button was built from.
 
-    Returns ``None`` for anything that isn't a well-formed Home Keeper action (a
-    foreign integration's action, or a malformed/empty value) so the listener can
-    ignore it.
+    *token* is the ``next_due`` snapshot the button carried. A mismatch means the task
+    moved between the send and the tap — completed, snoozed, skipped or rescheduled,
+    whether from this notification, a second card for the same task, or another surface
+    entirely — so the tap is stale and must not act on the task again.
+
+    Comparing against the task's *live* ``next_due`` (rather than anything scoped to the
+    notification the tap came from) is what makes two independent cards for one task
+    invalidate each other: they encode the same token, so whichever is tapped first
+    advances the task and strands the other.
+
+    A notification delivered before tokens existed carries ``token is None``. There is
+    nothing to compare, so the caller's own due-state check (*tokenless_ok*) decides.
+    """
+    if token is None:
+        return tokenless_ok
+    return token == due_token(task)
+
+
+def encode_action(verb: str, task_id: str, notification_id: str, token: str) -> str:
+    """Build the action identifier carried on a notification button.
+
+    *token* is the task's freshness token — see :func:`due_token`.
+    """
+    return _ACTION_SEP.join((_ACTION_PREFIX, verb, task_id, notification_id, token))
+
+
+def decode_action(action: str | None) -> tuple[str, str, str, str | None] | None:
+    """Parse an action string into ``(verb, task_id, notification_id, due_token)``.
+
+    Accepts both the current five-field form and the legacy four-field one, whose
+    ``due_token`` comes back as ``None``. Returns ``None`` for anything that isn't a
+    well-formed Home Keeper action (a foreign integration's action, or a
+    malformed/empty value) so the listener can ignore it.
     """
     if not action:
         return None
     parts = action.split(_ACTION_SEP)
-    if len(parts) != 4 or parts[0] != _ACTION_PREFIX:
+    if len(parts) not in (4, 5) or parts[0] != _ACTION_PREFIX:
         return None
-    _, verb, task_id, notification_id = parts
+    verb, task_id, notification_id = parts[1], parts[2], parts[3]
+    token = parts[4] if len(parts) == 5 else None
     if verb not in ACTIONS or not task_id or not notification_id:
         return None
-    return verb, task_id, notification_id
+    if token is not None and not token:
+        # Our builder always encodes a real ``next_due`` (a task only reaches a
+        # notification with one), so an empty token is malformed, not legacy.
+        return None
+    return verb, task_id, notification_id, token
 
 
 # ── notification normalization ───────────────────────────────────────────────────
@@ -291,7 +340,7 @@ def _action_button(
     lang: str = _DEFAULT_LANG,
 ) -> dict[str, Any]:
     """Build one mobile-app action button for *verb* on *task*."""
-    action_id = encode_action(verb, task["id"], notification["id"])
+    action_id = encode_action(verb, task["id"], notification["id"], due_token(task))
     if verb == ACTION_COMPLETE:
         return {"action": action_id, "title": _t(lang, "action_complete")}
     if verb == ACTION_SNOOZE:

--- a/custom_components/home_keeper/notifier.py
+++ b/custom_components/home_keeper/notifier.py
@@ -343,21 +343,50 @@ def async_setup_notifications(
 ) -> CALLBACK_TYPE:
     """Subscribe to mobile-app action events; returns the unsubscribe callback."""
 
-    async def _handle(verb: str, task_id: str, notification_id: str) -> None:
+    async def _handle(
+        verb: str, task_id: str, notification_id: str, due_token: str | None
+    ) -> None:
         notification = notifications.resolve_notification(
             _notifications(entry), notification_id
         )
         now = dt_util.now()
         try:
             if verb == notifications.ACTION_COMPLETE:
-                # Gate a "Mark done" tap on the task still being armed/overdue, so a
-                # stale notification tapped after the task was already completed (or
-                # snoozed) elsewhere is a silent no-op rather than a double-advance.
+                # Gate a "Mark done" tap on the button still reflecting the task's
+                # current schedule, so a stale card — tapped after the task was
+                # completed/snoozed/skipped elsewhere, or a second card for the same
+                # task whose twin was already actioned — is a silent no-op rather than
+                # a double-advance (each completion advances next_due a full interval).
                 # A missing task (deleted) is likewise a no-op.
+                #
+                # NOTE: this check and the mutation it guards are atomic, and must
+                # stay that way. Everything from get_task() through complete_task()'s
+                # ``self._tasks[task_id] = updated`` runs without a yield point
+                # (awaiting a coroutine runs its body inline until *it* suspends, and
+                # complete_task's first suspension is the later ``await self._save()``),
+                # so two simultaneous taps — two phones on one card, or two cards for
+                # one task — cannot both read the pre-completion next_due. Introducing
+                # an await above that assignment would open that race.
                 task = coord.store.get_task(task_id)
-                if task is None or not recurrence.is_overdue(
-                    task, now=dt_util.utcnow()
+                if task is None:
+                    _LOGGER.debug(
+                        "Home Keeper notification action complete on %s ignored: "
+                        "task no longer exists",
+                        task_id,
+                    )
+                    return
+                if not notifications.is_current_action(
+                    task,
+                    due_token,
+                    tokenless_ok=recurrence.is_overdue(task, now=now),
                 ):
+                    _LOGGER.debug(
+                        "Home Keeper notification action complete on %s ignored: "
+                        "stale tap (button carried next_due %s, task is now at %s)",
+                        task_id,
+                        due_token,
+                        task.get("next_due"),
+                    )
                     return
                 await coord.store.complete_task(
                     task_id, origin=ORIGIN_NOTIFICATION_ACTION
@@ -410,7 +439,7 @@ def async_setup_notifications(
         decoded = notifications.decode_action(event.data.get("action"))
         if decoded is None:
             return
-        verb, task_id, notification_id = decoded
-        hass.async_create_task(_handle(verb, task_id, notification_id))
+        verb, task_id, notification_id, due_token = decoded
+        hass.async_create_task(_handle(verb, task_id, notification_id, due_token))
 
     return hass.bus.async_listen(EVENT_MOBILE_APP_ACTION, _on_action)

--- a/tests/integration/test_notifications.py
+++ b/tests/integration/test_notifications.py
@@ -162,6 +162,146 @@ def test_notify_service_and_action_completes(ha, ha_token):
     )
 
 
+def _seed_due_soon_task(ha, label, notification_ids):
+    """A task due in 2 hours plus a due-soon profile and *notification_ids* cards.
+
+    Returns ``(task_id, due_token)`` — the token being the task's ``next_due``, which is
+    what every button on every one of those cards encodes.
+    """
+    resp = call_service(
+        ha,
+        "home_keeper",
+        "add_task",
+        {
+            "name": "Not yet due task",
+            "recurrence_type": "floating",
+            "interval": 7,
+            "unit": "days",
+            "labels": [label],
+        },
+        return_response=True,
+    )
+    task_id = resp.get("service_response", resp)["task_id"]
+    # A fresh floating task is due *now*; snooze it forward so it is genuinely not
+    # overdue, while still inside the 3-day due-soon window the profile selects on.
+    call_service(ha, "home_keeper", "snooze_task", {"task_id": task_id, "hours": 2})
+
+    call_service(
+        ha,
+        "home_keeper",
+        "set_options",
+        {
+            "profiles": [
+                {
+                    "id": "dueprofile",
+                    "name": "Due soon",
+                    "filter": {"status": "due_soon", "labels": [label]},
+                }
+            ],
+            "notifications": [
+                {
+                    "id": nid,
+                    "name": f"Card {nid}",
+                    "profile_id": "dueprofile",
+                    "targets": ["mobile_app_test"],
+                    "actions": ["complete", "snooze"],
+                }
+                for nid in notification_ids
+            ],
+        },
+    )
+
+    task = _get_task(ha, task_id)
+    assert task["next_due"], "snoozed task should carry a next_due"
+    return task_id, task["next_due"]
+
+
+def _wait_for_completion(ha, task_id, timeout=20):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        task = _get_task(ha, task_id)
+        if task and task.get("completions"):
+            return task
+        time.sleep(1)
+    return None
+
+
+def _cleanup(ha, task_id):
+    call_service(ha, "home_keeper", "delete_task", {"task_id": task_id})
+    call_service(
+        ha, "home_keeper", "set_options", {"profiles": [], "notifications": []}
+    )
+
+
+def test_action_completes_a_task_that_is_not_yet_due(ha):
+    """#216: "Mark done" on a due-soon notification was silently ignored.
+
+    A profile with ``status: due_soon`` legitimately queues a task whose ``next_due`` is
+    still in the future, and the notification it builds carries the full button set. The
+    old handler gated the tap on ``is_overdue``, so the button did nothing at all — no
+    completion, no log — and the task went on to become overdue. The gate now checks the
+    button against the task's *current* schedule instead of its due-state.
+    """
+    label = "hk_notify_due_soon"
+    task_id, token = _seed_due_soon_task(ha, label, ["duenotif"])
+
+    before = _get_task(ha, task_id)
+    assert not before.get("completions"), "precondition: task starts uncompleted"
+
+    _fire_action(ha, f"home_keeper::complete::{task_id}::duenotif::{token}")
+    completed = _wait_for_completion(ha, task_id)
+    assert completed, "an early 'Mark done' tap must complete the task (#216)"
+
+    # The same tap re-fired is now stale — the completion moved next_due, so the token
+    # the button carried no longer matches and the task must not advance a second time.
+    before_count = len(completed.get("completions", []))
+    before_next_due = completed.get("next_due")
+    _fire_action(ha, f"home_keeper::complete::{task_id}::duenotif::{token}")
+    time.sleep(3)  # let the (no-op) action handler run
+    after = _get_task(ha, task_id)
+    assert len(after.get("completions", [])) == before_count, (
+        "stale complete tap should not append a second completion"
+    )
+    assert after.get("next_due") == before_next_due, (
+        "stale complete tap should not advance next_due"
+    )
+
+    _cleanup(ha, task_id)
+
+
+def test_two_notifications_for_one_task_complete_it_once(ha):
+    """Two separate cards for the same task must not double-advance it.
+
+    Two saved notifications matching the same task deliver two independent cards, each
+    with its own ``tag`` — so actioning one does not replace the other on the phone.
+    Both encode the same freshness token (it is keyed on the *task*, not on the
+    notification), so whichever is tapped first advances the task and strands the other
+    — a notification-scoped dedupe could not do that. Each completion
+    advances ``next_due`` by a full interval, which is what makes a double-tap here
+    silently skip a cycle rather than merely duplicate a history row.
+    """
+    label = "hk_notify_two_cards"
+    task_id, token = _seed_due_soon_task(ha, label, ["cardone", "cardtwo"])
+
+    # Fired back to back with no wait: the freshness check and the store mutation it
+    # guards run without a yield point, so the second tap is guaranteed to observe the
+    # first one's completion rather than racing it.
+    _fire_action(ha, f"home_keeper::complete::{task_id}::cardone::{token}")
+    _fire_action(ha, f"home_keeper::complete::{task_id}::cardtwo::{token}")
+
+    completed = _wait_for_completion(ha, task_id)
+    assert completed, "the first card's tap must complete the task"
+    time.sleep(3)  # give the second tap every chance to land as well
+
+    after = _get_task(ha, task_id)
+    assert len(after.get("completions", [])) == 1, (
+        "two cards for one task must produce exactly one completion, got "
+        f"{len(after.get('completions', []))}"
+    )
+
+    _cleanup(ha, task_id)
+
+
 async def _ws_commands(token, commands):
     """Open one authed websocket; send each command; return the replies."""
     results = []

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -25,8 +25,33 @@ def task(tid, name, next_due, **extra):
 
 
 def test_encode_decode_roundtrip():
-    a = n.encode_action(n.ACTION_SNOOZE, "task123", "notif456")
-    assert n.decode_action(a) == (n.ACTION_SNOOZE, "task123", "notif456")
+    a = n.encode_action(n.ACTION_SNOOZE, "task123", "notif456", "2026-06-16T10:00:00")
+    assert a == "home_keeper::snooze::task123::notif456::2026-06-16T10:00:00"
+    assert n.decode_action(a) == (
+        n.ACTION_SNOOZE,
+        "task123",
+        "notif456",
+        "2026-06-16T10:00:00",
+    )
+
+
+def test_decode_accepts_legacy_tokenless_action():
+    # A notification delivered before the freshness token existed is still sitting on
+    # someone's phone; its buttons must keep routing, with no token to check.
+    assert n.decode_action("home_keeper::complete::task123::notif456") == (
+        n.ACTION_COMPLETE,
+        "task123",
+        "notif456",
+        None,
+    )
+
+
+def test_decode_keeps_an_offset_bearing_token_intact():
+    # An aware ISO-8601 next_due carries '+'/'-' and single ':' but never the '::'
+    # separator, so it survives the split verbatim and compares as an exact string.
+    token = "2026-06-16T10:00:00+02:00"
+    a = n.encode_action(n.ACTION_COMPLETE, "t", "x", token)
+    assert n.decode_action(a) == (n.ACTION_COMPLETE, "t", "x", token)
 
 
 def test_decode_rejects_foreign_and_malformed():
@@ -36,6 +61,53 @@ def test_decode_rejects_foreign_and_malformed():
     assert n.decode_action("home_keeper::complete::t") is None  # too few parts
     assert n.decode_action("home_keeper::bogus::t::x") is None  # unknown verb
     assert n.decode_action("home_keeper::complete::::x") is None  # empty task id
+    assert n.decode_action("home_keeper::complete::t::") is None  # empty notif id
+    assert n.decode_action("home_keeper::complete::t::x::") is None  # empty token
+    assert n.decode_action("home_keeper::complete::t::x::d::extra") is None  # 6 parts
+
+
+# ── freshness token ─────────────────────────────────────────────────────────
+
+
+def test_due_token_is_the_raw_next_due():
+    t = task("t", "T", dt(2026, 6, 16, 10))
+    assert n.due_token(t) == "2026-06-16T10:00:00-04:00"
+
+
+def test_due_token_of_an_undated_task_is_empty():
+    assert n.due_token(task("t", "T", None)) == ""
+    assert n.due_token({}) == ""
+
+
+def test_is_current_action_accepts_a_matching_token():
+    # The early-tap case from #216: the task is not yet due, but the button still
+    # reflects its current schedule, so "Mark done" must act.
+    t = task("t", "T", dt(2026, 6, 16, 10))
+    assert n.is_current_action(t, n.due_token(t), tokenless_ok=False) is True
+
+
+def test_is_current_action_rejects_a_moved_task():
+    # The task advanced after the button was built (completed/snoozed/skipped
+    # elsewhere, or a twin card for the same task was tapped first).
+    t = task("t", "T", dt(2026, 6, 16, 10))
+    stale = n.due_token(t)
+    moved = task("t", "T", dt(2026, 6, 23, 10))
+    assert n.is_current_action(moved, stale, tokenless_ok=True) is False
+
+
+def test_is_current_action_defers_to_the_caller_when_tokenless():
+    t = task("t", "T", dt(2026, 6, 16, 10))
+    assert n.is_current_action(t, None, tokenless_ok=True) is True
+    assert n.is_current_action(t, None, tokenless_ok=False) is False
+
+
+def test_two_cards_for_one_task_encode_the_same_token():
+    # Why one card invalidates the other: the token is keyed on the *task*, not on the
+    # notification the tap came from, so independent cards agree on it.
+    t = task("t", "T", dt(2026, 6, 16, 10))
+    a = n.encode_action(n.ACTION_COMPLETE, t["id"], "notif_a", n.due_token(t))
+    b = n.encode_action(n.ACTION_COMPLETE, t["id"], "notif_b", n.due_token(t))
+    assert n.decode_action(a)[3] == n.decode_action(b)[3]
 
 
 # ── notification normalization ───────────────────────────────────────────────
@@ -194,8 +266,13 @@ def test_build_notification_walk_actions_and_tag():
     assert payload["data"]["tag"] == "home_keeper_n1"
     actions = payload["data"]["actions"]
     assert [a["title"] for a in actions] == ["Mark done", "Snooze 6h", "Open"]
-    assert actions[0]["action"] == "home_keeper::complete::t1::n1"
+    assert actions[0]["action"] == (
+        "home_keeper::complete::t1::n1::2026-06-10T00:00:00-04:00"
+    )
     assert actions[2]["uri"] == "/home-keeper/tasks/t1"
+    # Every button carries the task's next_due, so a tap on any of them can be checked
+    # for freshness — not just "Mark done".
+    assert all(a["action"].endswith(f"::{n.due_token(t)}") for a in actions)
 
 
 def test_overdue_phrase_singular_and_due_now():
@@ -243,8 +320,16 @@ def test_action_titles_translate_by_lang():
     )
     t = task("t1", "Furnace filter", dt(2026, 6, 10))
     payload = n.build_notification(t, notification=notif, now=now, lang="es")
-    titles = [a["title"] for a in payload["data"]["actions"]]
+    actions = payload["data"]["actions"]
+    titles = [a["title"] for a in actions]
     assert titles == ["Marcar como hecho", "Posponer 6 h", "Omitir", "Abrir"]
+    # The full button set, so this is where every verb's routing key is pinned: the
+    # companion app echoes back whatever sits under "action", so a mistyped key on any
+    # one of them ships a button that does nothing.
+    assert [a["action"] for a in actions] == [
+        n.encode_action(verb, "t1", "n1", n.due_token(t))
+        for verb in ("complete", "snooze", "skip", "open")
+    ]
 
 
 def test_overdue_phrase_translates_and_pluralizes():


### PR DESCRIPTION
Fixes #216.

## The bug

A notification built from a Profile set to **Due soon** (or **All**) legitimately queues tasks whose `next_due` is still in the future, and `build_notification` attaches the full button set to them — `_action_button` never consulted due-state. But the tap handler gated `complete` on `recurrence.is_overdue`:

```python
task = coord.store.get_task(task_id)
if task is None or not recurrence.is_overdue(task, now=dt_util.utcnow()):
    return
```

So the button did nothing at all: no completion, no log, and the task went on to become overdue as if it had been left alone. **Snooze** and **Skip** on the very same card worked, because neither consults due-state. That asymmetry is exactly what the reporter described.

## Why not just drop the guard

`complete_task` appends a completion *and* advances `next_due` a full interval, so a duplicated tap silently skips a cycle — a quarterly task jumps six months out. Two ways that happens in practice: a double-tap, and a notification whose `targets` list covers several phones (`_send_payload` fans out to each). The guard was protecting something real. It was just using the wrong predicate: "is this task overdue" as a proxy for "is this button still valid".

## The fix

Check freshness directly. Each button now carries the task's `next_due` at send time as a fifth action-string field:

```
home_keeper::{verb}::{task_id}::{notification_id}::{due_token}
```

A tap acts only if that token still matches the live task. Raw `next_due` rather than a digest: ISO-8601 never contains the `::` separator, the values compare as exact strings with no parsing or timezone normalization, and it reads plainly in a debug log or a hand-written test action string.

| between send and tap | token | outcome |
|---|---|---|
| nothing (still due soon / overdue) | matches | **completes** — the bug |
| completed elsewhere | differs | no-op |
| snoozed / skipped / rescheduled | differs | no-op |
| a second card for the same task was tapped first | differs | no-op |

The last row is the one a notification-scoped dedupe could not do. The token is keyed on the **task**, not on the card it rode in on, so two independent notifications covering one task encode the same token and invalidate each other.

### Simultaneous taps

The check and the mutation it guards are atomic, so two phones on one card — or two cards for one task — cannot both observe the pre-completion `next_due`. Nothing from `get_task()` through `complete_task()`'s `self._tasks[task_id] = updated` yields: awaiting a coroutine runs its body inline until *it* suspends, and `complete_task`'s first suspension is the later `await self._save()`. That invariant is now commented at both ends, since an `await` added above that assignment would quietly open the race.

### Backward compatibility

`decode_action` still accepts the four-field form, so buttons already delivered to phones keep working. Those fall back to the old overdue gate, which is what the pre-existing N1 stale-tap test now pins.

Also in here: a `dt_util.utcnow()`/`dt_util.now()` split in the handler, and a debug log on every drop path — the reporter saw nothing in the logs at all.

## Tests

Both new integration tests were confirmed **red before the fix and green after**, by restoring the old `is_overdue` gate and re-running against the container:

```
test_action_completes_a_task_that_is_not_yet_due FAILED
  AssertionError: an early 'Mark done' tap must complete the task (#216)
test_two_notifications_for_one_task_complete_it_once FAILED
  AssertionError: the first card's tap must complete the task
```

- `test_action_completes_a_task_that_is_not_yet_due` — a due-soon profile, a task snoozed two hours out, an early "Mark done" tap; then the same tap re-fired, asserting no second completion and no `next_due` advance.
- `test_two_notifications_for_one_task_complete_it_once` — two cards, both taps fired back to back with no wait, exactly one completion.
- Unit coverage for `due_token`, `is_current_action`, the legacy decode path, and the token on every button.

Verified locally:

| check | result |
|---|---|
| `pytest tests/unit` | 908 passed, 1 skipped |
| integration suite (Docker) | 131 passed |
| e2e (Playwright) | 46 passed |
| `ci/test-mutation-python.sh` | **100.00%** (100/100), threshold 80% |
| `ruff check` / `ruff format --check` | clean |
| `vale CHANGELOG.md` | clean on added lines |

The mutation run surfaced a pre-existing gap it pulled into scope — nothing asserted the **skip** button's `action` key, so a mistyped key there would have shipped a dead button. Killed with an assertion over all four verbs' action strings.

## Release

Bumps to `0.16.0b2` (`manifest.json` + `PANEL_VERSION`) with a matching CHANGELOG section, since `0.16.0b1` is already published and the fix would otherwise have nowhere to ship. Please add the `preview-release` label so the reporter can install it via HACS before merge.

No `frontend/src/` change, so the screenshot gate doesn't apply and the walkthrough tour needs no edit.

## Note on local verification

`mypy` could not be run in the dev container — it is on Python 3.11 and Home Assistant needs 3.14, so `pip install homeassistant` fails to build. The changed files typecheck standalone under `--strict`, and CI's `lint.yml` mypy job has since passed on this head.