### PR TITLE
Notify and close issues when the release that fixes them ships

### DIFF
--- a/.amazonq/rules/testing-and-workflow.md
+++ b/.amazonq/rules/testing-and-workflow.md
@@ -176,6 +176,17 @@ gate); CI publishes it to the job summary.
   `preview-release.yml` publishes an installable ephemeral pre-release
   (`X.Y.Z.dev<pr>`) from the PR head for pre-merge HACS testing (auto-deleted on
   close; see RELEASE.md). Bug-fix/developer-only PRs don't.
+- **Shipping closes an issue, not merging.** A PR links its issue with `Refs #N`
+  (never `Fixes`/`Closes`/`Resolves`) so it stays open until users can install the
+  fix. `release.yml`'s `notify-issues` job reads the shipped version's CHANGELOG
+  section, comments on every issue it references, and — on a stable only — closes it
+  as completed. A beta comments and leaves the issue open.
+- **The `(Fixes #N)` refs in a CHANGELOG section are that release's issue list.**
+  Leave an issue out and it is never notified and never closes. Only closing keywords
+  are read; `(Related to #N)` and bare `(#N)` are ignored on purpose, since `(#N)` is
+  also the squash-merge PR number. `ci/release-issues.py` owns the parsing (and the
+  release-notes extraction) and is unit-tested in
+  `tests/unit/test_release_issues.py` — change the format there, not in the workflow.
 - The built `dist/home-keeper-panel.js` is gitignored; CI builds it.
 
 ## Typing (strict-typing gate — Platinum)
@@ -214,6 +225,9 @@ gate); CI publishes it to the job summary.
 - **Never comment on a GitHub issue.** Issues are the user↔maintainer channel;
   an agent posting there answers for the maintainer to someone who didn't ask.
   Analysis, findings and status go in the PR carrying the work. A PR that fixes
-  an issue links it (`Fixes #N`) and closes it on merge — that's the only signal
-  the issue needs. PR comments are unaffected (the `/q review` above and replies
-  to review threads are still required).
+  an issue links it (`Refs #N`) and the release shipping it closes it — that's the
+  only signal the issue needs. PR comments are unaffected (the `/q review` above and
+  replies to review threads are still required).
+  - The ban is on *you* posting, not on repo automation working from a fixed
+    template: `release.yml`'s `notify-issues` job and `ha-beta.yml`'s regression
+    reporter both comment on issues by design.

--- a/.amazonq/rules/testing-and-workflow.md
+++ b/.amazonq/rules/testing-and-workflow.md
@@ -176,11 +176,12 @@ gate); CI publishes it to the job summary.
   `preview-release.yml` publishes an installable ephemeral pre-release
   (`X.Y.Z.dev<pr>`) from the PR head for pre-merge HACS testing (auto-deleted on
   close; see RELEASE.md). Bug-fix/developer-only PRs don't.
-- **Shipping closes an issue, not merging.** A PR links its issue with `Refs #N`
-  (never `Fixes`/`Closes`/`Resolves`) so it stays open until users can install the
-  fix. `release.yml`'s `notify-issues` job reads the shipped version's CHANGELOG
-  section, comments on every issue it references, and — on a stable only — closes it
-  as completed. A beta comments and leaves the issue open.
+- **Shipping closes an issue, not merging.** Closing-on-merge is off for this repo, so
+  a PR's `Fixes #N` links the issue (filling its **Development** panel) without closing
+  it, and it stays open until users can install the fix. `release.yml`'s
+  `notify-issues` job reads the shipped version's CHANGELOG section, comments on every
+  issue it references, and — on a stable only — closes it as completed. A beta comments
+  and leaves the issue open.
 - **The `(Fixes #N)` refs in a CHANGELOG section are that release's issue list.**
   Leave an issue out and it is never notified and never closes. Only closing keywords
   are read; `(Related to #N)` and bare `(#N)` are ignored on purpose, since `(#N)` is
@@ -225,7 +226,7 @@ gate); CI publishes it to the job summary.
 - **Never comment on a GitHub issue.** Issues are the user↔maintainer channel;
   an agent posting there answers for the maintainer to someone who didn't ask.
   Analysis, findings and status go in the PR carrying the work. A PR that fixes
-  an issue links it (`Refs #N`) and the release shipping it closes it — that's the
+  an issue links it (`Fixes #N`) and the release shipping it closes it — that's the
   only signal the issue needs. PR comments are unaffected (the `/q review` above and
   replies to review threads are still required).
   - The ban is on *you* posting, not on repo automation working from a fixed

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+<!--
+Link issues with `Refs #N`, not `Fixes #N`.
+
+Merging doesn't put anything in a user's Home Assistant. Issues stay open until the
+fix ships, and `release.yml`'s notify-issues job closes them on the release that
+carries it — so the reporter's "closed" notification names a version they can install.
+For that to happen the issue also needs a `(Fixes #N)` line in the CHANGELOG entry.
+-->
+
+Refs #
+
+## What changed
+
+## Checklist
+
+- [ ] Tests run locally (`pytest tests/unit -v`, `bash ci/test-frontend.sh`)
+- [ ] `CHANGELOG.md` updated — user-facing changes only, with `(Fixes #N)` for each
+      issue this fixes (developer-only changes don't need an entry)
+- [ ] Panel UI changed → current screenshots committed under `docs/images/` and
+      embedded above with an HTML `<img>` tag
+- [ ] New user-facing UI surface → `tests/e2e/walkthrough.capture.ts` extended to
+      step through it
+- [ ] New user-facing feature → version bumped to the next beta (`manifest.json` +
+      `const.py`), `preview-release` label applied

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,16 @@
 <!--
-Link issues with `Refs #N`, not `Fixes #N`.
+Link the issue this fixes with `Fixes #N` below.
 
-Merging doesn't put anything in a user's Home Assistant. Issues stay open until the
-fix ships, and `release.yml`'s notify-issues job closes them on the release that
-carries it — so the reporter's "closed" notification names a version they can install.
-For that to happen the issue also needs a `(Fixes #N)` line in the CHANGELOG entry.
+Closing-on-merge is off for this repo, so the keyword links the PR to the issue
+without closing it. The issue stays open until the fix actually ships, and
+release.yml's notify-issues job closes it on the release that carries it — so the
+reporter's "closed" notification names a version they can install.
+
+For that to happen the issue also needs a `(Fixes #N)` line in the CHANGELOG entry:
+that section is what the release reads to decide who gets told.
 -->
 
-Refs #
+Fixes #
 
 ## What changed
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      notify_dry_run:
+        description: "Rehearse notify-issues: log what it would post, post nothing"
+        type: boolean
+        default: false
+      notify_version:
+        description: "Version for the dry run (default: the current manifest version)"
+        type: string
 
 jobs:
   release:
@@ -65,15 +73,7 @@ jobs:
         env:
           VERSION: ${{ steps.check.outputs.version }}
         run: |
-          awk -v ver="$VERSION" '
-            $0 ~ "^## \\[" ver "\\]" { found=1; print; next }
-            found && /^## \[/ { exit }
-            found { print }
-          ' CHANGELOG.md > release_notes.txt
-          if [ ! -s release_notes.txt ]; then
-            echo "::error::Failed to extract changelog section for $VERSION (awk pattern matched zero lines)."
-            exit 1
-          fi
+          python3 ci/release-issues.py --version "$VERSION" --notes > release_notes.txt
           {
             echo 'notes<<RELEASE_NOTES_EOF'
             cat release_notes.txt
@@ -143,3 +143,212 @@ jobs:
     uses: ./.github/workflows/docs-deploy.yml
     with:
       ref: "v${{ needs.release.outputs.version }}"
+
+  # Tell every issue this release fixes which version carries the fix. Merging a PR
+  # doesn't put anything in a user's Home Assistant, so PRs link issues with `Refs #N`
+  # and leave them open; the issue closes here, when the fix actually ships. A beta
+  # only comments (the fix is testable, not shipped); a stable comments and closes.
+  #
+  # Chained via `needs:` for the same reason as deploy-docs: the Release above is
+  # created by this workflow's GITHUB_TOKEN, so an `on: release` listener would never
+  # start a run.
+  notify-issues:
+    needs: release
+    if: >-
+      github.event_name != 'pull_request' &&
+      (inputs.notify_dry_run || needs.release.outputs.release == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Scoped to this job alone — the build above stays contents-only.
+      issues: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Resolve the version to notify for
+        id: target
+        env:
+          DISPATCH_VERSION: ${{ inputs.notify_version }}
+          RELEASE_VERSION: ${{ needs.release.outputs.version }}
+        run: |
+          VERSION="${DISPATCH_VERSION:-$RELEASE_VERSION}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+          # Re-derived rather than taken from the release job, so a dry run can target
+          # any past version without depending on that job's outputs.
+          if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(a|b|rc)[0-9]+$ ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::version '$VERSION' is malformed — expected X.Y.Z or X.Y.Z{a|b|rc}N."
+            exit 1
+          fi
+
+          # Read the changelog as it was at the tag, so a dry run against an old
+          # release sees that release's notes. The working tree deliberately stays on
+          # the current branch — checking the tag out would also roll
+          # ci/release-issues.py back to a version that predates it.
+          if git rev-parse --verify "refs/tags/v$VERSION" >/dev/null 2>&1; then
+            git show "v$VERSION:CHANGELOG.md" > /tmp/changelog.md
+            echo "ref=v$VERSION" >> "$GITHUB_OUTPUT"
+          else
+            cp CHANGELOG.md /tmp/changelog.md
+            echo "ref=HEAD" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Collect the issues this release fixes
+        id: collect
+        env:
+          VERSION: ${{ steps.target.outputs.version }}
+          REF: ${{ steps.target.outputs.ref }}
+          PRERELEASE: ${{ steps.target.outputs.prerelease }}
+        run: |
+          ISSUES=$(python3 ci/release-issues.py --version "$VERSION" --changelog /tmp/changelog.md --json)
+          echo "issues=$ISSUES" >> "$GITHUB_OUTPUT"
+          echo "Changelog references: $ISSUES"
+
+          # Cross-check: an issue referenced by a shipped commit but absent from the
+          # changelog section will never be notified and never close. That is the one
+          # way the deferred-closing model fails silently, so surface it — as a
+          # warning only. Changelog bookkeeping must not block a release that has
+          # already been tagged and published.
+          #
+          # PREV bounds the range this version's changelog section is answerable for,
+          # and that differs by kind. A stable's notes cover everything since the last
+          # *stable* (betas in between are rolled into it), so only bare vX.Y.Z tags
+          # count. A beta's notes cover only its own increment, so the previous tag of
+          # any kind is the bound — compare a beta against the last stable and every
+          # earlier beta's fixes look like omissions.
+          if [ "$PRERELEASE" = "true" ]; then
+            TAG_FILTER='^v[0-9]+\.[0-9]+\.[0-9]+([ab]|rc)?[0-9]*$'
+          else
+            TAG_FILTER='^v[0-9]+\.[0-9]+\.[0-9]+$'
+          fi
+
+          PREV=""
+          for TAG in $(git tag --list --sort=-v:refname | grep -E "$TAG_FILTER"); do
+            if [ "$TAG" != "v$VERSION" ] && git merge-base --is-ancestor "$TAG" "$REF" 2>/dev/null; then
+              PREV="$TAG"
+              break
+            fi
+          done
+
+          if [ -z "$PREV" ]; then
+            echo "No previous stable tag found — skipping the changelog cross-check."
+            echo "missing=[]" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Cross-checking commits in $PREV..$REF"
+          git log --format=%B "$PREV..$REF" > /tmp/commits.txt
+          MISSING=$(python3 ci/release-issues.py \
+            --version "$VERSION" --changelog /tmp/changelog.md --missing < /tmp/commits.txt)
+          echo "missing=$MISSING" >> "$GITHUB_OUTPUT"
+          echo "Referenced by a commit but absent from the changelog: $MISSING"
+
+      - name: Comment and close
+        uses: actions/github-script@v9
+        env:
+          ISSUES: ${{ steps.collect.outputs.issues }}
+          MISSING: ${{ steps.collect.outputs.missing }}
+          VERSION: ${{ steps.target.outputs.version }}
+          PRERELEASE: ${{ steps.target.outputs.prerelease }}
+          DRY_RUN: ${{ inputs.notify_dry_run }}
+        with:
+          script: |
+            const version = process.env.VERSION;
+            const isBeta = process.env.PRERELEASE === 'true';
+            const dryRun = process.env.DRY_RUN === 'true';
+            const entries = JSON.parse(process.env.ISSUES || '[]');
+            const missing = JSON.parse(process.env.MISSING || '[]');
+
+            // Re-running the workflow must not post a second time.
+            const marker = `<!-- home-keeper-release v${version} -->`;
+            const releaseUrl =
+              `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/releases/tag/v${version}`;
+
+            const body = (summary) => {
+              const quote = summary ? `\n> ${summary}\n` : '';
+              return isBeta
+                ? `${marker}\n**Fixed in Home Keeper v${version}**, out now as a beta.\n${quote}\n` +
+                  `To try it before it ships to everyone, turn on **Show beta versions** for ` +
+                  `Home Keeper in HACS and update. This issue stays open until the fix reaches ` +
+                  `a stable release.\n\n[Release notes](${releaseUrl})`
+                : `${marker}\n**Shipped in Home Keeper v${version}.** Update through HACS to get it.\n${quote}\n` +
+                  `Closing this out. If you still run into it after updating, reopen the issue ` +
+                  `or leave a comment and it'll be picked back up.\n\n[Release notes](${releaseUrl})`;
+            };
+
+            const rows = [];
+            for (const entry of entries) {
+              const number = entry.number;
+              // One bad number must never fail a release that is already published.
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  ...context.repo, issue_number: number,
+                });
+
+                if (issue.pull_request) {
+                  rows.push([`#${number}`, 'skipped', 'is a pull request, not an issue']);
+                  continue;
+                }
+
+                const comments = await github.paginate(github.rest.issues.listComments, {
+                  ...context.repo, issue_number: number, per_page: 100,
+                });
+                if (comments.some((comment) => comment.body && comment.body.includes(marker))) {
+                  rows.push([`#${number}`, 'skipped', `already notified about v${version}`]);
+                  continue;
+                }
+
+                if (dryRun) {
+                  rows.push([`#${number}`, 'dry run', isBeta ? 'would comment' : 'would comment and close']);
+                  continue;
+                }
+
+                await github.rest.issues.createComment({
+                  ...context.repo, issue_number: number, body: body(entry.summary),
+                });
+
+                if (isBeta) {
+                  rows.push([`#${number}`, 'commented', 'left open until a stable release']);
+                } else {
+                  await github.rest.issues.update({
+                    ...context.repo, issue_number: number,
+                    state: 'closed', state_reason: 'completed',
+                  });
+                  rows.push([`#${number}`, 'closed', 'commented and closed as completed']);
+                }
+              } catch (error) {
+                core.warning(`Could not notify #${number}: ${error.message}`);
+                rows.push([`#${number}`, 'failed', error.message]);
+              }
+            }
+
+            for (const number of missing) {
+              core.warning(
+                `#${number} is referenced by a commit in this release but has no ` +
+                `"Fixes #${number}" in the v${version} changelog section — it will not be ` +
+                `notified or closed. Add it to CHANGELOG.md if this release fixes it.`
+              );
+              rows.push([`#${number}`, 'not listed', 'referenced by a commit, missing from the changelog']);
+            }
+
+            const summary = core.summary
+              .addHeading(`Issue notifications for v${version}${dryRun ? ' (dry run)' : ''}`, 3)
+              .addRaw(isBeta
+                ? 'Beta release: issues are notified and left open.'
+                : 'Stable release: issues are notified and closed.')
+              .addBreak();
+            if (rows.length) {
+              summary.addTable([
+                [{ data: 'Issue', header: true }, { data: 'Result', header: true }, { data: 'Detail', header: true }],
+                ...rows,
+              ]);
+            } else {
+              summary.addRaw('No issue references found in this version\'s changelog section.');
+            }
+            await summary.write();

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,9 +145,10 @@ jobs:
       ref: "v${{ needs.release.outputs.version }}"
 
   # Tell every issue this release fixes which version carries the fix. Merging a PR
-  # doesn't put anything in a user's Home Assistant, so PRs link issues with `Refs #N`
-  # and leave them open; the issue closes here, when the fix actually ships. A beta
-  # only comments (the fix is testable, not shipped); a stable comments and closes.
+  # doesn't put anything in a user's Home Assistant, and closing-on-merge is off for
+  # this repo, so issues survive past merge on their own; the issue closes here, when
+  # the fix actually ships. A beta only comments (the fix is testable, not shipped);
+  # a stable comments and closes.
   #
   # Chained via `needs:` for the same reason as deploy-docs: the Release above is
   # created by this workflow's GITHUB_TOKEN, so an `on: release` listener would never

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,18 +174,28 @@ jobs:
           RELEASE_VERSION: ${{ needs.release.outputs.version }}
         run: |
           VERSION="${DISPATCH_VERSION:-$RELEASE_VERSION}"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-          # Re-derived rather than taken from the release job, so a dry run can target
-          # any past version without depending on that job's outputs.
+          # Validate before this value reaches $GITHUB_OUTPUT or a git argument.
+          # notify_version is operator input, and writing an unvalidated value to
+          # $GITHUB_OUTPUT first would let a newline in it forge a second output line
+          # (`prerelease=false` on a beta, say) and talk the job into closing issues a
+          # beta only meant to comment on. Nothing here is interpolated into a shell
+          # word — VERSION arrives as an env var and every use below is quoted — so
+          # this is about output forgery, not command injection.
+          #
+          # prerelease is re-derived rather than taken from the release job so a dry
+          # run can target any past version without depending on that job's outputs.
           if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(a|b|rc)[0-9]+$ ]]; then
-            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            PRERELEASE=true
           elif [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+            PRERELEASE=false
           else
             echo "::error::version '$VERSION' is malformed — expected X.Y.Z or X.Y.Z{a|b|rc}N."
             exit 1
           fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
 
           # Read the changelog as it was at the tag, so a dry run against an old
           # release sees that release's notes. The working tree deliberately stays on
@@ -204,7 +214,6 @@ jobs:
         env:
           VERSION: ${{ steps.target.outputs.version }}
           REF: ${{ steps.target.outputs.ref }}
-          PRERELEASE: ${{ steps.target.outputs.prerelease }}
         run: |
           ISSUES=$(python3 ci/release-issues.py --version "$VERSION" --changelog /tmp/changelog.md --json)
           echo "issues=$ISSUES" >> "$GITHUB_OUTPUT"
@@ -216,21 +225,15 @@ jobs:
           # warning only. Changelog bookkeeping must not block a release that has
           # already been tagged and published.
           #
-          # PREV bounds the range this version's changelog section is answerable for,
-          # and that differs by kind. A stable's notes cover everything since the last
-          # *stable* (betas in between are rolled into it), so only bare vX.Y.Z tags
-          # count. A beta's notes cover only its own increment, so the previous tag of
-          # any kind is the bound — compare a beta against the last stable and every
-          # earlier beta's fixes look like omissions.
-          if [ "$PRERELEASE" = "true" ]; then
-            TAG_FILTER='^v[0-9]+\.[0-9]+\.[0-9]+([ab]|rc)?[0-9]*$'
-          else
-            TAG_FILTER='^v[0-9]+\.[0-9]+\.[0-9]+$'
-          fi
-
+          # PREV bounds the range this version's changelog section is answerable for.
+          # --previous-tags ranks the candidates (and filters by release kind); git is
+          # only asked what it can actually answer, which of them this release descends
+          # from. Ranking in git would be wrong: `--sort=-v:refname` puts a bare
+          # v0.16.0 *below* its own v0.16.0rc1.
           PREV=""
-          for TAG in $(git tag --list --sort=-v:refname | grep -E "$TAG_FILTER"); do
-            if [ "$TAG" != "v$VERSION" ] && git merge-base --is-ancestor "$TAG" "$REF" 2>/dev/null; then
+          for TAG in $(git tag --list \
+                        | python3 ci/release-issues.py --version "$VERSION" --previous-tags); do
+            if git merge-base --is-ancestor "$TAG" "$REF" 2>/dev/null; then
               PREV="$TAG"
               break
             fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@
   mid-stream); don't carry beta-to-beta framing — e.g. a `### Changed` for something
   that didn't exist in the last stable — into the stable section. **Include a `###
   Fixed` section listing every GitHub issue fixed by commits since the last stable**
-  — check the git log for `Refs #N` / `(Fixes #N)` references and write each one into
-  the section as `(Fixes #N)`.
+  — check the git log for `(Fixes #N)` references and write each one into the section
+  as `(Fixes #N)`.
 - **A `(Fixes #N)` in a version's CHANGELOG section is what notifies and closes the
   issue.** `release.yml`'s `notify-issues` job reads the shipped version's section,
   comments on every issue it references, and closes it once the version is stable. An
@@ -26,12 +26,12 @@
   because `(#N)` is also the squash-merge PR number and the two can't be told apart.
   The job posts a CI warning naming any issue a shipped commit referenced that the
   section forgot.
-- **Link issues from a PR with `Refs #N`, never `Fixes`/`Closes`/`Resolves`.** Merging
-  ships nothing — the fix reaches users at a release, sometimes days and a beta later.
-  Keep the issue open until then and let `notify-issues` close it on the release that
-  actually carries the fix, so the reporter's "closed" notification names a version
-  they can install. (`Fixes #N` in a *CHANGELOG* entry is the opposite: that's the
-  bullet above, and it's required.)
+- **Keep linking issues from a PR with `Fixes #N`.** Closing-on-merge is turned off
+  for this repository, so the keyword links the PR to the issue — that's what fills in
+  the issue's **Development** panel and its linked-pull-request relationship — without
+  closing anything. The issue stays open until the fix actually reaches users, and
+  `notify-issues` closes it on the release that carries it, so the reporter's "closed"
+  notification names a version they can install.
 - **Beta versioning — always use the next release number.** After every stable
   `X.Y.0` ships, immediately bump `manifest.json` and `const.py` (`PANEL_VERSION`)
   to `X.(Y+1).0b1` on `main`, and rename the `## [Unreleased]` CHANGELOG section to
@@ -182,7 +182,7 @@
   maintainer, and an agent posting there answers on the maintainer's behalf to
   someone who didn't ask for it. Findings, analysis and status belong in the PR
   that carries the work, or in the reply to whoever asked. A PR that fixes an
-  issue links it (`Refs #N`) and the release that ships it closes it, which is the
+  issue links it (`Fixes #N`) and the release that ships it closes it, which is the
   only signal an issue needs. This does **not** restrict PR comments: the `/q review`
   request above and replies to review threads are still required.
   - The ban is on **you** posting. It does not cover repo automation, which posts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,24 @@
   introduced over the betas is **Added** (even if a later beta changed how it worked
   mid-stream); don't carry beta-to-beta framing — e.g. a `### Changed` for something
   that didn't exist in the last stable — into the stable section. **Include a `###
-  Fixed` section listing every GitHub issue closed by commits since the last stable**
-  — check the git log for `(Fixes #N)` / `(#N)` references and link each issue number
-  so they auto-close on merge (`Fixes #N` in the CHANGELOG entry).
+  Fixed` section listing every GitHub issue fixed by commits since the last stable**
+  — check the git log for `Refs #N` / `(Fixes #N)` references and write each one into
+  the section as `(Fixes #N)`.
+- **A `(Fixes #N)` in a version's CHANGELOG section is what notifies and closes the
+  issue.** `release.yml`'s `notify-issues` job reads the shipped version's section,
+  comments on every issue it references, and closes it once the version is stable. An
+  issue left out of the section is never told and never closes, so the section is the
+  release's issue list, not decoration. Only closing keywords count — write
+  `(Fixes #N)`; `(Related to #161)` and a bare `(#N)` are deliberately ignored,
+  because `(#N)` is also the squash-merge PR number and the two can't be told apart.
+  The job posts a CI warning naming any issue a shipped commit referenced that the
+  section forgot.
+- **Link issues from a PR with `Refs #N`, never `Fixes`/`Closes`/`Resolves`.** Merging
+  ships nothing — the fix reaches users at a release, sometimes days and a beta later.
+  Keep the issue open until then and let `notify-issues` close it on the release that
+  actually carries the fix, so the reporter's "closed" notification names a version
+  they can install. (`Fixes #N` in a *CHANGELOG* entry is the opposite: that's the
+  bullet above, and it's required.)
 - **Beta versioning — always use the next release number.** After every stable
   `X.Y.0` ships, immediately bump `manifest.json` and `const.py` (`PANEL_VERSION`)
   to `X.(Y+1).0b1` on `main`, and rename the `## [Unreleased]` CHANGELOG section to
@@ -167,9 +182,15 @@
   maintainer, and an agent posting there answers on the maintainer's behalf to
   someone who didn't ask for it. Findings, analysis and status belong in the PR
   that carries the work, or in the reply to whoever asked. A PR that fixes an
-  issue links it (`Fixes #N`) and closes it on merge, which is the only signal an
-  issue needs. This does **not** restrict PR comments: the `/q review` request
-  above and replies to review threads are still required.
+  issue links it (`Refs #N`) and the release that ships it closes it, which is the
+  only signal an issue needs. This does **not** restrict PR comments: the `/q review`
+  request above and replies to review threads are still required.
+  - The ban is on **you** posting. It does not cover repo automation, which posts
+    from a fixed template as the mechanical consequence of an event nobody has to
+    interpret: `release.yml`'s `notify-issues` job (a release shipped the fix) and
+    `ha-beta.yml`'s regression reporter (the nightly went red). Adding a comment to
+    an issue by hand, or by asking an agent to, is still off-limits — if something
+    needs saying there, the maintainer says it.
 
 ## Conventions live in `.amazonq/rules/` — keep them current
 
@@ -354,7 +375,10 @@ siblings instead of their fakes.
   the upgrade suite against `HA_TAG=beta`, plus mypy against a pre-release HA, and
   files/updates a single `ha-beta-regression` issue on failure.
 - `pytest_coverage.yml` + `post_coverage_to_pr.yml` — coverage comment on PRs.
-- `release.yml` — PR-merge-driven release (see RELEASE.md).
+- `release.yml` — PR-merge-driven release (see RELEASE.md). Its `notify-issues` job
+  tells every issue the version fixes which release carries the fix, and closes them
+  on a stable. Rehearse it against a past release with a `workflow_dispatch` run and
+  `notify_dry_run: true`.
 
 ### Home Assistant versions
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -35,8 +35,11 @@ the GitHub release automatically. No manual `git tag` step.
 
 An issue closes when its fix **ships**, not when its PR merges. A merged PR is not in
 anyone's Home Assistant yet — it may sit on `main` for days and go out in a beta before
-it reaches everyone — so a PR links its issue with `Refs #N` (never `Fixes #N`) and
-leaves it open.
+it reaches everyone.
+
+Closing-on-merge is turned off for this repository, so a PR's `Fixes #N` links the
+issue (filling in its **Development** panel) without closing it, and the issue stays
+open on its own. Keep writing `Fixes #N` — the link is worth having.
 
 The `notify-issues` job in `release.yml` closes the loop. It reads the shipped
 version's `## [X.Y.Z]` CHANGELOG section, pulls out every `(Fixes #N)` reference, and

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -25,9 +25,61 @@ the GitHub release automatically. No manual `git tag` step.
    5. Build `home_keeper.zip` (the HACS asset).
    6. Push tag `vX.Y.Z` and create the GitHub Release with the changelog section as
       the body and `home_keeper.zip` attached.
+   7. Comment on every issue the changelog section says this version fixes, and — on
+      a stable release — close it. See "Issue notifications" below.
 
 3. **HACS picks it up** via `hacs.json` (`zip_release: true`, `filename:
    home_keeper.zip`).
+
+## Issue notifications
+
+An issue closes when its fix **ships**, not when its PR merges. A merged PR is not in
+anyone's Home Assistant yet — it may sit on `main` for days and go out in a beta before
+it reaches everyone — so a PR links its issue with `Refs #N` (never `Fixes #N`) and
+leaves it open.
+
+The `notify-issues` job in `release.yml` closes the loop. It reads the shipped
+version's `## [X.Y.Z]` CHANGELOG section, pulls out every `(Fixes #N)` reference, and
+for each one:
+
+- **On a beta** — comments that the fix is available for testing, with the "Show beta
+  versions" instructions, and leaves the issue **open**.
+- **On a stable** — comments that it shipped, quotes the changelog bullet, and closes
+  the issue as `completed`.
+
+Notes on how it behaves:
+
+- **`(Fixes #N)` in the changelog is the only thing that notifies an issue.** Forget it
+  and the issue is never told and never closes. The job posts a CI warning naming any
+  issue that a commit in the release referenced but the section left out — check the
+  job summary after a release. A **developer-only** issue (a CI or tooling fix, which
+  correctly gets no changelog entry) shows up here too; that one is expected, and
+  closing it is a manual call.
+- **The cross-check range depends on the kind of release.** A stable is compared
+  against the previous stable, because its section rolls up every beta in between. A
+  beta is compared against the previous tag of any kind, because its section covers
+  only its own increment.
+- **Bare `(#N)` is ignored**, because it's also the PR number squash-merge appends to
+  commit subjects, and the two can't be distinguished. So is `(Related to #N)`.
+- **Re-running is safe.** Each comment carries a `<!-- home-keeper-release vX.Y.Z -->`
+  marker and the job skips any issue that already has one.
+- **It can't fail a release.** The release is already tagged and published by the time
+  it runs; a bad issue number becomes a warning and a row in the job summary.
+
+### Rehearsing it
+
+Run the workflow manually (Actions → Release → Run workflow) with **notify_dry_run**
+checked and **notify_version** set to a past release such as `0.15.0`. The job resolves
+the same issue list and writes the full plan to the run summary without posting or
+closing anything.
+
+The parsing itself lives in `ci/release-issues.py`, which also cuts the release notes.
+Run it locally against any version:
+
+```bash
+python3 ci/release-issues.py --version 0.15.0 --json    # issues it would notify
+python3 ci/release-issues.py --version 0.15.0 --notes   # the release body
+```
 
 ## Beta / pre-release releases
 

--- a/ci/release-issues.py
+++ b/ci/release-issues.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Extract a CHANGELOG section and the GitHub issues it says it fixes.
+
+``release.yml`` uses this twice. Once to pull the ``## [X.Y.Z]`` section out of
+``CHANGELOG.md`` for the GitHub Release body, and once to work out which issues that
+release ships a fix for, so ``notify-issues`` can tell each reporter which version
+carries it (and close the issue when that version is stable).
+
+That second use is why the parsing is strict. An issue only closes because its number
+appeared here, so a false positive closes something that isn't fixed:
+
+* Only ``Fixes|Closes|Resolves #N`` counts. The CHANGELOG also carries softer refs
+  like ``(Related to #161)``, which must *not* close anything.
+* A bare ``(#N)`` never counts. This repo overloads it — ``(#189)`` in a commit
+  subject is the PR number appended by squash-merge, while ``(#183)`` in the same
+  subject is the issue. There is no way to tell them apart, so neither is read.
+
+Usage:
+    python3 ci/release-issues.py --version 0.16.0 --notes   # the section, verbatim
+    python3 ci/release-issues.py --version 0.16.0 --json    # [{"number":…,"summary":…}]
+    git log --format=%B a..b | python3 ci/release-issues.py --scan  # refs, one per line
+
+``--notes`` and ``--json`` exit 1 when the version has no section — a release must
+not ship with empty notes, and ``release.yml`` already treated that as fatal.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+_DEFAULT_CHANGELOG = Path(__file__).resolve().parents[1] / "CHANGELOG.md"
+
+# Closing keywords only. ``Related to #N`` and bare ``(#N)`` are deliberately absent —
+# see the module docstring.
+_CLOSING_WORDS = r"fix(?:es|ed)?|close[sd]?|resolve[sd]?"
+_CLOSES = re.compile(rf"\b(?:{_CLOSING_WORDS})\s+#(\d+)\b", re.IGNORECASE)
+
+# ``--scan`` reads commit messages, where the new convention is ``Refs #N`` (the PR
+# links the issue without closing it). Anything that mentions an issue at all is worth
+# cross-checking against the changelog, so this is the looser pattern.
+_MENTIONS = re.compile(rf"\b(?:{_CLOSING_WORDS}|refs?)\s+#(\d+)\b", re.IGNORECASE)
+
+_BULLET = re.compile(r"^[-*] ")
+_HEADING = re.compile(r"^#")
+_BOLD_LEAD = re.compile(r"^\*\*(.+?)\*\*")
+
+
+def section(changelog: str, version: str) -> str:
+    """Return the ``## [version]`` section of *changelog*, heading line included.
+
+    Everything from the heading up to (not including) the next ``## [`` heading, which
+    is what the release body has always contained. Returns "" when there is no such
+    section.
+    """
+    heading = f"## [{version}]"
+    out: list[str] = []
+    found = False
+    for line in changelog.splitlines():
+        if not found:
+            if line.startswith(heading):
+                found = True
+                out.append(line)
+            continue
+        if line.startswith("## ["):
+            break
+        out.append(line)
+    if not found:
+        return ""
+    return "\n".join(out) + "\n"
+
+
+def bullets(text: str) -> list[str]:
+    """Split *text* into its top-level Markdown bullets, each flattened to one line.
+
+    A bullet runs from a ``- `` at column zero until the next bullet, heading or blank
+    line. The changelog wraps prose across several indented continuation lines, and a
+    ``Fixes #N`` often lands on a different line from the sentence that describes it,
+    so the whole bullet has to be reassembled before either can be read.
+    """
+    out: list[str] = []
+    current: list[str] = []
+
+    def flush() -> None:
+        if current:
+            out.append(re.sub(r"\s+", " ", " ".join(current)).strip())
+            current.clear()
+
+    for line in text.splitlines():
+        if _BULLET.match(line):
+            flush()
+            current.append(_BULLET.sub("", line))
+        elif not line.strip() or _HEADING.match(line):
+            flush()
+        elif current:
+            current.append(line.strip())
+    flush()
+    return out
+
+
+def summarize(bullet: str) -> str:
+    """The bullet's lead sentence, for quoting back at the issue reporter.
+
+    Changelog bullets open with a bolded one-line summary — exactly the sentence a
+    reporter wants to see. Fall back to the first sentence when a bullet doesn't
+    follow the convention.
+    """
+    bold = _BOLD_LEAD.match(bullet)
+    if bold:
+        return bold.group(1).strip()
+    first = re.split(r"(?<=\.)\s", bullet, maxsplit=1)[0].strip()
+    return first if len(first) <= 200 else first[:197].rstrip() + "…"
+
+
+def issues(text: str) -> list[dict[str, object]]:
+    """Issues *text* claims to fix, in first-mention order, deduped.
+
+    A number can legitimately appear in more than one bullet (a fix split across two
+    entries), and the stable section repeats the refs from its betas, so dedupe is not
+    optional.
+    """
+    seen: dict[int, dict[str, object]] = {}
+    for bullet in bullets(text):
+        summary = summarize(bullet)
+        for match in _CLOSES.finditer(bullet):
+            number = int(match.group(1))
+            seen.setdefault(number, {"number": number, "summary": summary})
+    return list(seen.values())
+
+
+def scan(text: str) -> list[int]:
+    """Every issue number *text* mentions, deduped, in first-mention order."""
+    seen: list[int] = []
+    for match in _MENTIONS.finditer(text):
+        number = int(match.group(1))
+        if number not in seen:
+            seen.append(number)
+    return seen
+
+
+def missing(commits: str, section_body: str) -> list[int]:
+    """Issues the shipped commits reference but the release notes never mention.
+
+    The one silent failure of shipping-closes-the-issue: forget the ``Fixes #N`` line
+    in the changelog and the issue is never notified and never closed — it just sits
+    open forever with no signal that anything went wrong. ``release.yml`` turns this
+    into a warning (never a failure: the release is already tagged and published by
+    the time it runs, and changelog bookkeeping must not look like a broken release).
+    """
+    listed = {entry["number"] for entry in issues(section_body)}
+    return [number for number in scan(commits) if number not in listed]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", help="release version, e.g. 0.16.0 or 0.16.0b1")
+    parser.add_argument("--changelog", type=Path, default=_DEFAULT_CHANGELOG)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--notes", action="store_true", help="print the section verbatim")
+    mode.add_argument("--json", action="store_true", help="print the issues as JSON")
+    mode.add_argument(
+        "--scan", action="store_true", help="print issue refs read from stdin"
+    )
+    mode.add_argument(
+        "--missing",
+        action="store_true",
+        help="print, as JSON, the issues stdin references that the section omits",
+    )
+    args = parser.parse_args(argv)
+
+    if args.scan:
+        for number in scan(sys.stdin.read()):
+            print(number)
+        return 0
+
+    if not args.version:
+        parser.error("--version is required for --notes, --json and --missing")
+
+    body = section(args.changelog.read_text(encoding="utf-8"), args.version)
+    if not body.strip():
+        print(
+            f"::error::CHANGELOG.md has no '## [{args.version}]' section "
+            "(or it is empty).",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.notes:
+        sys.stdout.write(body)
+    elif args.missing:
+        json.dump(missing(sys.stdin.read(), body), sys.stdout)
+        sys.stdout.write("\n")
+    else:
+        json.dump(issues(body), sys.stdout)
+        sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/release-issues.py
+++ b/ci/release-issues.py
@@ -44,9 +44,18 @@ _CLOSES = re.compile(rf"\b(?:{_CLOSING_WORDS})\s+#(\d+)\b", re.IGNORECASE)
 # cross-checking against the changelog, so this is the looser pattern.
 _MENTIONS = re.compile(rf"\b(?:{_CLOSING_WORDS}|refs?)\s+#(\d+)\b", re.IGNORECASE)
 
-_BULLET = re.compile(r"^[-*] ")
+# A bullet at any indent. A nested bullet is its own entry, not part of its parent's
+# text, so a ``Fixes #N`` inside one is summarised by the sentence that actually
+# describes it. An indented line that is *not* a bullet is still a continuation.
+_BULLET = re.compile(r"^\s*[-*] ")
 _HEADING = re.compile(r"^#")
+_FENCE = re.compile(r"^\s*```")
 _BOLD_LEAD = re.compile(r"^\*\*(.+?)\*\*")
+
+# vX.Y.Z with an optional PEP 440 pre-release suffix — the only shapes release.yml
+# accepts, and so the only tags this project produces.
+_TAG = re.compile(r"^v(\d+)\.(\d+)\.(\d+)(?:(a|b|rc)(\d+))?$")
+_STAGES = {"a": 0, "b": 1, "rc": 2}
 
 
 def section(changelog: str, version: str) -> str:
@@ -76,13 +85,18 @@ def section(changelog: str, version: str) -> str:
 def bullets(text: str) -> list[str]:
     """Split *text* into its top-level Markdown bullets, each flattened to one line.
 
-    A bullet runs from a ``- `` at column zero until the next bullet, heading or blank
+    A bullet runs from a ``- `` (at any indent) until the next bullet, heading or blank
     line. The changelog wraps prose across several indented continuation lines, and a
     ``Fixes #N`` often lands on a different line from the sentence that describes it,
     so the whole bullet has to be reassembled before either can be read.
+
+    Fenced code blocks are dropped first. A ``Fixes #N`` inside one is a code sample,
+    not a claim that this release fixed anything, and acting on it would close a
+    stranger's issue.
     """
     out: list[str] = []
     current: list[str] = []
+    fenced = False
 
     def flush() -> None:
         if current:
@@ -90,6 +104,14 @@ def bullets(text: str) -> list[str]:
             current.clear()
 
     for line in text.splitlines():
+        if _FENCE.match(line):
+            # Skip the fence itself but keep the bullet open: prose after a code
+            # sample belongs to the bullet that introduced it, and closing here would
+            # silently drop a `Fixes #N` that follows the sample.
+            fenced = not fenced
+            continue
+        if fenced:
+            continue
         if _BULLET.match(line):
             flush()
             current.append(_BULLET.sub("", line))
@@ -154,6 +176,55 @@ def missing(commits: str, section_body: str) -> list[int]:
     return [number for number in scan(commits) if number not in listed]
 
 
+def version_key(tag: str) -> tuple[int, int, int, int, int] | None:
+    """Sort key for a ``vX.Y.Z[{a|b|rc}N]`` tag, or None if it isn't one.
+
+    ``git tag --sort=-v:refname`` cannot do this. Git orders a bare ``v0.16.0``
+    *below* every one of its own pre-releases, so asking git for the tag before
+    ``v0.17.0b1`` hands back ``v0.16.0rc1`` when ``v0.16.0`` shipped after it. PEP 440
+    is the opposite — a final release outranks its pre-releases — which is the order
+    this project's tags actually mean.
+    """
+    match = _TAG.match(tag)
+    if not match:
+        return None
+    major, minor, patch, stage, serial = match.groups()
+    # Stage 3 = a final release, which outranks rc > b > a at the same X.Y.Z.
+    return (
+        int(major),
+        int(minor),
+        int(patch),
+        _STAGES.get(stage, 3) if stage else 3,
+        int(serial) if serial else 0,
+    )
+
+
+def previous_tags(tags: list[str], version: str) -> list[str]:
+    """Candidate predecessors of *version*, newest first.
+
+    The kind of release decides what may be a predecessor, mirroring how the changelog
+    is written (AGENTS.md): a **stable**'s section covers everything since the last
+    *stable* — the betas in between are rolled into it — so only bare ``vX.Y.Z`` tags
+    qualify. A **beta**'s section covers only its own increment, so the previous tag of
+    any kind qualifies; measuring a beta from the last stable makes every earlier
+    beta's fixes look like omissions.
+    """
+    current = version_key(f"v{version}")
+    if current is None:
+        return []
+    stable_only = current[3] == 3
+
+    keyed = []
+    for tag in tags:
+        key = version_key(tag)
+        if key is None or key >= current:
+            continue
+        if stable_only and key[3] != 3:
+            continue
+        keyed.append((key, tag))
+    return [tag for _, tag in sorted(keyed, reverse=True)]
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--version", help="release version, e.g. 0.16.0 or 0.16.0b1")
@@ -169,6 +240,11 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="print, as JSON, the issues stdin references that the section omits",
     )
+    mode.add_argument(
+        "--previous-tags",
+        action="store_true",
+        help="rank the tags on stdin as predecessors of --version, newest first",
+    )
     args = parser.parse_args(argv)
 
     if args.scan:
@@ -177,7 +253,12 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     if not args.version:
-        parser.error("--version is required for --notes, --json and --missing")
+        parser.error("--version is required for every mode except --scan")
+
+    if args.previous_tags:
+        for tag in previous_tags(sys.stdin.read().split(), args.version):
+            print(tag)
+        return 0
 
     body = section(args.changelog.read_text(encoding="utf-8"), args.version)
     if not body.strip():

--- a/ci/release-issues.py
+++ b/ci/release-issues.py
@@ -44,12 +44,23 @@ _CLOSES = re.compile(rf"\b(?:{_CLOSING_WORDS})\s+#(\d+)\b", re.IGNORECASE)
 # cross-checking against the changelog, so this is the looser pattern.
 _MENTIONS = re.compile(rf"\b(?:{_CLOSING_WORDS}|refs?)\s+#(\d+)\b", re.IGNORECASE)
 
-# A bullet at any indent. A nested bullet is its own entry, not part of its parent's
-# text, so a ``Fixes #N`` inside one is summarised by the sentence that actually
-# describes it. An indented line that is *not* a bullet is still a continuation.
-_BULLET = re.compile(r"^\s*[-*] ")
+# A bullet at any indent, ordered or unordered. A nested bullet is its own entry, not
+# part of its parent's text, so a ``Fixes #N`` inside one is summarised by the sentence
+# that actually describes it. An indented line that is *not* a bullet is still a
+# continuation. Ordered items count too: dropping them would silently swallow a
+# ``Fixes #N`` written as ``1. …`` and leave that issue open forever.
+_BULLET = re.compile(r"^\s*(?:[-*]|\d+\.)\s")
 _HEADING = re.compile(r"^#")
-_FENCE = re.compile(r"^\s*```")
+
+# A thematic break (``---``, ``* * *``, ``- - -``). ``* * *`` and ``- - -`` otherwise
+# read as a bullet whose text is ``* *``, which then swallows the prose beneath it and
+# quotes that nonsense back at the reporter.
+_HRULE = re.compile(r"^\s*(?:[-*_]\s*){3,}$")
+
+# Both CommonMark fence styles. A ``~~~`` block used to sail straight through, so a
+# ``Fixes #N`` in a code sample would close a stranger's issue.
+_FENCE = re.compile(r"^\s*(?:`{3,}|~{3,})")
+
 _BOLD_LEAD = re.compile(r"^\*\*(.+?)\*\*")
 
 # vX.Y.Z with an optional PEP 440 pre-release suffix — the only shapes release.yml
@@ -85,14 +96,17 @@ def section(changelog: str, version: str) -> str:
 def bullets(text: str) -> list[str]:
     """Split *text* into its top-level Markdown bullets, each flattened to one line.
 
-    A bullet runs from a ``- `` (at any indent) until the next bullet, heading or blank
-    line. The changelog wraps prose across several indented continuation lines, and a
-    ``Fixes #N`` often lands on a different line from the sentence that describes it,
-    so the whole bullet has to be reassembled before either can be read.
+    A bullet runs from a ``- ``, ``* `` or ``1. `` (at any indent) until the next
+    bullet, heading, thematic break or blank line. The changelog wraps prose across
+    several indented continuation lines, and a ``Fixes #N`` often lands on a different
+    line from the sentence that describes it, so the whole bullet has to be reassembled
+    before either can be read.
 
-    Fenced code blocks are dropped first. A ``Fixes #N`` inside one is a code sample,
-    not a claim that this release fixed anything, and acting on it would close a
-    stranger's issue.
+    Fenced code blocks are dropped, in both ``` and ``~~~`` styles. A ``Fixes #N``
+    inside one is a code sample, not a claim that this release fixed anything, and
+    acting on it would close a stranger's issue. An unclosed fence therefore swallows
+    the rest of the section — the same thing a Markdown renderer does, and the safe
+    direction to err in when the alternative is closing an issue by accident.
     """
     out: list[str] = []
     current: list[str] = []
@@ -112,7 +126,9 @@ def bullets(text: str) -> list[str]:
             continue
         if fenced:
             continue
-        if _BULLET.match(line):
+        if _HRULE.match(line):
+            flush()
+        elif _BULLET.match(line):
             flush()
             current.append(_BULLET.sub("", line))
         elif not line.strip() or _HEADING.match(line):

--- a/tests/unit/test_release_issues.py
+++ b/tests/unit/test_release_issues.py
@@ -1,0 +1,302 @@
+"""Unit tests for ``ci/release-issues.py``.
+
+The script decides which issues a release closes. A false positive closes an issue
+that was never fixed, on someone else's thread, irreversibly enough to be rude — so
+the exclusions matter as much as the matches, and both are pinned here.
+
+The parity test is the other half: ``release.yml`` used an inline ``awk`` to cut the
+release-notes section for every release this project has shipped, and the script has
+to reproduce it byte for byte or the switch silently changes release bodies.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _ROOT / "ci" / "release-issues.py"
+_CHANGELOG = _ROOT / "CHANGELOG.md"
+
+# The awk program release.yml carried before this script replaced it.
+_AWK = r"""
+$0 ~ "^## \\[" ver "\\]" { found=1; print; next }
+found && /^## \[/ { exit }
+found { print }
+"""
+
+
+def _load():
+    # The filename has a hyphen, so it is not importable as a module name.
+    spec = importlib.util.spec_from_file_location("release_issues", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_mod = _load()
+section = _mod.section
+issues = _mod.issues
+bullets = _mod.bullets
+summarize = _mod.summarize
+scan = _mod.scan
+
+
+def _numbers(text: str) -> list[int]:
+    return [entry["number"] for entry in issues(text)]
+
+
+CHANGELOG = textwrap.dedent(
+    """\
+    # Changelog
+
+    Preamble prose that mentions Fixes #999 and must never be read.
+
+    ## [0.16.0b1] - 2026-08-21
+
+    ### Fixed
+
+    - **A wrapped bullet.** The description runs across several lines, and the
+      issue reference lands on a line of its own rather than the one carrying
+      the summary. (Fixes #214)
+
+    ### Changed
+
+    - **Something softer.** This one only nods at an issue. (Related to #161)
+
+    ## [0.15.0] - 2026-08-20
+
+    ### Added
+
+    - **First fix.** (Fixes #211)
+    - **Second fix.** (Closes #212) and also (Resolves #213)
+
+    ## [0.14.0]
+
+    ### Fixed
+
+    - **No refs at all.** Nothing to notify here.
+    """
+)
+
+
+class TestSection:
+    def test_returns_heading_and_body(self):
+        body = section(CHANGELOG, "0.15.0")
+        assert body.startswith("## [0.15.0] - 2026-08-20")
+        assert "First fix" in body
+
+    def test_stops_at_the_next_version(self):
+        body = section(CHANGELOG, "0.15.0")
+        assert "0.14.0" not in body
+        assert "No refs at all" not in body
+
+    def test_excludes_earlier_sections(self):
+        assert "0.16.0b1" not in section(CHANGELOG, "0.15.0")
+
+    def test_dateless_heading_is_found(self):
+        # Most beta sections in the real changelog carry no date.
+        assert section(CHANGELOG, "0.14.0").startswith("## [0.14.0]")
+
+    def test_unknown_version_is_empty(self):
+        assert section(CHANGELOG, "9.9.9") == ""
+
+    def test_prefix_of_a_real_version_does_not_match(self):
+        # "0.15" must not match "## [0.15.0]" — a truncated version would ship the
+        # wrong notes and notify the wrong issues.
+        assert section(CHANGELOG, "0.15") == ""
+
+    def test_ends_with_a_newline(self):
+        assert section(CHANGELOG, "0.15.0").endswith("\n")
+
+
+class TestIssues:
+    def test_reference_on_a_continuation_line_is_found(self):
+        assert _numbers(section(CHANGELOG, "0.16.0b1")) == [214]
+
+    def test_related_to_is_not_a_closing_reference(self):
+        assert 161 not in _numbers(section(CHANGELOG, "0.16.0b1"))
+
+    @pytest.mark.parametrize(
+        "keyword",
+        ["Fixes", "fixes", "Fixed", "fix", "Closes", "closed", "Resolves", "resolve"],
+    )
+    def test_closing_keywords_and_case(self, keyword):
+        assert _numbers(f"- **X.** ({keyword} #7)") == [7]
+
+    def test_bare_reference_is_ignored(self):
+        # "(#189)" is the squash-merge PR number in this repo's commit subjects and
+        # is indistinguishable from an issue ref. Reading it would close random PRs.
+        assert _numbers("- **X.** Something happened (#189)") == []
+
+    def test_multiple_references_in_one_section(self):
+        assert _numbers(section(CHANGELOG, "0.15.0")) == [211, 212, 213]
+
+    def test_order_is_first_mention(self):
+        assert _numbers("- **B.** (Fixes #9)\n- **A.** (Fixes #2)") == [9, 2]
+
+    def test_deduped_across_bullets(self):
+        # The stable section repeats its betas' refs, so duplicates are routine.
+        assert _numbers("- **A.** (Fixes #5)\n- **B.** (Fixes #5)") == [5]
+
+    def test_first_mention_wins_the_summary(self):
+        found = issues("- **First.** (Fixes #5)\n- **Second.** (Fixes #5)")
+        assert found == [{"number": 5, "summary": "First."}]
+
+    def test_summary_travels_with_its_own_bullet(self):
+        found = issues(section(CHANGELOG, "0.15.0"))
+        assert found[0]["summary"] == "First fix."
+        assert found[1]["summary"] == "Second fix."
+
+    def test_section_without_references(self):
+        assert _numbers(section(CHANGELOG, "0.14.0")) == []
+
+
+class TestBullets:
+    def test_continuation_lines_are_joined_and_unwrapped(self):
+        assert bullets("- one\n  two\n  three") == ["one two three"]
+
+    def test_bullets_are_separate(self):
+        assert bullets("- one\n- two") == ["one", "two"]
+
+    def test_headings_end_a_bullet(self):
+        assert bullets("- one\n### Fixed\n- two") == ["one", "two"]
+
+    def test_asterisk_bullets(self):
+        assert bullets("* one") == ["one"]
+
+    def test_prose_outside_a_bullet_is_dropped(self):
+        assert bullets("Loose prose.\n\n- one") == ["one"]
+
+
+class TestSummarize:
+    def test_bold_lead_wins(self):
+        assert summarize("**The headline.** Then detail. And more.") == "The headline."
+
+    def test_falls_back_to_the_first_sentence(self):
+        assert summarize("No bold here. Second sentence.") == "No bold here."
+
+    def test_long_unpunctuated_text_is_truncated(self):
+        assert summarize("word " * 100).endswith("…")
+        assert len(summarize("word " * 100)) <= 200
+
+
+class TestScan:
+    def test_reads_refs_and_closing_keywords(self):
+        assert scan("Refs #300\nFixes #216\nCloses #7") == [300, 216, 7]
+
+    def test_ignores_bare_pr_suffixes(self):
+        assert scan("feat: a thing (#222)") == []
+
+    def test_deduped_in_first_mention_order(self):
+        assert scan("Refs #4 Fixes #4 Refs #1") == [4, 1]
+
+
+class TestMissing:
+    """The cross-check that catches a forgotten changelog reference."""
+
+    def test_referenced_but_not_listed_is_reported(self):
+        commits = "feat: a thing (#219)\n\nRefs #214\nRefs #999\n"
+        assert _mod.missing(commits, section(CHANGELOG, "0.16.0b1")) == [999]
+
+    def test_listed_issues_are_not_reported(self):
+        assert _mod.missing("Refs #214", section(CHANGELOG, "0.16.0b1")) == []
+
+    def test_pr_suffix_is_not_reported(self):
+        # Every squash-merged commit ends in "(#N)". Flagging those would make the
+        # warning noise and get it ignored.
+        commits = "feat(profiles): exclude tasks (#219)"
+        assert _mod.missing(commits, section(CHANGELOG, "0.16.0b1")) == []
+
+    def test_a_commit_closing_keyword_still_counts_as_a_reference(self):
+        assert _mod.missing("Fixes #99", section(CHANGELOG, "0.16.0b1")) == [99]
+
+    def test_empty_commit_range(self):
+        assert _mod.missing("", section(CHANGELOG, "0.16.0b1")) == []
+
+
+class TestCli:
+    def _run(self, *args, stdin=""):
+        return subprocess.run(
+            ["python3", str(_SCRIPT), *args],
+            capture_output=True,
+            text=True,
+            input=stdin,
+            cwd=_ROOT,
+        )
+
+    def test_notes_prints_the_section(self):
+        result = self._run("--version", "0.15.0", "--notes")
+        assert result.returncode == 0
+        assert result.stdout.startswith("## [0.15.0]")
+
+    def test_json_is_parseable(self):
+        result = self._run("--version", "0.15.0", "--json")
+        assert result.returncode == 0
+        assert json.loads(result.stdout) == [
+            {"number": 211, "summary": "Complete a task by scanning an NFC/RFID tag."}
+        ]
+
+    def test_missing_section_fails(self):
+        result = self._run("--version", "9.9.9", "--notes")
+        assert result.returncode == 1
+        assert "9.9.9" in result.stderr
+
+    def test_scan_reads_stdin(self):
+        result = self._run("--scan", stdin="Refs #12\nFixes #34\n")
+        assert result.returncode == 0
+        assert result.stdout.split() == ["12", "34"]
+
+    def test_missing_is_json(self):
+        result = self._run(
+            "--version", "0.15.0", "--missing", stdin="Refs #211\nRefs #998\n"
+        )
+        assert result.returncode == 0
+        assert json.loads(result.stdout) == [998]
+
+    def test_a_mode_is_required(self):
+        assert self._run("--version", "0.15.0").returncode != 0
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        "0.16.0b2",
+        "0.16.0b1",
+        "0.15.0",
+        "0.14.0",
+        "0.13.0",
+        "0.12.0",
+        "0.8.0",
+        "0.8.0b5",
+    ],
+)
+def test_notes_are_byte_identical_to_the_awk_it_replaced(version):
+    """Every shipped release's notes must come out unchanged."""
+    expected = subprocess.run(
+        ["awk", "-v", f"ver={version}", _AWK, str(_CHANGELOG)],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert expected, f"the awk baseline found no section for {version}"
+    assert section(_CHANGELOG.read_text(encoding="utf-8"), version) == expected
+
+
+def test_real_changelog_never_yields_a_pull_request_number():
+    """A sweep of the whole file: no PR number may leak in as an issue."""
+    text = _CHANGELOG.read_text(encoding="utf-8")
+    found = set()
+    for line in text.splitlines():
+        if line.startswith("## ["):
+            found.update(_numbers(section(text, line[4:].split("]")[0])))
+    # These are PR numbers appearing as "(#N)" in the same prose, plus the one
+    # "Related to" reference. None may be read as something to close.
+    assert found.isdisjoint({161, 189, 219, 222})
+    assert {214, 216, 211} <= found

--- a/tests/unit/test_release_issues.py
+++ b/tests/unit/test_release_issues.py
@@ -16,6 +16,7 @@ import json
 import subprocess
 import textwrap
 from pathlib import Path
+from typing import ClassVar
 
 import pytest
 
@@ -46,6 +47,8 @@ issues = _mod.issues
 bullets = _mod.bullets
 summarize = _mod.summarize
 scan = _mod.scan
+version_key = _mod.version_key
+previous_tags = _mod.previous_tags
 
 
 def _numbers(text: str) -> list[int]:
@@ -196,6 +199,140 @@ class TestScan:
 
     def test_deduped_in_first_mention_order(self):
         assert scan("Refs #4 Fixes #4 Refs #1") == [4, 1]
+
+
+class TestFencedCode:
+    """A `Fixes #N` in a code sample is not a claim that this release fixed it."""
+
+    def test_reference_inside_a_fence_is_ignored(self):
+        text = "- **A.** Example:\n\n```\ngit commit -m 'Fixes #4'\n```\n"
+        assert _numbers(text) == []
+
+    def test_indented_fence_inside_a_bullet_is_ignored(self):
+        text = (
+            "- **A.** Example:\n  ```bash\n  # Fixes #4\n  ```\n  Real text. (Fixes #5)"
+        )
+        assert _numbers(text) == [5]
+
+    def test_text_after_a_closed_fence_is_read_again(self):
+        text = "- **A.**\n```\nnoise\n```\n- **B.** (Fixes #6)"
+        assert _numbers(text) == [6]
+
+
+class TestNestedBullets:
+    """A nested bullet is its own entry, so its ref gets its own summary."""
+
+    def test_nested_bullet_is_separate(self):
+        assert bullets("- parent\n  - child") == ["parent", "child"]
+
+    def test_nested_reference_gets_its_own_summary(self):
+        text = "- **Parent headline.** Prose.\n  - **Child headline.** (Fixes #8)"
+        assert issues(text) == [{"number": 8, "summary": "Child headline."}]
+
+    def test_parent_reference_is_unaffected_by_a_nested_bullet(self):
+        text = "- **Parent headline.** (Fixes #9)\n  - **Child headline.** Detail."
+        assert issues(text) == [{"number": 9, "summary": "Parent headline."}]
+
+    def test_continuation_lines_still_join(self):
+        # An indented line that is *not* a bullet remains part of the bullet above it.
+        assert bullets("- parent\n  wrapped prose\n  - child") == [
+            "parent wrapped prose",
+            "child",
+        ]
+
+    def test_real_changelog_nested_bullets_do_not_change_the_issue_list(self):
+        # The 0.14.0 section is the one with nested bullets; splitting them must not
+        # drop or move the reference the release actually closes.
+        text = _CHANGELOG.read_text(encoding="utf-8")
+        assert _numbers(section(text, "0.14.0")) == [204]
+
+
+class TestVersionKey:
+    """PEP 440 ordering, which `git tag --sort=-v:refname` does not provide."""
+
+    def test_a_final_release_outranks_its_own_prereleases(self):
+        # This is the bug: git sorts v0.16.0 *below* v0.16.0rc1.
+        assert version_key("v0.16.0") > version_key("v0.16.0rc1")
+        assert version_key("v0.16.0rc1") > version_key("v0.16.0b2")
+        assert version_key("v0.16.0b2") > version_key("v0.16.0a1")
+
+    def test_beta_serials_order_numerically(self):
+        assert version_key("v0.16.0b10") > version_key("v0.16.0b2")
+
+    def test_across_versions(self):
+        assert version_key("v0.16.0b1") > version_key("v0.15.0")
+
+    @pytest.mark.parametrize("tag", ["v0.16", "0.16.0", "v0.16.0.dev1", "vX.Y.Z", ""])
+    def test_non_release_tags_are_rejected(self, tag):
+        assert version_key(tag) is None
+
+
+class TestPreviousTags:
+    ALL: ClassVar[list[str]] = [
+        "v0.17.0b1",
+        "v0.16.0",
+        "v0.16.0rc1",
+        "v0.16.0b10",
+        "v0.16.0b2",
+        "v0.16.0b1",
+        "v0.15.0",
+        "v0.15.0b1",
+        "not-a-tag",
+    ]
+
+    def test_a_stable_only_considers_stables(self):
+        # A stable's section rolls up its betas, so it is measured from the last stable.
+        assert previous_tags(self.ALL, "0.16.0") == ["v0.15.0"]
+
+    def test_a_beta_considers_any_kind(self):
+        # The regression this fixes: git ranked v0.16.0rc1 above v0.16.0, so a beta
+        # measured from the rc and flagged everything v0.16.0 shipped as missing.
+        assert previous_tags(self.ALL, "0.17.0b1")[0] == "v0.16.0"
+
+    def test_ordering_is_newest_first(self):
+        assert previous_tags(self.ALL, "0.17.0b1") == [
+            "v0.16.0",
+            "v0.16.0rc1",
+            "v0.16.0b10",
+            "v0.16.0b2",
+            "v0.16.0b1",
+            "v0.15.0",
+            "v0.15.0b1",
+        ]
+
+    def test_the_version_itself_is_excluded(self):
+        assert "v0.16.0" not in previous_tags(self.ALL, "0.16.0")
+
+    def test_newer_tags_are_excluded(self):
+        assert "v0.17.0b1" not in previous_tags(self.ALL, "0.16.0")
+
+    def test_a_beta_excludes_its_own_line_above_it(self):
+        assert previous_tags(self.ALL, "0.16.0b2")[0] == "v0.16.0b1"
+
+    def test_unparseable_tags_are_dropped(self):
+        assert "not-a-tag" not in previous_tags(self.ALL, "0.17.0b1")
+
+    def test_no_candidates(self):
+        assert previous_tags(["v0.1.0"], "0.1.0") == []
+
+    def test_a_malformed_version_yields_nothing(self):
+        assert previous_tags(self.ALL, "garbage") == []
+
+
+class TestOutputSafety:
+    """The JSON reaches $GITHUB_OUTPUT as `issues=<json>`, so it must stay one line."""
+
+    def test_json_is_single_line_even_with_hostile_prose(self):
+        text = "- **A line\nbreak and a `backtick`.** (Fixes #5)"
+        assert "\n" not in json.dumps(issues(text))
+
+    def test_a_forged_output_line_in_prose_cannot_escape_the_json(self):
+        # A changelog line that looks like a workflow output must stay inert data.
+        text = "- Evil stuff\n  prerelease=false\n  more (Fixes #5)"
+        encoded = json.dumps(issues(text))
+        assert "\n" not in encoded
+        summary = json.loads(encoded)[0]["summary"]
+        assert summary == "Evil stuff prerelease=false more (Fixes #5)"
 
 
 class TestMissing:

--- a/tests/unit/test_release_issues.py
+++ b/tests/unit/test_release_issues.py
@@ -270,6 +270,22 @@ class TestOrderedLists:
     def test_a_version_number_is_not_a_bullet(self):
         assert bullets("0.16.0b1 shipped this") == []
 
+    def test_a_decimal_in_prose_is_not_a_bullet(self):
+        # "2.5 seconds" must not start a list: the marker needs whitespace after it.
+        assert bullets("  it took 2.5 seconds") == []
+
+    def test_a_numeric_continuation_line_splits_but_keeps_the_reference(self):
+        # Known boundary, pinned deliberately. A wrapped line that begins with a
+        # number and a period ("30. Then …") is indistinguishable from an ordered
+        # list item, so it starts a new bullet and the quoted summary shifts to it.
+        # The reference is still found, so the issue still closes correctly — the
+        # cost is a less apt sentence in the comment, not a missed fix. Tracking
+        # indentation to tell the two apart would add more risk than the case is
+        # worth: the changelog has no ordered lists and no numeric continuations.
+        found = issues("- **Parent.** It takes\n  30. Then the rest. (Fixes #9)")
+        assert [entry["number"] for entry in found] == [9]
+        assert found[0]["summary"] == "Then the rest."
+
 
 class TestNestedBullets:
     """A nested bullet is its own entry, so its ref gets its own summary."""

--- a/tests/unit/test_release_issues.py
+++ b/tests/unit/test_release_issues.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import re
 import subprocess
 import textwrap
 from pathlib import Path
@@ -218,6 +219,57 @@ class TestFencedCode:
         text = "- **A.**\n```\nnoise\n```\n- **B.** (Fixes #6)"
         assert _numbers(text) == [6]
 
+    def test_tilde_fences_are_dropped_too(self):
+        # CommonMark accepts ~~~ as well as ```. A ~~~ block used to sail straight
+        # through and close whatever issue the code sample happened to mention.
+        assert _numbers("- **A.**\n~~~\nFixes #4\n~~~\n") == []
+
+    def test_a_longer_fence_run_is_still_a_fence(self):
+        assert _numbers("- **A.**\n````\nFixes #4\n````\n") == []
+
+    def test_an_unclosed_fence_swallows_the_rest(self):
+        # Erring toward dropping beats erring toward closing someone's issue.
+        assert _numbers("- **A.** (Fixes #1)\n```\nFixes #2\n- **B.** (Fixes #3)") == [
+            1
+        ]
+
+
+class TestThematicBreaks:
+    """`* * *` and `- - -` are horizontal rules, not bullets."""
+
+    @pytest.mark.parametrize("rule", ["---", "--- ", "***", "* * *", "- - -", "___"])
+    def test_rules_are_not_bullets(self, rule):
+        assert bullets(rule) == []
+
+    def test_a_rule_does_not_swallow_the_prose_below_it(self):
+        # `* * *` used to parse as a bullet with the text "* *", absorb the line
+        # under it, and quote that back at the reporter as the summary.
+        assert bullets("* * *\ncontinuation (Fixes #7)") == []
+
+    def test_a_rule_separates_two_bullets(self):
+        assert _numbers("- **A.** (Fixes #1)\n\n---\n\n- **B.** (Fixes #2)") == [1, 2]
+
+    def test_a_real_bullet_starting_with_a_dash_still_parses(self):
+        assert bullets("- - is a dash") == ["- is a dash"]
+
+
+class TestOrderedLists:
+    """A `Fixes #N` in a numbered item must not be silently dropped."""
+
+    def test_numbered_items_are_bullets(self):
+        assert bullets("1. one\n2. two") == ["one", "two"]
+
+    def test_a_reference_in_a_numbered_item_is_found(self):
+        assert issues("1. **First.** (Fixes #5)") == [
+            {"number": 5, "summary": "First."}
+        ]
+
+    def test_multi_digit_numbering(self):
+        assert bullets("10. ten") == ["ten"]
+
+    def test_a_version_number_is_not_a_bullet(self):
+        assert bullets("0.16.0b1 shipped this") == []
+
 
 class TestNestedBullets:
     """A nested bullet is its own entry, so its ref gets its own summary."""
@@ -401,21 +453,20 @@ class TestCli:
         assert self._run("--version", "0.15.0").returncode != 0
 
 
-@pytest.mark.parametrize(
-    "version",
-    [
-        "0.16.0b2",
-        "0.16.0b1",
-        "0.15.0",
-        "0.14.0",
-        "0.13.0",
-        "0.12.0",
-        "0.8.0",
-        "0.8.0b5",
-    ],
-)
+def _released_versions() -> list[str]:
+    """Every version with a section in the real CHANGELOG."""
+    text = _CHANGELOG.read_text(encoding="utf-8")
+    return re.findall(r"^## \[([^\]]+)\]", text, re.MULTILINE)
+
+
+@pytest.mark.parametrize("version", _released_versions())
 def test_notes_are_byte_identical_to_the_awk_it_replaced(version):
-    """Every shipped release's notes must come out unchanged."""
+    """Every shipped release's notes must come out unchanged.
+
+    Parametrized over the whole file rather than a sample: a hand-picked list can't
+    fail for a section nobody thought to add to it, and this test is the only thing
+    standing between a parser change and silently rewritten release bodies.
+    """
     expected = subprocess.run(
         ["awk", "-v", f"ver={version}", _AWK, str(_CHANGELOG)],
         capture_output=True,
@@ -426,14 +477,43 @@ def test_notes_are_byte_identical_to_the_awk_it_replaced(version):
     assert section(_CHANGELOG.read_text(encoding="utf-8"), version) == expected
 
 
-def test_real_changelog_never_yields_a_pull_request_number():
-    """A sweep of the whole file: no PR number may leak in as an issue."""
+# The complete set of issues the real CHANGELOG claims to close. Pinned rather than
+# recomputed: this is the list that decides whose issue gets closed, so a parser change
+# that quietly adds or drops one has to show up as a failing test, not a silent diff.
+_KNOWN_ISSUES = frozenset(
+    {
+        104,
+        105,
+        118,
+        119,
+        143,
+        144,
+        145,
+        150,
+        159,
+        160,
+        163,
+        164,
+        173,
+        182,
+        183,
+        204,
+        211,
+        214,
+        216,
+    }
+)
+
+
+def test_real_changelog_yields_exactly_the_known_issue_set():
     text = _CHANGELOG.read_text(encoding="utf-8")
     found = set()
-    for line in text.splitlines():
-        if line.startswith("## ["):
-            found.update(_numbers(section(text, line[4:].split("]")[0])))
-    # These are PR numbers appearing as "(#N)" in the same prose, plus the one
-    # "Related to" reference. None may be read as something to close.
-    assert found.isdisjoint({161, 189, 219, 222})
-    assert {214, 216, 211} <= found
+    for version in _released_versions():
+        found.update(_numbers(section(text, version)))
+    assert found == _KNOWN_ISSUES
+
+
+def test_real_changelog_never_yields_a_pull_request_number():
+    """No PR number, and no soft reference, may be read as something to close."""
+    # 189/219/222 appear as "(#N)" in the same prose; 161 is "(Related to #161)".
+    assert _KNOWN_ISSUES.isdisjoint({161, 189, 219, 222})


### PR DESCRIPTION
## What changed

A merged PR is not in anyone's Home Assistant yet — the fix may sit on `main` for days, go out in a beta, and reach everyone later still. Nothing ever tells the reporter when a version they can install exists.

Closing-on-merge is turned off for this repository, so issues already stay open past merge on their own (PR #222's body opens with a literal `Fixes #216.`, it merged, and #216 is still open). What's missing is the other half: **telling the reporter when the fix actually ships, and closing the issue then.**

A new `notify-issues` job in `release.yml` reads the shipped version's CHANGELOG section and, for every issue it references:

- **Beta** — comments with the *Show beta versions* instructions, leaves the issue **open**.
- **Stable** — comments that it shipped, quotes the changelog bullet, closes it as `completed`.

**What the comments look like**

Beta:
> **Fixed in Home Keeper v0.16.0b1**, out now as a beta.
>
> > "Mark done" on a notification works before the task is due.
>
> To try it before it ships to everyone, turn on **Show beta versions** for Home Keeper in HACS and update. This issue stays open until the fix reaches a stable release.
>
> [Release notes](…)

Stable:
> **Shipped in Home Keeper v0.16.0.** Update through HACS to get it.
>
> > "Mark done" on a notification works before the task is due.
>
> Closing this out. If you still run into it after updating, reopen the issue or leave a comment and it'll be picked back up.
>
> [Release notes](…)

**No contributor-facing convention change.** Keep writing `Fixes #N` in PR bodies — it creates GitHub's linked-pull-request relationship (the issue's Development panel) without closing anything here. An earlier revision of this PR switched to `Refs #N`; that was wrong, since only a closing keyword creates that link, and it was reverted in a2f132f.

### How it picks the issues

The section's `(Fixes #N)` refs are the release's issue list, parsed by the new `ci/release-issues.py`. Parsing is deliberately strict — only closing keywords count. A bare `(#N)` is ignored because it's also the PR number squash-merge appends to commit subjects (`… (Fixes #216) (#222)`) and the two can't be told apart; `(Related to #161)` is ignored for the same reason. Fenced code blocks (both ``` and `~~~`) are skipped, and thematic breaks are not bullets.

The script also takes over cutting the release notes from the inline `awk` it replaces, so one unit-tested implementation owns both.

### Guards, since this posts to other people's threads

- Scoped `issues: write` on the new job alone; the build job stays `contents: write`.
- Gated on `github.event_name != 'pull_request'` — `release.yml` runs on every PR to `main`, and without this **each release PR would comment on live issues**. Confirmed on this PR's own run: `notify-issues` → `skipped` ([run 32544226873](https://github.com/prestomation/ha-home-keeper/actions/runs/32544226873)).
- Each comment carries a hidden `home-keeper-release vX.Y.Z` HTML-comment marker; the job paginates all comments and skips an issue that already has one, so re-running posts nothing twice.
- Every issue is handled in a `try`/`catch`: a bad number becomes a warning and a summary row, never a failed release that is already tagged and published.
- Version input is validated **before** anything reaches `$GITHUB_OUTPUT`, so a newline can't forge a second output line (a forged `prerelease=false` would make a beta close issues it only meant to comment on).
- `workflow_dispatch` gains `notify_dry_run` / `notify_version` to rehearse the whole thing against a past release without posting anything.

### The silent-failure guard

Tying closure to the changelog fails silently in exactly one way: forget the `(Fixes #N)` line and the issue never closes, with no signal. So the job cross-checks commit refs in the release against the changelog section and **warns** (never fails) on anything missing.

The comparison range follows the changelog convention — a stable against the previous *stable* (its section rolls up the betas), a beta against the previous tag of any kind. Ranking is done in Python by PEP 440, not by git: `git tag --sort=-v:refname` places a bare `v0.16.0` *below* its own `v0.16.0rc1`, which would silently widen the range.

### Why a job and not `on: release`

`release.yml:130` already documents it: the Release is created by this workflow's `GITHUB_TOKEN`, so a `release` event never starts a run. `deploy-docs` chains via `needs:` for the same reason; this follows it.

### Conventions

`AGENTS.md` and `.amazonq/rules/testing-and-workflow.md` now say *why* an issue stays open past merge (the repo setting) instead of leaving it unexplained, and carve repo automation out of **"Never comment on a GitHub issue"** — that ban is on an agent posting on the maintainer's behalf, not on a fixed-template release notice (`ha-beta.yml`'s regression reporter is already in the same category). Also corrects a claim in `AGENTS.md` that `Fixes #N` in the CHANGELOG auto-closes on merge: GitHub's keyword parser reads PR bodies and commit messages, not file contents.

Adds a PR template.

## Checklist

- [x] Tests run locally — `pytest tests/unit` (1049 passed, 1 skipped), `ruff check` + `ruff format --check` over `custom_components tests ci`
- [x] `CHANGELOG.md` updated — n/a, developer-only change
- [x] Panel UI changed → n/a, no UI change
- [x] New user-facing UI surface → n/a
- [x] New user-facing feature → n/a, no beta bump or `preview-release` label needed

## Verification

98 unit tests in `tests/unit/test_release_issues.py`. Beyond those:

- **Release-notes parity** — `--notes` output is byte-identical to the `awk` it replaces for **all 48 sections** in `CHANGELOG.md`, parametrized over the file rather than a sample.
- **Whole-changelog sweep** — the parser yields exactly `{104, 105, 118, 119, 143, 144, 145, 150, 159, 160, 163, 164, 173, 182, 183, 204, 211, 214, 216}`, pinned as a constant so a parser change that adds or drops one fails a test instead of producing a silent diff. Never `#161` (`Related to`) or `#189`/`#219`/`#222` (PR numbers).
- **The `github-script` body run against a mock API** for six scenarios: beta (comments, doesn't close), stable (comments, closes as `completed`), re-run (marker found, skips), dry run (posts nothing), edge cases (404 → warning; a PR number → skipped; a missing changelog ref → warning), and an empty section.
- **The shell steps run against real tags** for `v0.16.0b2`, `v0.16.0b1`, `v0.15.0`, `v0.14.0`, `v0.12.0`. This is what caught the beta cross-check range bug — comparing `0.16.0b2` against the last stable flagged `#214` as missing when it had already shipped and been notified in `b1`.

The remaining warning on `v0.14.0` (`#199`) is genuine: a CI-only fix, which correctly has no changelog entry and so won't auto-close. That case is documented in `RELEASE.md`.

### What CI on this PR does *not* cover

`release.yml`'s dry run short-circuits here — the manifest is at `0.16.0b2` and tag `v0.16.0b2` already exists, so `release=false` and every step after "Determine release version" is skipped, including **Extract changelog section**. So the `awk`→script swap is not exercised by CI on this PR; the 48-section parity test is what covers it. The first release PR after merge (which bumps the version, so `release=true`) will exercise it as a dry run before the version can ship.

**Before trusting this live:** run Actions → Release → Run workflow with `notify_dry_run: true` and `notify_version: 0.15.0`, and confirm the summary lists `#211` with nothing posted to it.

### When this merges

`0.16.0`'s stable section will need `Fixes #214` and `Fixes #216` — both are already named in the `0.16.0b1` / `0.16.0b2` sections, so the existing roll-up rule covers it. Those two issues then get their first-ever "your fix shipped" comment and close.