### PR TITLE
fix(todo): retire a completed one-off from the to-do list (Fixes #221)

### DIFF
--- a/.amazonq/rules/architecture-and-code.md
+++ b/.amazonq/rules/architecture-and-code.md
@@ -105,9 +105,13 @@ command for admins; Home Keeper follows that rather than inventing a weaker line
   schedule — owned by another integration), and `sensor` (due-state derived from a
   bound numeric entity — see below). `one-off`, `triggered`, and `sensor` all carry
   **no cadence fields** (`normalize_fields` returns early for each); a completed
-  one-off and a dormant triggered/sensor task all have `next_due=None`, so they fall
-  out of every time surface (to-do/calendar/sensors/transitions) for free. Keep the
-  recurrence math in pure `recurrence.py` with an explicit `now`.
+  one-off and a dormant triggered/sensor task all have `next_due=None`, and every
+  time surface (to-do/calendar/sensors/transitions) must drop them. Only the surfaces
+  that *compare* `next_due` get that free (`is_overdue` is `False` for `None`);
+  a surface that **lists** tasks needs an explicit dormancy skip, so add one when you
+  build a new one — the to-do list shipped without one for `one-off`, and a finished
+  do-once task sat there undated forever (#221). Keep the recurrence math in pure
+  `recurrence.py` with an explicit `now`.
 - **Sensor-based tasks** (`REC_SENSOR`) bind a task to a numeric entity via a
   `task["sensor"]` block (`models.normalize_sensor`: `entity_id`, `mode`, and the
   mode's fields — `target` for `usage`, `comparison`+`value`+optional `for_seconds`
@@ -189,7 +193,8 @@ command for admins; Home Keeper follows that rather than inventing a weaker line
 - Per-task device-page entities (`button`/`sensor`/`binary_sensor`) are created
   only for **enabled, device-attached** tasks (use
   `coordinator.device_attached_task_ids()`); `todo`/`calendar` likewise skip
-  disabled tasks.
+  disabled tasks, and both also skip **dormant** ones (`next_due is None` on a
+  `one-off`/`triggered`/`sensor`).
 - Attach to an existing device by reusing that device's `DeviceInfo`
   `identifiers`/`connections` (Battery-Notes-style identifier merge) — never
   create a duplicate device for someone else's hardware.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to Home Keeper are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
 
+## [0.16.0b3]
+
+### Fixed
+
+- **A do-once task you already finished no longer sits on the to-do list forever.**
+  Checking off a one-off task (renew the passport, register the car) retires it: it
+  goes dormant and leaves the calendar, the due-date sensors and the panel's active
+  list, landing in the panel's **Completed** section with its record intact. The native
+  `todo.home_keeper_tasks` list kept showing it anyway, unchecked and with its due date
+  gone, and nothing could clear it short of deleting the task and its history. A
+  finished one-off now drops off the to-do list as soon as it's done, and comes back at
+  its due date if you undo the completion. Checking one off a second time (through
+  `todo.update_item`, say) no longer records a second completion for work done once.
+  (Fixes #221)
+
 ## [0.16.0b2]
 
 ### Fixed

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor", "number"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.16.0b2"
+PANEL_VERSION = "0.16.0b3"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -20,5 +20,5 @@
   "requirements": [
     "Babel>=2.12"
   ],
-  "version": "0.16.0b2"
+  "version": "0.16.0b3"
 }

--- a/custom_components/home_keeper/todo.py
+++ b/custom_components/home_keeper/todo.py
@@ -1,13 +1,19 @@
 """To-do list entity for Home Keeper.
 
-Exposes all tasks as items in a single native HA to-do list, so users can view
-and complete them from HA's built-in To-do card and the mobile app. Checking an
-item off routes into the recurrence engine: the task's clock advances and the
+Exposes every live task as an item in a single native HA to-do list, so users can
+view and complete them from HA's built-in To-do card and the mobile app. Checking
+an item off routes into the recurrence engine: the task's clock advances and the
 item reappears with its new due date (native TodoListEntity has no recurrence of
 its own).
+
+A task that has gone *dormant* carries no ``next_due`` — a do-once task that is
+finished, a triggered or sensor task that is not armed — and is off the list until
+it is armed again.
 """
 
 from __future__ import annotations
+
+from typing import Any
 
 from homeassistant.components.todo import (
     TodoItem,
@@ -22,9 +28,24 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
-from .const import DOMAIN, REC_SENSOR, REC_TRIGGERED
+from .const import DOMAIN, REC_ONE_OFF, REC_SENSOR, REC_TRIGGERED
 from .coordinator import HomeKeeperCoordinator
 from .models import TaskValidationError
+
+
+def _completed_one_off(task: dict[str, Any]) -> bool:
+    """True for a do-once task that is already done (dormant, not re-armed).
+
+    The same dormant-and-completed shape ``recurrence.one_off_expired`` keys its
+    retention window on, and the panel's ``_statusBucket`` files under Completed.
+    Kept local rather than imported: ``one_off_expired`` answers the different
+    question "is this purgeable yet", and it takes a retention window to do it.
+    """
+    return (
+        task.get("recurrence_type") == REC_ONE_OFF
+        and not task.get("next_due")
+        and bool(task.get("last_completed"))
+    )
 
 
 async def async_setup_entry(
@@ -55,17 +76,22 @@ class HomeKeeperTodoListEntity(
 
     @property
     def todo_items(self) -> list[TodoItem]:
-        """Return one item per enabled task, dated by next_due."""
+        """Return one item per enabled, non-dormant task, dated by next_due."""
         items: list[TodoItem] = []
         for task in self.coordinator.data.values():
             if not task.get("enabled", True):
                 continue
             due_iso = task.get("next_due")
-            # A dormant triggered or sensor task (next_due == None) is "armed but not
-            # due" — keep it off the to-do list entirely rather than showing it as an
-            # undated item. It reappears the moment it is armed (next_due set).
+            # A dormant task (next_due == None) is off every time surface: a completed
+            # one-off is permanently done, and a triggered or sensor task is "armed but
+            # not due". Keep both off the to-do list entirely rather than showing them
+            # as undated items that can never be cleared. Each reappears the moment it
+            # is (re-)armed — a one-off when its completion is undone, the other two
+            # when their condition fires again. Not a bare `not due_iso` check: a
+            # floating or fixed task always carries a next_due, so a missing one there
+            # is malformed data that should stay visible rather than silently vanish.
             rec_type = task.get("recurrence_type")
-            if rec_type in (REC_TRIGGERED, REC_SENSOR) and not due_iso:
+            if rec_type in (REC_ONE_OFF, REC_TRIGGERED, REC_SENSOR) and not due_iso:
                 continue
             due = dt_util.parse_datetime(due_iso) if due_iso else None
             items.append(
@@ -87,13 +113,19 @@ class HomeKeeperTodoListEntity(
           integration must clear the underlying problem — surfaced as a
           ``HomeAssistantError`` so the card shows the reason and leaves it
           checked-pending).
+        * A completion aimed at an already-completed do-once task is ignored. It is
+          dormant and off the list, so the only thing a second check-off could do is
+          duplicate the record of work done exactly once.
         * Editing the summary/notes in the detail dialog applies as a task update.
           The entity declares ``UPDATE_TODO_ITEM``, so a rename must actually persist
           rather than silently revert on the next render.
         """
         if not item.uid:
             return
+        task = self.coordinator.store.get_task(item.uid)
         if item.status == TodoItemStatus.COMPLETED:
+            if task is not None and _completed_one_off(task):
+                return
             try:
                 await self.coordinator.store.complete_task(item.uid)
             except TaskValidationError as err:
@@ -108,7 +140,6 @@ class HomeKeeperTodoListEntity(
             return
 
         # NEEDS_ACTION: persist summary/notes edits made in the card detail dialog.
-        task = self.coordinator.store.get_task(item.uid)
         if task is None:
             return
         updates: dict[str, str] = {}

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -19,11 +19,76 @@ def _list_tasks(ha):
     return resp.get("service_response", resp)["tasks"]
 
 
+def _todo_summaries(ha):
+    """The to-do list's actual items, not just the count the entity state carries."""
+    resp = call_service(
+        ha,
+        "todo",
+        "get_items",
+        {"entity_id": "todo.home_keeper_tasks"},
+        return_response=True,
+    )
+    payload = resp.get("service_response", resp)
+    return [item["summary"] for item in payload["todo.home_keeper_tasks"]["items"]]
+
+
 def test_todo_entity_exists_with_seeded_tasks(ha):
     state = get_state(ha, "todo.home_keeper_tasks")
     assert state is not None
     # State is the count of incomplete items; 4 seeded tasks are enabled.
     assert int(state["state"]) >= 1
+    summaries = _todo_summaries(ha)
+    # An armed one-off is a normal item...
+    assert "Renew passport" in summaries
+    # ...but the seeded "Renew car registration" is already completed, so it is
+    # dormant (next_due None) and must not be on the list (#221).
+    assert "Renew car registration" not in summaries
+
+
+def test_completed_one_off_leaves_the_todo_list(ha):
+    """Regression (#221): a do-once task retires from the to-do list once it's done.
+
+    It used to sit there as an undated needs_action item forever — the entity only
+    emits needs_action, so nothing short of deleting the task could clear it.
+    """
+    name = "One-off todo probe"
+    resp = call_service(
+        ha,
+        "home_keeper",
+        "add_task",
+        {
+            "name": name,
+            "recurrence_type": "one-off",
+            "due": "2026-07-15T09:00:00-04:00",
+        },
+        return_response=True,
+    )
+    task_id = resp.get("service_response", resp)["task_id"]
+    try:
+        assert name in _todo_summaries(ha), "an armed one-off belongs on the list"
+
+        call_service(ha, "home_keeper", "complete_task", {"task_id": task_id})
+        deadline = time.monotonic() + 20
+        while time.monotonic() < deadline and name in _todo_summaries(ha):
+            time.sleep(1)
+        assert name not in _todo_summaries(ha), "a completed one-off is dormant"
+
+        # The reporter's other symptom: checking the stale item off again appended a
+        # second completion. HA can no longer resolve an item that isn't listed...
+        rejected = ha.post(
+            f"{HA_URL}/api/services/todo/update_item",
+            json={
+                "entity_id": "todo.home_keeper_tasks",
+                "item": name,
+                "status": "completed",
+            },
+        )
+        assert rejected.status_code >= 400
+        # ...and the completion history stayed at the single real completion.
+        task = next(t for t in _list_tasks(ha) if t["id"] == task_id)
+        assert len(task["completions"]) == 1
+    finally:
+        call_service(ha, "home_keeper", "delete_task", {"task_id": task_id})
 
 
 def test_calendar_entity_exists(ha):

--- a/tests/unit/test_calendar.py
+++ b/tests/unit/test_calendar.py
@@ -25,80 +25,109 @@ def _dt(y, mo, d, h=0, mi=0) -> datetime:
     return datetime(y, mo, d, h, mi, tzinfo=TZ)
 
 
-def _install_ha_stubs() -> None:
-    """Register minimal stand-ins for the HA symbols ``calendar.py`` imports.
+def _real_ha_present() -> bool:
+    """True only when the *real* Home Assistant package is installed.
 
-    Only installed when Home Assistant isn't importable (the pure-unit
-    environment). When real HA is present these modules already exist and are
-    left untouched.
+    A hand-built stub ``homeassistant`` module (e.g. from ``test_todo.py``) has no
+    ``__file__``; the real package does. This distinguishes them so we fill gaps
+    over a stub tree but never shadow real submodules.
     """
-    try:  # pragma: no cover - depends on environment
-        import homeassistant  # noqa: F401
+    mod = sys.modules.get("homeassistant")
+    if mod is None:
+        try:  # pragma: no cover - depends on environment
+            import homeassistant as mod  # type: ignore[no-redef]
+        except ImportError:
+            return False
+    return getattr(mod, "__file__", None) is not None
 
+
+def _install_ha_stubs() -> None:
+    """Additively register the HA symbols ``calendar.py`` imports.
+
+    Idempotent and non-clobbering, on the same contract as
+    ``test_coordinator_purge.py``, ``test_device_heal.py`` and ``test_todo.py``:
+    each installs its own partial ``homeassistant`` stub tree, so we only *fill
+    gaps* rather than early-return or overwrite, and load order between the suites
+    stays irrelevant. (Early-returning on "some ``homeassistant`` module exists"
+    would leave ``homeassistant.components.calendar`` unregistered whenever another
+    suite's stubs landed first.)
+    """
+    if _real_ha_present():  # pragma: no cover - real HA env
         return
-    except ImportError:
-        pass
 
     def _mod(name: str) -> types.ModuleType:
+        existing = sys.modules.get(name)
+        if existing is not None:
+            return existing
         m = types.ModuleType(name)
         sys.modules[name] = m
         return m
 
     ha = _mod("homeassistant")
-    _mod("homeassistant.components")
-    ha.components = sys.modules["homeassistant.components"]
+    components = _mod("homeassistant.components")
+    ha.components = components
 
     comp_cal = _mod("homeassistant.components.calendar")
+    if not hasattr(comp_cal, "CalendarEntity"):
 
-    class CalendarEntity:
-        pass
+        class CalendarEntity:
+            pass
 
-    class CalendarEvent:
-        def __init__(self, summary, start, end, uid, description=None):
-            self.summary = summary
-            self.start = start
-            self.end = end
-            self.uid = uid
-            self.description = description
+        class CalendarEvent:
+            def __init__(self, summary, start, end, uid, description=None):
+                self.summary = summary
+                self.start = start
+                self.end = end
+                self.uid = uid
+                self.description = description
 
-    comp_cal.CalendarEntity = CalendarEntity
-    comp_cal.CalendarEvent = CalendarEvent
+        comp_cal.CalendarEntity = CalendarEntity
+        comp_cal.CalendarEvent = CalendarEvent
+    components.calendar = comp_cal
 
     config_entries = _mod("homeassistant.config_entries")
-    config_entries.ConfigEntry = type("ConfigEntry", (), {})
+    if not hasattr(config_entries, "ConfigEntry"):
+        config_entries.ConfigEntry = type("ConfigEntry", (), {})
 
     core = _mod("homeassistant.core")
-    core.HomeAssistant = type("HomeAssistant", (), {})
+    if not hasattr(core, "HomeAssistant"):
+        core.HomeAssistant = type("HomeAssistant", (), {})
 
-    _mod("homeassistant.helpers")
+    helpers = _mod("homeassistant.helpers")
     entity_platform = _mod("homeassistant.helpers.entity_platform")
-    entity_platform.AddEntitiesCallback = object
+    if not hasattr(entity_platform, "AddEntitiesCallback"):
+        entity_platform.AddEntitiesCallback = object
+    helpers.entity_platform = entity_platform
 
     update_coordinator = _mod("homeassistant.helpers.update_coordinator")
-    _T = typing.TypeVar("_T")
+    if not hasattr(update_coordinator, "CoordinatorEntity"):
+        _T = typing.TypeVar("_T")
 
-    class CoordinatorEntity(typing.Generic[_T]):
-        def __init__(self, coordinator):
-            self.coordinator = coordinator
+        class CoordinatorEntity(typing.Generic[_T]):
+            def __init__(self, coordinator):
+                self.coordinator = coordinator
 
-    update_coordinator.CoordinatorEntity = CoordinatorEntity
+        update_coordinator.CoordinatorEntity = CoordinatorEntity
 
     util = _mod("homeassistant.util")
     dt = _mod("homeassistant.util.dt")
+    if not hasattr(dt, "parse_datetime"):
 
-    def parse_datetime(value):
-        if not value:
-            return None
-        try:
-            return datetime.fromisoformat(value)
-        except (TypeError, ValueError):
-            return None
+        def parse_datetime(value):
+            if not value:
+                return None
+            try:
+                return datetime.fromisoformat(value)
+            except (TypeError, ValueError):
+                return None
 
-    def now():  # overridden per-test via monkeypatch
-        raise AssertionError("dt_util.now() must be patched in tests")
+        dt.parse_datetime = parse_datetime
+    if not hasattr(dt, "now"):
 
-    dt.parse_datetime = parse_datetime
-    dt.now = now
+        def now():  # overridden per-test via monkeypatch
+            raise AssertionError("dt_util.now() must be patched in tests")
+
+        dt.now = now
     util.dt = dt
 
 

--- a/tests/unit/test_release_issues.py
+++ b/tests/unit/test_release_issues.py
@@ -517,6 +517,7 @@ _KNOWN_ISSUES = frozenset(
         211,
         214,
         216,
+        221,
     }
 )
 

--- a/tests/unit/test_todo.py
+++ b/tests/unit/test_todo.py
@@ -1,0 +1,456 @@
+"""Unit tests for the to-do entity's dormancy projection (``todo.py``).
+
+The to-do entity is a thin projection over the task store, but it imports Home
+Assistant (``TodoItem``/``CoordinatorEntity``/``dt_util``). Like ``test_calendar.py``
+we load ``todo.py`` under the synthetic ``hk`` package used by the other pure unit
+tests (see ``tests/conftest.py``), stubbing only the HA symbols it references, and
+drive it against an in-memory coordinator/store. The real store/entity wiring is
+exercised by the integration suite.
+
+What's pinned here is the dormancy rule (#221): a task with no ``next_due`` whose
+kind goes dormant — a completed do-once task, an unarmed triggered/sensor task — is
+off the list entirely, because the entity only ever emits ``NEEDS_ACTION`` items and
+an undated one can never be cleared.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import enum
+import importlib.util
+import sys
+import types
+import typing
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+_COMPONENT_DIR = (
+    Path(__file__).resolve().parent.parent.parent / "custom_components" / "home_keeper"
+)
+
+TZ = timezone(timedelta(hours=-4))
+DUE = datetime(2026, 7, 15, 9, 0, tzinfo=TZ)
+
+
+def _real_ha_present() -> bool:
+    """True only when the *real* Home Assistant package is installed.
+
+    A hand-built stub ``homeassistant`` module (e.g. from ``test_calendar.py``) has
+    no ``__file__``; the real package does. This distinguishes them so we fill gaps
+    over a stub tree but never shadow real submodules.
+    """
+    mod = sys.modules.get("homeassistant")
+    if mod is None:
+        try:  # pragma: no cover - depends on environment
+            import homeassistant as mod  # type: ignore[no-redef]
+        except ImportError:
+            return False
+    return getattr(mod, "__file__", None) is not None
+
+
+def _install_ha_stubs() -> None:
+    """Additively register the HA symbols ``todo.py`` imports.
+
+    Idempotent and non-clobbering, like ``test_coordinator_purge.py``: the other
+    pure-unit suites install their own partial ``homeassistant`` stub trees, so we
+    only *fill gaps* rather than early-return or overwrite — otherwise load order
+    between the suites would matter.
+    """
+    if _real_ha_present():  # pragma: no cover - real HA env
+        return
+
+    def _mod(name: str) -> types.ModuleType:
+        existing = sys.modules.get(name)
+        if existing is not None:
+            return existing
+        m = types.ModuleType(name)
+        sys.modules[name] = m
+        return m
+
+    ha = _mod("homeassistant")
+    components = _mod("homeassistant.components")
+    ha.components = components
+
+    comp_todo = _mod("homeassistant.components.todo")
+    if not hasattr(comp_todo, "TodoItem"):
+
+        class TodoItem:
+            def __init__(
+                self,
+                *,
+                uid=None,
+                summary=None,
+                status=None,
+                due=None,
+                description=None,
+            ) -> None:
+                self.uid = uid
+                self.summary = summary
+                self.status = status
+                self.due = due
+                self.description = description
+
+        class TodoItemStatus(enum.Enum):
+            NEEDS_ACTION = "needs_action"
+            COMPLETED = "completed"
+
+        class TodoListEntity:
+            pass
+
+        class TodoListEntityFeature(enum.IntFlag):
+            CREATE_TODO_ITEM = 1
+            DELETE_TODO_ITEM = 2
+            UPDATE_TODO_ITEM = 4
+
+        comp_todo.TodoItem = TodoItem
+        comp_todo.TodoItemStatus = TodoItemStatus
+        comp_todo.TodoListEntity = TodoListEntity
+        comp_todo.TodoListEntityFeature = TodoListEntityFeature
+    components.todo = comp_todo
+
+    config_entries = _mod("homeassistant.config_entries")
+    if not hasattr(config_entries, "ConfigEntry"):
+        config_entries.ConfigEntry = type("ConfigEntry", (), {})
+
+    core = _mod("homeassistant.core")
+    if not hasattr(core, "HomeAssistant"):
+        core.HomeAssistant = type("HomeAssistant", (), {})
+
+    exceptions = _mod("homeassistant.exceptions")
+    if not hasattr(exceptions, "HomeAssistantError"):
+
+        class HomeAssistantError(Exception):
+            def __init__(
+                self,
+                *args,
+                translation_domain=None,
+                translation_key=None,
+                translation_placeholders=None,
+            ) -> None:
+                super().__init__(*args)
+                self.translation_domain = translation_domain
+                self.translation_key = translation_key
+                self.translation_placeholders = translation_placeholders
+
+        exceptions.HomeAssistantError = HomeAssistantError
+
+    helpers = _mod("homeassistant.helpers")
+    entity_platform = _mod("homeassistant.helpers.entity_platform")
+    if not hasattr(entity_platform, "AddEntitiesCallback"):
+        entity_platform.AddEntitiesCallback = object
+    helpers.entity_platform = entity_platform
+
+    update_coordinator = _mod("homeassistant.helpers.update_coordinator")
+    if not hasattr(update_coordinator, "CoordinatorEntity"):
+        _T = typing.TypeVar("_T")
+
+        class CoordinatorEntity(typing.Generic[_T]):
+            def __init__(self, coordinator) -> None:
+                self.coordinator = coordinator
+
+        update_coordinator.CoordinatorEntity = CoordinatorEntity
+
+    util = _mod("homeassistant.util")
+    dt_mod = _mod("homeassistant.util.dt")
+    if not hasattr(dt_mod, "parse_datetime"):
+
+        def parse_datetime(value):
+            if not value:
+                return None
+            try:
+                return datetime.fromisoformat(value)
+            except (TypeError, ValueError):
+                return None
+
+        dt_mod.parse_datetime = parse_datetime
+    util.dt = dt_mod
+
+
+def _load_todo() -> types.ModuleType:
+    """Load ``todo.py`` as ``hk.todo`` so its relative imports resolve."""
+    if "hk.todo" in sys.modules:
+        return sys.modules["hk.todo"]
+    _install_ha_stubs()
+    # ``from .coordinator import HomeKeeperCoordinator`` — the real module pulls in
+    # HA/store; the entity only needs the name for typing, so stub it if no other
+    # suite has already registered one (test_coordinator_purge.py loads the real one).
+    if "hk.coordinator" not in sys.modules:
+        coord = types.ModuleType("hk.coordinator")
+        coord.HomeKeeperCoordinator = type("HomeKeeperCoordinator", (), {})
+        sys.modules["hk.coordinator"] = coord
+    spec = importlib.util.spec_from_file_location(
+        "hk.todo", str(_COMPONENT_DIR / "todo.py")
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["hk.todo"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+todo = _load_todo()
+TodoItem = sys.modules["homeassistant.components.todo"].TodoItem
+TodoItemStatus = sys.modules["homeassistant.components.todo"].TodoItemStatus
+HomeAssistantError = sys.modules["homeassistant.exceptions"].HomeAssistantError
+
+
+class FakeStore:
+    """The slice of ``store.py`` the entity touches, recording what it was asked."""
+
+    def __init__(self, tasks: dict) -> None:
+        self._tasks = tasks
+        self.completed: list[str] = []
+        self.updated: list[tuple[str, dict]] = []
+        self.raise_on_complete: Exception | None = None
+        self.raise_on_update: Exception | None = None
+
+    def get_task(self, task_id: str):
+        return self._tasks.get(task_id)
+
+    async def complete_task(self, task_id: str):
+        if self.raise_on_complete is not None:
+            raise self.raise_on_complete
+        self.completed.append(task_id)
+        return self._tasks[task_id]
+
+    async def update_task(self, task_id: str, updates: dict):
+        if self.raise_on_update is not None:
+            raise self.raise_on_update
+        self.updated.append((task_id, updates))
+        return self._tasks[task_id]
+
+
+def _entity(*tasks: dict):
+    """Build a to-do entity over an in-memory coordinator/store (no __init__)."""
+    by_id = {task["id"]: task for task in tasks}
+    entity = object.__new__(todo.HomeKeeperTodoListEntity)
+    store = FakeStore(by_id)
+    calls: list[str] = []
+
+    def _record(marker: str):
+        async def _call():
+            calls.append(marker)
+
+        return _call
+
+    entity.coordinator = types.SimpleNamespace(
+        data=by_id,
+        store=store,
+        async_settle_buy_tasks=_record("settle"),
+        async_request_refresh=_record("refresh"),
+    )
+    return entity, store, calls
+
+
+def _task(task_id: str, rec_type: str, **over) -> dict:
+    task = {
+        "id": task_id,
+        "name": f"Task {task_id}",
+        "recurrence_type": rec_type,
+        "next_due": None,
+        "enabled": True,
+    }
+    task.update(over)
+    return task
+
+
+def _uids(entity) -> list[str]:
+    return [item.uid for item in entity.todo_items]
+
+
+# --- todo_items: the dormancy projection ------------------------------------
+
+
+def test_completed_one_off_is_dropped() -> None:
+    """#221: a do-once task that's done is dormant, so it leaves the list."""
+    entity, _store, _calls = _entity(
+        _task("done", "one-off", last_completed="2026-06-16T10:00:00-04:00")
+    )
+    assert _uids(entity) == []
+
+
+def test_armed_one_off_is_listed_with_its_due_date() -> None:
+    entity, _store, _calls = _entity(
+        _task(
+            "armed",
+            "one-off",
+            name="Renew passport",
+            next_due=DUE.isoformat(),
+            notes="bring photos",
+        )
+    )
+    (item,) = entity.todo_items
+    assert item.uid == "armed"
+    assert item.summary == "Renew passport"
+    assert item.status is TodoItemStatus.NEEDS_ACTION
+    assert item.due == date(2026, 7, 15)
+    assert item.description == "bring photos"
+
+
+def test_skipped_one_off_is_dropped() -> None:
+    """A skipped do-once task is dormant too — no last_completed, still gone."""
+    entity, _store, _calls = _entity(_task("skipped", "one-off"))
+    assert _uids(entity) == []
+
+
+def test_recurring_task_stays_listed_after_a_completion() -> None:
+    """The skip keys on dormancy, not on "has been completed"."""
+    entity, _store, _calls = _entity(
+        _task(
+            "float",
+            "floating",
+            next_due=DUE.isoformat(),
+            last_completed="2026-06-16T10:00:00-04:00",
+        )
+    )
+    assert _uids(entity) == ["float"]
+
+
+def test_undated_recurring_task_stays_listed() -> None:
+    """Only the dormant *kinds* are dropped: a floating task with no next_due is
+    malformed data, and hiding it would make it unreachable from the card."""
+    entity, _store, _calls = _entity(_task("float", "floating"))
+    assert _uids(entity) == ["float"]
+
+
+def test_disabled_task_is_dropped() -> None:
+    entity, _store, _calls = _entity(
+        _task("off", "floating", next_due=DUE.isoformat(), enabled=False)
+    )
+    assert _uids(entity) == []
+
+
+@pytest.mark.parametrize("rec_type", ["triggered", "sensor"])
+def test_dormant_triggered_and_sensor_stay_dropped(rec_type: str) -> None:
+    entity, _store, _calls = _entity(_task("dormant", rec_type))
+    assert _uids(entity) == []
+
+
+@pytest.mark.parametrize("rec_type", ["triggered", "sensor"])
+def test_armed_triggered_and_sensor_are_listed(rec_type: str) -> None:
+    entity, _store, _calls = _entity(_task("armed", rec_type, next_due=DUE.isoformat()))
+    assert _uids(entity) == ["armed"]
+
+
+# --- async_update_todo_item: completion routing ------------------------------
+
+
+def test_completing_an_already_completed_one_off_is_ignored() -> None:
+    """A second check-off must not duplicate the record of work done once (#221)."""
+    task = _task("done", "one-off", last_completed="2026-06-16T10:00:00-04:00")
+    entity, store, calls = _entity(task)
+    asyncio.run(
+        entity.async_update_todo_item(
+            TodoItem(uid="done", summary=task["name"], status=TodoItemStatus.COMPLETED)
+        )
+    )
+    assert store.completed == []
+    assert calls == []
+
+
+def test_completing_an_armed_one_off_completes_it() -> None:
+    task = _task("armed", "one-off", next_due=DUE.isoformat())
+    entity, store, calls = _entity(task)
+    asyncio.run(
+        entity.async_update_todo_item(
+            TodoItem(uid="armed", summary=task["name"], status=TodoItemStatus.COMPLETED)
+        )
+    )
+    assert store.completed == ["armed"]
+    assert calls == ["settle"]
+
+
+def test_completing_a_skipped_one_off_still_completes_it() -> None:
+    """Dormant but never completed: the guard is about duplicates, not dormancy."""
+    task = _task("skipped", "one-off")
+    entity, store, _calls = _entity(task)
+    asyncio.run(
+        entity.async_update_todo_item(
+            TodoItem(
+                uid="skipped", summary=task["name"], status=TodoItemStatus.COMPLETED
+            )
+        )
+    )
+    assert store.completed == ["skipped"]
+
+
+def test_completing_a_recurring_task_still_completes_it() -> None:
+    task = _task(
+        "float",
+        "floating",
+        next_due=DUE.isoformat(),
+        last_completed="2026-06-16T10:00:00-04:00",
+    )
+    entity, store, _calls = _entity(task)
+    asyncio.run(
+        entity.async_update_todo_item(
+            TodoItem(uid="float", summary=task["name"], status=TodoItemStatus.COMPLETED)
+        )
+    )
+    assert store.completed == ["float"]
+
+
+def test_completion_rejected_by_the_store_surfaces_as_ha_error() -> None:
+    """A problem-synced task is rejected by the store; the card shows the reason."""
+    task = _task("synced", "triggered", next_due=DUE.isoformat())
+    entity, store, _calls = _entity(task)
+    store.raise_on_complete = todo.TaskValidationError("clear the problem first")
+    with pytest.raises(HomeAssistantError):
+        asyncio.run(
+            entity.async_update_todo_item(
+                TodoItem(
+                    uid="synced", summary=task["name"], status=TodoItemStatus.COMPLETED
+                )
+            )
+        )
+
+
+# --- async_update_todo_item: rename/notes path -------------------------------
+
+
+def test_renaming_an_item_persists_and_refreshes() -> None:
+    """The hoisted get_task lookup must leave the NEEDS_ACTION branch intact."""
+    task = _task("float", "floating", next_due=DUE.isoformat(), notes="old")
+    entity, store, calls = _entity(task)
+    asyncio.run(
+        entity.async_update_todo_item(
+            TodoItem(
+                uid="float",
+                summary="New name",
+                description="new",
+                status=TodoItemStatus.NEEDS_ACTION,
+            )
+        )
+    )
+    assert store.updated == [("float", {"name": "New name", "notes": "new"})]
+    assert calls == ["refresh"]
+
+
+def test_unchanged_item_writes_nothing() -> None:
+    task = _task("float", "floating", next_due=DUE.isoformat(), notes="keep")
+    entity, store, calls = _entity(task)
+    asyncio.run(
+        entity.async_update_todo_item(
+            TodoItem(
+                uid="float",
+                summary=task["name"],
+                description="keep",
+                status=TodoItemStatus.NEEDS_ACTION,
+            )
+        )
+    )
+    assert store.updated == []
+    assert calls == []
+
+
+def test_unknown_uid_on_the_rename_path_is_ignored() -> None:
+    entity, store, calls = _entity(_task("float", "floating", next_due=DUE.isoformat()))
+    asyncio.run(
+        entity.async_update_todo_item(
+            TodoItem(uid="ghost", summary="x", status=TodoItemStatus.NEEDS_ACTION)
+        )
+    )
+    assert store.updated == []
+    assert calls == []

--- a/tests/unit/test_todo.py
+++ b/tests/unit/test_todo.py
@@ -210,6 +210,10 @@ class FakeStore:
         return self._tasks.get(task_id)
 
     async def complete_task(self, task_id: str):
+        # The real store raises KeyError for an unknown id *before* recording
+        # anything (store.complete_task), so mirror that order here.
+        if task_id not in self._tasks:
+            raise KeyError(task_id)
         if self.raise_on_complete is not None:
             raise self.raise_on_complete
         self.completed.append(task_id)
@@ -390,6 +394,35 @@ def test_completing_a_recurring_task_still_completes_it() -> None:
         )
     )
     assert store.completed == ["float"]
+
+
+def test_completing_an_unknown_uid_still_reaches_the_store() -> None:
+    """Hoisting the get_task lookup must not swallow an unknown id.
+
+    ``task`` is now bound before the COMPLETED branch, so ``None`` has to keep
+    falling through to the store — which raises, as it did before the hoist.
+    """
+    entity, store, calls = _entity(_task("float", "floating", next_due=DUE.isoformat()))
+    with pytest.raises(KeyError):
+        asyncio.run(
+            entity.async_update_todo_item(
+                TodoItem(uid="ghost", summary="x", status=TodoItemStatus.COMPLETED)
+            )
+        )
+    assert store.completed == []
+    assert calls == []
+
+
+def test_item_without_a_uid_is_ignored() -> None:
+    entity, store, calls = _entity(_task("float", "floating", next_due=DUE.isoformat()))
+    asyncio.run(
+        entity.async_update_todo_item(
+            TodoItem(uid=None, summary="x", status=TodoItemStatus.COMPLETED)
+        )
+    )
+    assert store.completed == []
+    assert store.updated == []
+    assert calls == []
 
 
 def test_completion_rejected_by_the_store_surfaces_as_ha_error() -> None:


### PR DESCRIPTION
Fixes #221

## What changed

`todo_items` skipped dormant tasks only for `triggered` and `sensor`:

```python
if rec_type in (REC_TRIGGERED, REC_SENSOR) and not due_iso:
    continue
```

But `recurrence.apply_completion` sets `next_due = None` for `one-off` too — its own comment says "all go dormant (every time surface drops them)". A completed do-once task therefore fell through and was emitted like any other task, and since the entity only ever emits `NEEDS_ACTION`, it came back unchecked on every refresh with `due=None`. Both of the reporter's symptoms (stuck `needs_action`, missing `due`) come from that one missing branch — the date the item showed *was* `next_due`.

Nothing could clear it, either: the entity declares no CREATE/DELETE, so `todo.remove_item` isn't available, and `todo.update_item(status: completed)` just re-completed the task and appended a duplicate entry to the history of work done exactly once. `delete_task` was the only way out, and it takes the completion record with it.

Every other surface already had this right — `calendar.py`, `binary_sensor.py`, `sensor.py`, `transitions.py`, `profiles.py`, and the panel's `_statusBucket`, which files exactly this shape under **Completed**. So did the docs: `README.md` ("drops out of every active surface") and `docs/INTEGRATING.md` ("invisible to the to-do list, the calendar…") both already describe the fixed behaviour. The to-do list was the lone holdout: its dormancy skip was written for triggered tasks and later extended to sensor ones, never to one-off.

**The fix** extends that skip. Deliberately not a bare `not due_iso` — a floating or fixed task always carries a `next_due`, so a missing one there is malformed data that should stay visible rather than silently vanish. The rule keys on dormancy, not on "has been completed", so a recurring task that just advanced still lists, and a *skipped* one-off (dormant, no `last_completed`) now leaves too.

**A completion arriving for an already-completed one-off is now ignored**, which is what stops the duplicate entry. It's defence in depth rather than the main fix — once the item is off the list, HA's own `_find_by_uid_or_summary` already rejects the reporter's call — but it still guards direct entity calls, intents, and a capture-then-complete race. The predicate stays local to `todo.py`: `recurrence.one_off_expired` answers a different question ("purgeable yet?") and takes a retention window to do it, and widening the mutmut allowlist for a two-line bug fix isn't worth it. `store.complete_task` is untouched, so the device button, the service, tag scans and notification actions keep working on a dormant one-off (e.g. re-completing after an undo).

### Tests

Red before, green after — verified by reverting the skip and re-running both tiers.

- **`tests/unit/test_todo.py`** (new — `todo.py` had no unit coverage at all). Loads the module under the synthetic `hk` package like `test_calendar.py` does, and pins the projection: completed and skipped one-offs absent, armed one-off present with its due date, a just-completed recurring task still listed, an undated floating task still listed, dormant/armed triggered and sensor regressions, plus the completion-routing and rename paths.
- **`tests/integration/test_lifecycle.py`** — the seeded completed one-off ("Renew car registration") is not on the list while the armed one ("Renew passport") is, and a full create → complete → gone flow that also asserts `todo.update_item` can no longer reach the item and the history stayed at exactly one completion. Asserts on `todo.get_items` rather than the entity's state count.

`test_calendar.py`'s HA-stub installer became gap-filling, matching the contract `test_coordinator_purge.py` and `test_device_heal.py` already document (and claim it follows). It early-returned when *any* `homeassistant` module existed, so whichever suite stubbed first won — `pytest tests/unit/test_device_heal.py tests/unit/test_calendar.py` already failed to collect on `main`, and a third such file made that likelier. A full `pytest tests/unit` run was never affected.

### Worth knowing

- **Buy reminders are `one-off` too.** `reconcile_buy_tasks` deliberately keeps a *completed* reminder in the store while the part is still low ("occupies the episode"). Those also lingered undated on the to-do list and now disappear once checked off — the intended level-triggered behaviour.
- **A skipped one-off** now leaves the to-do list, while the panel's `_statusBucket` still files it under the generic no-schedule bucket. That seems right (the panel is the admin surface where nothing silently disappears), but flagging it so it isn't read as a new bug.
- The committed integration fixture carries five leaked `E2E one-off …` records (pre-existing; `TEST_CREATED_MARKERS` has no `e2e` marker). Out of scope here, but they're why the seeded todo count drops by more than one.
- **`mypy` was not run locally**: this container is Python 3.11, below HA's floor, so `pip install homeassistant` backtracks to an ancient release that fails to build (the #199 trap). `lint.yml` covers it. `ruff check` / `ruff format --check` pass locally.

## Checklist

- [x] Tests run locally — `pytest tests/unit -v` (1068 passed) and the full Docker integration suite (132 passed). No frontend change, so `ci/test-frontend.sh` is unaffected.
- [x] `CHANGELOG.md` updated with `(Fixes #221)` under a new `## [0.16.0b3]` section
- [ ] Panel UI changed → n/a, backend-only (`todo.py`)
- [ ] New user-facing UI surface → n/a, no new surface
- [ ] New user-facing feature → n/a (bug fix); version still bumped to `0.16.0b3` in `manifest.json` + `const.py` so the fix reaches beta testers via HACS, `preview-release` not applied

Also updates `.amazonq/rules/architecture-and-code.md`: the rule said a dormant task falls out of every time surface "for free", which is the assumption that caused this bug. Surfaces that *compare* `next_due` get it free; a surface that **lists** tasks needs an explicit skip.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EqEpXgnmp7qh62kGdJsAAD)_