### PR TITLE
fix(options): stop the options flow wiping notifications and profiles

### DIFF
--- a/.amazonq/rules/architecture-and-code.md
+++ b/.amazonq/rules/architecture-and-code.md
@@ -83,6 +83,12 @@ command for admins; Home Keeper follows that rather than inventing a weaker line
   callers instead of importing them here.
 - Keep the recurrence engine deterministic: functions take an explicit `now`
   rather than calling a clock internally.
+- `options.py` sits on the boundary: it takes a `ConfigEntry` and a `HomeAssistant`,
+  but only ever reads attributes off them, so those two imports live under
+  `if TYPE_CHECKING:` and the module is runtime-pure. That is what lets the fast unit
+  tier assert on the option merge rules every write path shares. Keep it that way —
+  reach for `hass.<something>` at import time and `tests/unit/test_options.py` stops
+  running without the HA harness.
 
 ## Datetimes & timezones
 - All datetimes are timezone-aware. Use `homeassistant.util.dt` (`dt_util`) at the
@@ -575,9 +581,30 @@ The appliance/asset feature lives in `assets.py` (pure model — no HA imports, 
   **coordinator's periodic refresh** uses to auto-delete completed one-offs
   (`recurrence.one_off_expired` collects expired ids; `_purge_expired_one_offs` deletes
   via `store.delete_task`), and `shopping_list_entity` (a `todo.*` entity id; `""` =
-  off) driving the shopping-list mirror. Put a new option's default/coercion in
-  `options.py` and add it to all three surfaces (flow schema, `SET_OPTIONS_SCHEMA`,
-  Settings `settingsSchema`) with `strings.json`/`services.yaml` parity.
+  off) driving the shopping-list mirror. Put a new option's default in
+  `options.py`'s `_empty_options` **and** its coercion in `_normalize` — both, or the
+  key is invisible to every reader and dropped by every writer — then add it to all
+  three surfaces (flow schema *and* `FLOW_OPTIONS`, `SET_OPTIONS_SCHEMA`, Settings
+  `settingsSchema`) with `strings.json`/`services.yaml` parity. `tests/unit/test_options.py`
+  fails the build if a `const.OPTION_*` misses either half.
+  - **The options *flow* merges; it never replaces.** Home Assistant stores whatever
+    an options flow returns from `async_create_entry` as `entry.options` **verbatim**
+    — the whole object, not a patch. The Configure dialog renders only
+    `options.FLOW_OPTIONS`; `profiles`, `notifications` and `dismissed_companions` are
+    panel-only, so returning `user_input` deleted every one of them on each save, and
+    notifications then stopped firing with nothing on screen to say why (`notifier`
+    reads a missing key back as `[]`). `async_step_init` returns
+    `options.merge_flow_input(entry, user_input)`, which starts from `current_options`,
+    resets any `FLOW_OPTIONS` key the submission *omits* — that absence is how clearing
+    the `shopping_list_entity` picker turns the mirror off, and it's the one field with
+    no voluptuous `default` for exactly that reason — routes everything through
+    `_normalize`, and touches nothing else. Guarded at three levels:
+    `tests/unit/test_options.py` (every `const.OPTION_*` reaches `_empty_options` and
+    `_normalize`; `strings.json`'s labels match `FLOW_OPTIONS`),
+    `tests/unit/test_config_flow.py` (the form's schema keys equal `FLOW_OPTIONS`, and
+    the shopping picker still has no `default`), and
+    `tests/integration/test_options_flow.py` (a real save over HA's flow API leaves the
+    panel-only keys byte-identical — the framework contract no mock can see).
   - **A single-value picker needs a clear-coercion on the panel side.** `ha-form`'s
     entity selector emits `undefined` when cleared, and JSON drops it — so the key
     never reaches `_normalize`'s `if key in updates` merge and "turn it off" silently

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,6 +263,13 @@ rules. Keep the rules and `AGENTS.md` consistent with each other.
   baselined silently on startup). A new event isn't done until it's in `docs/EVENTS.md`
   and, if device-facing, in `device_trigger.py` with translation-parity labels. Events
   need no new service. See `.amazonq/rules/architecture-and-code.md` and `docs/EVENTS.md`.
+- **An options flow merges; it never replaces.** Home Assistant stores what an options
+  flow returns from `async_create_entry` as the *entire* `entry.options`, and the
+  Configure dialog renders only `options.FLOW_OPTIONS` — so return
+  `options.merge_flow_input(entry, user_input)`, never `user_input`, or every key the
+  form doesn't render (profiles, notifications, dismissed companions) is deleted on
+  each save. See `.amazonq/rules/architecture-and-code.md` → "Options have three
+  editing surfaces".
 - Tasks are plain dicts: `id, name, notes, recurrence_type, interval, unit|freq,
   anchor, device_id, area_id, enabled, last_completed, next_due, completions[]`.
 - All datetimes are timezone-aware (`homeassistant.util.dt`); `recurrence.py` takes
@@ -313,10 +320,12 @@ bash ci/test-mutation-frontend.sh --all
 - **The mutable surface is an allowlist**, in exactly one place per language:
   `only_mutate` in `[tool.mutmut]` (pyproject.toml) and `mutate` in
   `stryker.conf.json`. It holds the pure Python core (`recurrence`, `models`,
-  `assets`, `reconcile`, `notifications`, `sensor_tasks`, `problem_tasks`,
-  `inventory`, `profiles`, `documents`, `events`, `transitions`) and the focused
-  frontend modules (`utils`, `forms`, `card-filter`, `documents`, `markdown`,
-  `i18n`, `limits`). Excluded on purpose: everything importing Home Assistant
+  `assets`, `reconcile`, `shopping`, `notifications`, `sensor_tasks`,
+  `problem_tasks`, `inventory`, `profiles`, `documents`, `events`, `transitions`,
+  `tags`, `options`) and the focused frontend modules (`utils`, `forms`,
+  `card-filter`, `documents`, `markdown`, `i18n`, `limits`). `options.py` counts as
+  pure because its Home Assistant imports are `TYPE_CHECKING`-only. Excluded on
+  purpose: everything else importing Home Assistant
   (only the Docker tiers cover it — far too slow to run once per mutant),
   `const.py` / `companions_catalog.py` (data, not logic), `backend_i18n.py` (pure
   but with no unit-test entry point), `testing.py` (already coverage-omitted), and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to Home Keeper are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
 
+## [Unreleased]
+
+### Fixed
+
+- **Opening Configure no longer wipes your notifications and profiles.** Saving the
+  integration's options dialog (Settings → Devices & services → Home Keeper →
+  Configure) replaced the whole settings object with just the seven fields on that
+  form. Every notification, every profile, and every companion suggestion you had
+  dismissed was deleted. Notifications then stopped arriving, with nothing on screen
+  to say why. The dialog now changes only its own fields and leaves what you set in
+  the panel alone.
+
 ## [0.16.0b5]
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,8 @@ Three gates worth repeating because they are easy to miss:
   executes that code without asserting anything that would catch it being wrong —
   kill it with a real assertion, or annotate a genuinely equivalent mutant with a
   reason. Never lower the threshold to get green. The mutable surface is an
-  allowlist: `only_mutate` in `[tool.mutmut]` and `mutate` in `stryker.conf.json`.
+  allowlist: `only_mutate` in `[tool.mutmut]` and `mutate` in `stryker.conf.json`
+  (the pure Python core — including `options.py`, whose HA imports are
+  `TYPE_CHECKING`-only — plus the focused frontend modules).
 
 See AGENTS.md "Workflow" for the first two and "Mutation testing" for the third.

--- a/custom_components/home_keeper/config_flow.py
+++ b/custom_components/home_keeper/config_flow.py
@@ -6,6 +6,11 @@ flow exposes the integration-wide settings — the opt-in syncing of
 ``device_class: problem`` binary sensors as tasks (with entity/area/label
 exclusions), completed one-off retention, and the to-do list auto-buy reminders
 are mirrored onto.
+
+That form covers only ``options.FLOW_OPTIONS``; profiles, notifications and
+dismissed companions are edited from the panel and never appear here. Since Home
+Assistant stores an options flow's result as the *entire* ``entry.options``, saving
+goes through ``options.merge_flow_input`` so those keep their values.
 """
 
 from __future__ import annotations
@@ -20,9 +25,10 @@ from homeassistant.config_entries import (
     ConfigFlowResult,
     OptionsFlow,
 )
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import selector
 
+from . import options
 from .const import (
     DOMAIN,
     OPTION_ONE_OFF_RETENTION_DAYS,
@@ -36,6 +42,74 @@ from .const import (
 )
 from .shopping import TODO_DOMAIN
 from .shopping_sync import own_todo_entity_ids
+
+
+def _options_schema(hass: HomeAssistant, current: dict[str, Any]) -> vol.Schema:
+    """Build the options form, defaulted from *current* (an ``options`` dict).
+
+    Its keys must be exactly ``options.FLOW_OPTIONS``, in this order —
+    ``tests/unit/test_config_flow.py`` fails the build if they drift, because both
+    directions lose data. A field here that the tuple omits is discarded on save; a
+    key in the tuple that this form omits is *cleared* on every save.
+    """
+    return vol.Schema(
+        {
+            vol.Required(
+                OPTION_SYNC_PROBLEM_SENSORS,
+                default=current[OPTION_SYNC_PROBLEM_SENSORS],
+            ): selector.BooleanSelector(),
+            vol.Optional(
+                OPTION_PROBLEM_SENSOR_EXCLUDE_ENTITIES,
+                default=current[OPTION_PROBLEM_SENSOR_EXCLUDE_ENTITIES],
+            ): selector.EntitySelector(
+                selector.EntitySelectorConfig(
+                    domain="binary_sensor",
+                    device_class=BinarySensorDeviceClass.PROBLEM,
+                    multiple=True,
+                )
+            ),
+            vol.Optional(
+                OPTION_PROBLEM_SENSOR_EXCLUDE_DEVICES,
+                default=current[OPTION_PROBLEM_SENSOR_EXCLUDE_DEVICES],
+            ): selector.DeviceSelector(selector.DeviceSelectorConfig(multiple=True)),
+            vol.Optional(
+                OPTION_PROBLEM_SENSOR_EXCLUDE_AREAS,
+                default=current[OPTION_PROBLEM_SENSOR_EXCLUDE_AREAS],
+            ): selector.AreaSelector(selector.AreaSelectorConfig(multiple=True)),
+            vol.Optional(
+                OPTION_PROBLEM_SENSOR_EXCLUDE_LABELS,
+                default=current[OPTION_PROBLEM_SENSOR_EXCLUDE_LABELS],
+            ): selector.LabelSelector(selector.LabelSelectorConfig(multiple=True)),
+            # Auto-delete completed one-off tasks this many days after completion;
+            # 0 keeps them forever.
+            vol.Optional(
+                OPTION_ONE_OFF_RETENTION_DAYS,
+                default=current[OPTION_ONE_OFF_RETENTION_DAYS],
+            ): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0, max=3650, step=1, mode=selector.NumberSelectorMode.BOX
+                )
+            ),
+            # The to-do list auto-buy reminders are mirrored onto. Deliberately
+            # has no ``default``: clearing the picker then leaves the key out of
+            # ``user_input`` entirely, which is how the mirror is turned off —
+            # ``options.merge_flow_input`` reads a missing ``FLOW_OPTIONS`` key as
+            # "the user cleared this" and resets it to ``""``. Home Keeper's own
+            # to-do list is excluded, since mirroring a list onto itself is a loop
+            # (and ours accepts no new items anyway).
+            vol.Optional(
+                OPTION_SHOPPING_LIST_ENTITY,
+                description={
+                    "suggested_value": current[OPTION_SHOPPING_LIST_ENTITY] or None
+                },
+            ): selector.EntitySelector(
+                selector.EntitySelectorConfig(
+                    domain=TODO_DOMAIN,
+                    exclude_entities=own_todo_entity_ids(hass),
+                )
+            ),
+        }
+    )
 
 
 class HomeKeeperConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -68,69 +142,23 @@ class HomeKeeperOptionsFlow(OptionsFlow):
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Single options step. Saving triggers a reload (see __init__)."""
-        if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
+        """Single options step. Saving triggers a reload (see __init__).
 
-        current = self.config_entry.options
-        schema = vol.Schema(
-            {
-                vol.Required(
-                    OPTION_SYNC_PROBLEM_SENSORS,
-                    default=current.get(OPTION_SYNC_PROBLEM_SENSORS, False),
-                ): selector.BooleanSelector(),
-                vol.Optional(
-                    OPTION_PROBLEM_SENSOR_EXCLUDE_ENTITIES,
-                    default=current.get(OPTION_PROBLEM_SENSOR_EXCLUDE_ENTITIES, []),
-                ): selector.EntitySelector(
-                    selector.EntitySelectorConfig(
-                        domain="binary_sensor",
-                        device_class=BinarySensorDeviceClass.PROBLEM,
-                        multiple=True,
-                    )
-                ),
-                vol.Optional(
-                    OPTION_PROBLEM_SENSOR_EXCLUDE_DEVICES,
-                    default=current.get(OPTION_PROBLEM_SENSOR_EXCLUDE_DEVICES, []),
-                ): selector.DeviceSelector(
-                    selector.DeviceSelectorConfig(multiple=True)
-                ),
-                vol.Optional(
-                    OPTION_PROBLEM_SENSOR_EXCLUDE_AREAS,
-                    default=current.get(OPTION_PROBLEM_SENSOR_EXCLUDE_AREAS, []),
-                ): selector.AreaSelector(selector.AreaSelectorConfig(multiple=True)),
-                vol.Optional(
-                    OPTION_PROBLEM_SENSOR_EXCLUDE_LABELS,
-                    default=current.get(OPTION_PROBLEM_SENSOR_EXCLUDE_LABELS, []),
-                ): selector.LabelSelector(selector.LabelSelectorConfig(multiple=True)),
-                # Auto-delete completed one-off tasks this many days after completion;
-                # 0 keeps them forever.
-                vol.Optional(
-                    OPTION_ONE_OFF_RETENTION_DAYS,
-                    default=current.get(OPTION_ONE_OFF_RETENTION_DAYS, 0),
-                ): selector.NumberSelector(
-                    selector.NumberSelectorConfig(
-                        min=0, max=3650, step=1, mode=selector.NumberSelectorMode.BOX
-                    )
-                ),
-                # The to-do list auto-buy reminders are mirrored onto. Deliberately
-                # has no ``default``: clearing the picker then leaves the key out of
-                # ``user_input`` entirely, which ``options.current_options`` reads
-                # back as ``""`` — the off switch. Home Keeper's own to-do list is
-                # excluded, since mirroring a list onto itself is a loop (and ours
-                # accepts no new items anyway).
-                vol.Optional(
-                    OPTION_SHOPPING_LIST_ENTITY,
-                    description={
-                        "suggested_value": current.get(OPTION_SHOPPING_LIST_ENTITY)
-                        or None
-                    },
-                ): selector.EntitySelector(
-                    selector.EntitySelectorConfig(
-                        domain=TODO_DOMAIN,
-                        exclude_entities=own_todo_entity_ids(self.hass),
-                    )
-                ),
-            }
+        Home Assistant stores what this returns as ``entry.options`` **verbatim** —
+        the whole object, not a patch — and the form renders only
+        ``options.FLOW_OPTIONS``. So the submission is merged onto the current
+        options rather than replacing them: returning ``user_input`` directly deleted
+        every saved profile, notification and dismissed companion on each save.
+        """
+        if user_input is not None:
+            return self.async_create_entry(
+                title="",
+                data=options.merge_flow_input(self.config_entry, user_input),
+            )
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=_options_schema(
+                self.hass, options.current_options(self.config_entry)
+            ),
         )
-        return self.async_show_form(step_id="init", data_schema=schema)

--- a/custom_components/home_keeper/config_flow.py
+++ b/custom_components/home_keeper/config_flow.py
@@ -51,6 +51,12 @@ def _options_schema(hass: HomeAssistant, current: dict[str, Any]) -> vol.Schema:
     ``tests/unit/test_config_flow.py`` fails the build if they drift, because both
     directions lose data. A field here that the tuple omits is discarded on save; a
     key in the tuple that this form omits is *cleared* on every save.
+
+    A field's ``default`` decides what an empty submission means, so choose it
+    deliberately when adding one. With a ``default``, voluptuous fills the value back
+    in and the key always reaches ``merge_flow_input``. Without one — which only
+    ``shopping_list_entity`` wants — the key drops out when the user clears it, and
+    that absence is read as "cleared" and reset.
     """
     return vol.Schema(
         {

--- a/custom_components/home_keeper/options.py
+++ b/custom_components/home_keeper/options.py
@@ -130,7 +130,22 @@ def _coerce_days(value: Any) -> int:
 
 
 def _normalize(updates: dict[str, Any], base: dict[str, Any]) -> dict[str, Any]:
-    """Merge *updates* onto *base*, coercing to the stored shape (bool/int/id list)."""
+    """Merge *updates* onto *base*, coercing to the stored shape (bool/int/id list).
+
+    The one coercion table, shared by every read and every write. Each branch exists
+    because the value can arrive from a form, a service call or an automation, none of
+    which is obliged to send the stored shape:
+
+    - **the sync toggle** — anything truthy becomes a real ``bool``
+    - **retention days** — a ``NumberSelector`` sends a float, garbage becomes ``0``
+    - **the shopping target** — anything unusable collapses to ``""``, the off switch
+    - **profiles / notifications** — their own normalizers fill in per-item defaults
+    - **id lists** — stringified, and empties dropped: no registry id is falsy, and
+      without the filter a ``None`` in the list would be stored as ``"None"``
+
+    A key absent from *updates* keeps its value from *base*, which is what makes an
+    update partial.
+    """
     merged = dict(base)
     if OPTION_SYNC_PROBLEM_SENSORS in updates:
         merged[OPTION_SYNC_PROBLEM_SENSORS] = bool(updates[OPTION_SYNC_PROBLEM_SENSORS])
@@ -154,7 +169,7 @@ def _normalize(updates: dict[str, Any], base: dict[str, Any]) -> dict[str, Any]:
         )
     for key in _LIST_OPTIONS:
         if key in updates:
-            merged[key] = [str(x) for x in (updates[key] or [])]
+            merged[key] = [str(x) for x in (updates[key] or []) if x]
     return merged
 
 
@@ -179,6 +194,10 @@ def merge_flow_input(entry: ConfigEntry, user_input: dict[str, Any]) -> dict[str
 
     Keys outside ``FLOW_OPTIONS`` are ignored even when present: the form can only
     change what the form owns.
+
+    This is the options flow's entry point and nothing else's. The ``set_options``
+    service and the panel's Settings tab already send partial updates, so they go
+    through ``async_set_options``, which persists and reloads as well.
     """
     empty = _empty_options()
     submitted = {

--- a/custom_components/home_keeper/options.py
+++ b/custom_components/home_keeper/options.py
@@ -10,14 +10,21 @@ normalization live here so they can't drift. Writing options goes through
 service / websocket path (``async_set_options``) additionally *awaits* that reload so
 the caller sees the reconciled task set immediately (the options flow, which updates
 the entry directly, still relies on the update listener).
+
+Two of those three surfaces send a *partial* update, which ``_normalize`` merges onto
+what is already stored. The options flow can't: Home Assistant stores whatever an
+options flow returns from ``async_create_entry`` as ``entry.options`` **verbatim** —
+the whole object, not a patch — and its form renders only ``FLOW_OPTIONS``. So it goes
+through ``merge_flow_input``, which turns the submission back into a partial update.
+
+This module imports Home Assistant only for type annotations, so the unit tier can
+exercise the merge rules without the HA test harness. Keep it that way — see
+``tests/unit/test_options.py``.
 """
 
 from __future__ import annotations
 
-from typing import Any
-
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from typing import TYPE_CHECKING, Any
 
 from . import notifications, profiles, shopping
 from .const import (
@@ -33,6 +40,10 @@ from .const import (
     OPTION_SYNC_PROBLEM_SENSORS,
 )
 
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+
 # The exclusion options (and the dismissed-companions list) are id/domain lists;
 # the sync toggle is the only boolean.
 _LIST_OPTIONS = (
@@ -41,6 +52,46 @@ _LIST_OPTIONS = (
     OPTION_PROBLEM_SENSOR_EXCLUDE_AREAS,
     OPTION_PROBLEM_SENSOR_EXCLUDE_LABELS,
     OPTION_DISMISSED_COMPANIONS,
+)
+
+
+def _empty_options() -> dict[str, Any]:
+    """Every option key at its default: toggle off, lists empty, pickers cleared.
+
+    The single definition of *which keys exist* and *what each looks like holding
+    nothing*. ``current_options`` builds on it and ``merge_flow_input`` resets a
+    cleared form field to its entry here, so a default and a "cleared" value can
+    never disagree. Returns a fresh dict each call — the list values are handed out
+    to callers.
+    """
+    return {
+        OPTION_SYNC_PROBLEM_SENSORS: False,
+        OPTION_ONE_OFF_RETENTION_DAYS: 0,
+        OPTION_SHOPPING_LIST_ENTITY: "",
+        OPTION_PROFILES: [],
+        OPTION_NOTIFICATIONS: [],
+        **{key: [] for key in _LIST_OPTIONS},
+    }
+
+
+# Every option key, in the order ``_empty_options`` declares them. A key missing from
+# there is invisible to every reader and silently dropped by every writer, so
+# ``tests/unit/test_options.py`` asserts this covers every ``const.OPTION_*``.
+ALL_OPTIONS: tuple[str, ...] = tuple(_empty_options())
+
+# The keys the options flow's form renders (``config_flow._options_schema``), in form
+# order. A key here that a submission *omits* was cleared by the user and resets; a key
+# **not** here is not the form's to touch and is preserved verbatim. Pinned to the
+# schema by ``tests/unit/test_config_flow.py`` and to ``strings.json`` by
+# ``tests/unit/test_options.py``.
+FLOW_OPTIONS: tuple[str, ...] = (
+    OPTION_SYNC_PROBLEM_SENSORS,
+    OPTION_PROBLEM_SENSOR_EXCLUDE_ENTITIES,
+    OPTION_PROBLEM_SENSOR_EXCLUDE_DEVICES,
+    OPTION_PROBLEM_SENSOR_EXCLUDE_AREAS,
+    OPTION_PROBLEM_SENSOR_EXCLUDE_LABELS,
+    OPTION_ONE_OFF_RETENTION_DAYS,
+    OPTION_SHOPPING_LIST_ENTITY,
 )
 
 # Entry ids whose reload an explicit caller (the ``set_options`` service / the
@@ -60,24 +111,13 @@ def current_options(entry: ConfigEntry) -> dict[str, Any]:
 
     A fully-populated dict keeps the panel form and the options flow simple — they
     never have to special-case a missing key.
+
+    Reading is just ``_normalize`` over the defaults: what's stored is a partial
+    update onto an empty options object. Sharing the one coercion table means a read
+    and a write can't disagree about a key's shape, which is what makes
+    ``async_set_options``' ``merged == base`` short-circuit trustworthy.
     """
-    opts = dict(entry.options)
-    result: dict[str, Any] = {
-        OPTION_SYNC_PROBLEM_SENSORS: bool(opts.get(OPTION_SYNC_PROBLEM_SENSORS, False)),
-        OPTION_ONE_OFF_RETENTION_DAYS: _coerce_days(
-            opts.get(OPTION_ONE_OFF_RETENTION_DAYS, 0)
-        ),
-        OPTION_SHOPPING_LIST_ENTITY: shopping.normalize_target(
-            opts.get(OPTION_SHOPPING_LIST_ENTITY, "")
-        ),
-        OPTION_PROFILES: profiles.normalize_profiles(opts.get(OPTION_PROFILES, [])),
-        OPTION_NOTIFICATIONS: notifications.normalize_notifications(
-            opts.get(OPTION_NOTIFICATIONS, [])
-        ),
-    }
-    for key in _LIST_OPTIONS:
-        result[key] = list(opts.get(key, []) or [])
-    return result
+    return _normalize(dict(entry.options), _empty_options())
 
 
 def _coerce_days(value: Any) -> int:
@@ -116,6 +156,36 @@ def _normalize(updates: dict[str, Any], base: dict[str, Any]) -> dict[str, Any]:
         if key in updates:
             merged[key] = [str(x) for x in (updates[key] or [])]
     return merged
+
+
+def merge_flow_input(entry: ConfigEntry, user_input: dict[str, Any]) -> dict[str, Any]:
+    """Merge an options-*flow* submission onto *entry*'s current options.
+
+    Home Assistant stores whatever an options flow returns from
+    ``async_create_entry`` as ``entry.options`` **verbatim** — the whole object, not a
+    patch. The form renders only ``FLOW_OPTIONS``, so returning the submission as-is
+    deleted every saved profile, notification and dismissed companion on each save,
+    and notifications then stopped firing (``notifier`` reads a missing key back as an
+    empty list, so there was nothing on screen to say why). Start from
+    ``current_options`` and change nothing the form doesn't own.
+
+    A ``FLOW_OPTIONS`` key *missing* from *user_input* was **cleared** by the user and
+    resets to its ``_empty_options`` value — the opposite of a key the form doesn't
+    render, which is preserved. That distinction is load-bearing:
+    ``shopping_list_entity`` is declared with no voluptuous ``default`` precisely so a
+    cleared picker drops out of the submission, and that absence is how the
+    shopping-list mirror is turned off. A plain ``{**current, **user_input}`` would
+    resurrect the old entity id instead.
+
+    Keys outside ``FLOW_OPTIONS`` are ignored even when present: the form can only
+    change what the form owns.
+    """
+    empty = _empty_options()
+    submitted = {
+        key: user_input[key] if key in user_input else empty[key]
+        for key in FLOW_OPTIONS
+    }
+    return _normalize(submitted, current_options(entry))
 
 
 async def async_set_options(

--- a/custom_components/home_keeper/quality_scale.yaml
+++ b/custom_components/home_keeper/quality_scale.yaml
@@ -25,7 +25,12 @@ rules:
   config-flow: done
   config-flow-test-coverage:
     status: done
-    comment: tests/integration covers setup and the options flow.
+    comment: >-
+      tests/integration/test_lifecycle.py covers setup;
+      tests/integration/test_options_flow.py drives the real options flow over HA's
+      flow API and asserts a save leaves the panel-only options intact;
+      tests/unit/test_config_flow.py pins the form's schema to options.FLOW_OPTIONS,
+      and tests/unit/test_options.py covers the merge and normalization rules.
   dependency-transparency:
     status: done
     comment: No external requirements; depends only on HA core http + frontend.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,9 @@ only_mutate = [
     "custom_components/home_keeper/events.py",
     "custom_components/home_keeper/transitions.py",
     "custom_components/home_keeper/tags.py",
+    # Imports Home Assistant only under ``TYPE_CHECKING``, so the fast unit tier runs
+    # it directly (tests/unit/test_options.py) — see "Pure, HA-free core".
+    "custom_components/home_keeper/options.py",
 ]
 pytest_add_cli_args_test_selection = ["tests/unit"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,10 @@ _PURE_MODULES = (
     "profiles",
     "notifications",
     "tags",
+    # ``options`` imports Home Assistant only under ``TYPE_CHECKING``, so the merge
+    # and normalization rules every write path shares are testable here. Keep it
+    # after the siblings it does ``from . import`` (notifications/profiles/shopping).
+    "options",
 )
 
 

--- a/tests/integration/test_options_flow.py
+++ b/tests/integration/test_options_flow.py
@@ -1,0 +1,155 @@
+"""The integration's Configure dialog must not delete what it doesn't render.
+
+Home Assistant stores whatever an options flow returns from ``async_create_entry``
+as ``entry.options`` **verbatim** — the whole object, not a patch. That is a framework
+contract no mock can see, so it needs asserting against a real HA: the unit tier can
+prove ``options.merge_flow_input`` merges correctly, but only this tier proves the
+flow's return value is what lands on disk.
+
+The form renders seven of the ten option keys. Before ``merge_flow_input``, pressing
+Submit deleted every saved profile, notification and dismissed companion — and
+notifications then stopped firing, with nothing on screen to say why.
+
+The flow is driven over HA's REST config API; options are read back over the
+``home_keeper/get_options`` websocket command, since the REST config-entries listing
+doesn't expose them.
+"""
+
+import time
+
+import pytest
+from conftest import HA_URL, call_service
+from ha_registry import ws_command
+
+ENTRY_ID = "home_keeper_test_entry"
+
+# Seeded by this module rather than relied on from the fixture: test_notifications.py
+# deliberately clears profiles and notifications so later tests start clean, and it
+# sorts ahead of this file.
+PROFILE = {
+    "id": "options_flow_profile",
+    "name": "Options flow profile",
+    "filter": {"status": "overdue", "labels": [], "areas": [], "devices": []},
+}
+NOTIFICATION = {
+    "id": "options_flow_notification",
+    "name": "Options flow notification",
+    "profile_id": PROFILE["id"],
+    "targets": [],
+}
+DISMISSED = ["options_flow_companion"]
+
+
+def _start_flow(ha) -> str:
+    """Open the options flow for the seeded entry and return its flow id."""
+    r = ha.post(
+        f"{HA_URL}/api/config/config_entries/options/flow", json={"handler": ENTRY_ID}
+    )
+    r.raise_for_status()
+    body = r.json()
+    assert body["step_id"] == "init", body
+    return body["flow_id"]
+
+
+def _submit(ha, flow_id: str, user_input: dict) -> dict:
+    r = ha.post(
+        f"{HA_URL}/api/config/config_entries/options/flow/{flow_id}", json=user_input
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def _options(ha, timeout: int = 60) -> dict:
+    """Read the current options, retrying past the entry's post-save reload.
+
+    Saving updates the entry, which fires the update listener and reloads it; the
+    websocket command answers with an error while there's no active coordinator.
+    """
+    deadline = time.monotonic() + timeout
+    last = None
+    while time.monotonic() < deadline:
+        try:
+            return ws_command(ha, "home_keeper/get_options")["options"]
+        except AssertionError as err:  # mid-reload — retry
+            last = err
+        time.sleep(1)
+    raise TimeoutError(f"get_options never succeeded. Last failure: {last}")
+
+
+@pytest.fixture
+def panel_options(ha):
+    """Seed the three panel-only options, and clear them again afterwards."""
+    call_service(
+        ha,
+        "home_keeper",
+        "set_options",
+        {
+            "profiles": [PROFILE],
+            "notifications": [NOTIFICATION],
+            "dismissed_companions": DISMISSED,
+        },
+    )
+    seeded = _options(ha)
+    assert seeded["profiles"], "seeding failed; the assertions below would be vacuous"
+    assert seeded["notifications"], "seeding failed"
+    yield seeded
+    call_service(
+        ha,
+        "home_keeper",
+        "set_options",
+        {
+            "profiles": [],
+            "notifications": [],
+            "dismissed_companions": [],
+            "one_off_retention_days": 0,
+            "shopping_list_entity": "",
+        },
+    )
+
+
+def test_options_flow_save_keeps_the_panel_only_options(ha, panel_options):
+    """Submitting the Configure dialog leaves profiles/notifications untouched."""
+    before = panel_options
+
+    flow_id = _start_flow(ha)
+    result = _submit(
+        ha,
+        flow_id,
+        {
+            "sync_problem_sensors": before["sync_problem_sensors"],
+            "problem_sensor_exclude_entities": [],
+            "problem_sensor_exclude_devices": [],
+            "problem_sensor_exclude_areas": [],
+            "problem_sensor_exclude_labels": [],
+            # A real change, so the save actually writes and reloads.
+            "one_off_retention_days": 7,
+            # shopping_list_entity omitted: a cleared picker drops out of the
+            # submission entirely, and that absence is how the mirror is turned off.
+        },
+    )
+    assert result["type"] == "create_entry", result
+
+    after = _options(ha)
+    assert after["profiles"] == before["profiles"]
+    assert after["notifications"] == before["notifications"]
+    assert after["dismissed_companions"] == DISMISSED
+    # ...and the fields the form does own took effect.
+    assert after["one_off_retention_days"] == 7
+    assert after["shopping_list_entity"] == ""
+
+
+def test_options_flow_form_is_prefilled_from_the_current_options(ha, panel_options):
+    """Opening the dialog offers the stored values back, not the defaults."""
+    call_service(ha, "home_keeper", "set_options", {"one_off_retention_days": 21})
+
+    flow_id = _start_flow(ha)
+    try:
+        r = ha.get(f"{HA_URL}/api/config/config_entries/options/flow/{flow_id}")
+        r.raise_for_status()
+        fields = {
+            field["name"]: field for field in r.json()["data_schema"] if "name" in field
+        }
+
+        assert fields["one_off_retention_days"]["default"] == 21
+    finally:
+        ha.delete(f"{HA_URL}/api/config/config_entries/options/flow/{flow_id}")

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -1,0 +1,178 @@
+"""The options flow's form, and the save that must not clobber what it can't see.
+
+``config_flow.py`` imports Home Assistant and voluptuous, so the whole module is
+skipped when those aren't installed; CI's full unit suite installs them
+(``ci/install-deps.sh``). The HA-free half of the same contract — the merge rules and
+the ``strings.json`` drift guard — lives in ``test_options.py`` and always runs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import hk_const as const  # type: ignore[import-not-found]
+import hk_options as opts  # type: ignore[import-not-found]
+import pytest
+
+pytest.importorskip("homeassistant")
+pytest.importorskip("voluptuous")
+
+_COMPONENT_DIR = (
+    Path(__file__).resolve().parents[2] / "custom_components" / "home_keeper"
+)
+
+# A package of its own, not ``hk``: loading ``config_flow`` pulls in a real
+# ``shopping_sync`` sibling through ``from .shopping_sync import …``, which would
+# collide with the fake ``hk.shopping_sync`` that ``test_shopping_sync.py`` installs
+# (whichever test ran first would win). ``hk_cf.*`` can't clash with anything.
+_PKG = "hk_cf"
+
+_FULL: dict[str, Any] = {
+    const.OPTION_SYNC_PROBLEM_SENSORS: True,
+    const.OPTION_ONE_OFF_RETENTION_DAYS: 30,
+    const.OPTION_SHOPPING_LIST_ENTITY: "todo.kitchen_list",
+    const.OPTION_DISMISSED_COMPANIONS: ["acme_vacuum"],
+    const.OPTION_PROFILES: [
+        {"id": "p1", "name": "My chores", "filter": {"status": "overdue"}}
+    ],
+    const.OPTION_NOTIFICATIONS: [
+        {"id": "n1", "name": "Walk", "profile_id": "p1", "targets": []}
+    ],
+}
+
+
+def _config_flow() -> types.ModuleType:
+    """Load ``config_flow.py`` under ``hk_cf``, with a stubbed ``shopping_sync``.
+
+    The stub is only there to keep the to-do exclusion list out of an entity
+    registry — nothing here is testing which lists get excluded.
+    """
+    module = sys.modules.get(f"{_PKG}.config_flow")
+    if module is not None:
+        return module
+
+    pkg = types.ModuleType(_PKG)
+    pkg.__path__ = [str(_COMPONENT_DIR)]  # type: ignore[attr-defined]
+    sys.modules[_PKG] = pkg
+
+    shopping_sync = types.ModuleType(f"{_PKG}.shopping_sync")
+    shopping_sync.own_todo_entity_ids = lambda hass: []  # type: ignore[attr-defined]
+    sys.modules[f"{_PKG}.shopping_sync"] = shopping_sync
+    # Alias rather than let a second copy of options.py load under this package, so
+    # the flow merges through the very module these tests assert against.
+    sys.modules[f"{_PKG}.options"] = opts
+
+    spec = importlib.util.spec_from_file_location(
+        f"{_PKG}.config_flow", str(_COMPONENT_DIR / "config_flow.py")
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[f"{_PKG}.config_flow"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _entry(options: dict[str, Any]) -> Any:
+    return types.SimpleNamespace(options=options)
+
+
+def test_form_schema_matches_flow_options() -> None:
+    """The form's fields are exactly ``options.FLOW_OPTIONS``, in order.
+
+    Both directions lose data, which is why this is an equality and not a subset. A
+    field the tuple omits is discarded by ``merge_flow_input`` the moment it's saved;
+    a tuple key with no field is treated as *cleared* and reset on every save.
+    """
+    cf = _config_flow()
+
+    schema = cf._options_schema(object(), opts.current_options(_entry({})))
+
+    assert [str(key) for key in schema.schema] == list(opts.FLOW_OPTIONS)
+
+
+def test_form_defaults_come_from_the_normalized_options() -> None:
+    """Garbage on disk must not reach the form as a default."""
+    cf = _config_flow()
+    current = opts.current_options(
+        _entry({const.OPTION_ONE_OFF_RETENTION_DAYS: "not-a-number"})
+    )
+
+    schema = cf._options_schema(object(), current)
+    # An unset ``default`` is voluptuous' ``UNDEFINED`` sentinel; a set one is a
+    # factory. The shopping picker deliberately has none — see ``merge_flow_input``.
+    defaults = {
+        str(key): key.default()
+        for key in schema.schema
+        if callable(getattr(key, "default", None))
+    }
+
+    assert defaults[const.OPTION_ONE_OFF_RETENTION_DAYS] == 0
+
+
+def test_the_shopping_picker_has_no_default() -> None:
+    """Clearing the mirror depends on the key dropping out of the submission.
+
+    Give this field a ``default`` and voluptuous fills the old entity id back in on a
+    cleared picker, so ``merge_flow_input`` never sees it as cleared and the mirror
+    can't be turned off from the Configure dialog. The ``suggested_value`` in its
+    ``description`` is what pre-fills the picker instead.
+    """
+    cf = _config_flow()
+    current = opts.current_options(_entry(_FULL))
+
+    schema = cf._options_schema(object(), current)
+    picker = next(
+        key for key in schema.schema if str(key) == const.OPTION_SHOPPING_LIST_ENTITY
+    )
+
+    assert not callable(getattr(picker, "default", None))
+    assert picker.description == {"suggested_value": "todo.kitchen_list"}
+
+
+def test_saving_the_form_preserves_the_panel_options() -> None:
+    """The bug, at the flow: a save must not delete what the form never rendered.
+
+    ``OptionsFlow.config_entry`` is a property whose backing has changed across Home
+    Assistant versions, so this overrides it on a subclass rather than assigning to
+    it or reaching into the real class.
+    """
+    cf = _config_flow()
+    entry = _entry(_FULL)
+
+    class _Flow(cf.HomeKeeperOptionsFlow):  # type: ignore[misc, name-defined]
+        @property
+        def config_entry(self) -> Any:
+            return entry
+
+    flow = _Flow()
+    flow.async_create_entry = lambda **kwargs: kwargs  # type: ignore[method-assign]
+
+    result = asyncio.run(
+        flow.async_step_init(
+            {
+                const.OPTION_SYNC_PROBLEM_SENSORS: False,
+                const.OPTION_PROBLEM_SENSOR_EXCLUDE_ENTITIES: [],
+                const.OPTION_PROBLEM_SENSOR_EXCLUDE_DEVICES: [],
+                const.OPTION_PROBLEM_SENSOR_EXCLUDE_AREAS: [],
+                const.OPTION_PROBLEM_SENSOR_EXCLUDE_LABELS: [],
+                const.OPTION_ONE_OFF_RETENTION_DAYS: 7,
+                # shopping_list_entity omitted: the cleared-picker case.
+            }
+        )
+    )
+
+    saved = result["data"]
+    expected = opts.current_options(entry)
+    assert saved[const.OPTION_PROFILES] == expected[const.OPTION_PROFILES]
+    assert saved[const.OPTION_NOTIFICATIONS] == expected[const.OPTION_NOTIFICATIONS]
+    assert saved[const.OPTION_DISMISSED_COMPANIONS] == ["acme_vacuum"]
+    assert saved[const.OPTION_ONE_OFF_RETENTION_DAYS] == 7
+    assert saved[const.OPTION_SYNC_PROBLEM_SENSORS] is False
+    assert saved[const.OPTION_SHOPPING_LIST_ENTITY] == ""
+    # Home Assistant stores this dict as the whole of ``entry.options``.
+    assert set(saved) == set(opts.ALL_OPTIONS)

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -263,6 +263,27 @@ def test_current_options_coerces_stored_garbage() -> None:
     assert result[const.OPTION_DISMISSED_COMPANIONS] == ["1", "2"]
 
 
+def test_id_lists_drop_empty_entries() -> None:
+    """No registry id is falsy, so a falsy entry is junk — and would stringify badly.
+
+    Without the filter a ``None`` in an exclusion list is stored as the literal
+    ``"None"``, which then sits in the entry forever matching nothing.
+    """
+    stored = {
+        const.OPTION_PROBLEM_SENSOR_EXCLUDE_ENTITIES: [
+            "binary_sensor.real",
+            None,
+            "",
+        ],
+    }
+
+    result = opts.current_options(_entry(stored))
+
+    assert result[const.OPTION_PROBLEM_SENSOR_EXCLUDE_ENTITIES] == [
+        "binary_sensor.real"
+    ]
+
+
 def test_current_options_hands_out_fresh_lists() -> None:
     """Callers mutating a returned list must not corrupt the next read."""
     first = opts.current_options(_entry(_FULL))

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -1,0 +1,313 @@
+"""The config-entry options merge rules, and the drift guards around them.
+
+Three surfaces write ``entry.options`` and they share one coercion table in
+``options.py``. Two of them (the ``set_options`` service and the panel's Settings
+tab) send a *partial* update, which is merged onto what is stored. The options flow
+can't: Home Assistant stores whatever an options flow returns from
+``async_create_entry`` as ``entry.options`` **verbatim**, and its form renders only
+seven of the ten keys. Returning the submission as-is deleted every saved profile,
+notification and dismissed companion on each save — with nothing on screen to say so,
+because a missing key reads back as an empty list and notifications simply stopped
+arriving. ``merge_flow_input`` turns that submission back into a partial update.
+
+The guards at the bottom are the point: a new option key added to ``const.py`` and
+forgotten anywhere else fails here rather than shipping. ``options.py`` imports Home
+Assistant only under ``TYPE_CHECKING``, so all of this runs under a bare
+``pip install pytest && pytest tests/unit``.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import types
+from pathlib import Path
+from typing import Any
+
+import hk_const as const  # type: ignore[import-not-found]
+import hk_options as opts  # type: ignore[import-not-found]
+import pytest
+
+_COMPONENT = Path(__file__).resolve().parents[2] / "custom_components" / "home_keeper"
+_STRINGS = _COMPONENT / "strings.json"
+_INIT_PY = _COMPONENT / "__init__.py"
+
+# Every option key the integration defines, read off ``const.py`` rather than
+# restated here — that is what makes the guards below notice a *new* one.
+_CONST_OPTION_KEYS = frozenset(
+    getattr(const, name) for name in dir(const) if name.startswith("OPTION_")
+)
+
+# An entry whose options are fully populated, every key holding a non-default value.
+_FULL: dict[str, Any] = {
+    const.OPTION_SYNC_PROBLEM_SENSORS: True,
+    const.OPTION_ONE_OFF_RETENTION_DAYS: 30,
+    const.OPTION_SHOPPING_LIST_ENTITY: "todo.kitchen_list",
+    const.OPTION_PROBLEM_SENSOR_EXCLUDE_ENTITIES: ["binary_sensor.sump"],
+    const.OPTION_PROBLEM_SENSOR_EXCLUDE_DEVICES: ["dev-1"],
+    const.OPTION_PROBLEM_SENSOR_EXCLUDE_AREAS: ["kitchen"],
+    const.OPTION_PROBLEM_SENSOR_EXCLUDE_LABELS: ["label-1"],
+    const.OPTION_DISMISSED_COMPANIONS: ["acme_vacuum"],
+    const.OPTION_PROFILES: [
+        {"id": "p1", "name": "My chores", "filter": {"status": "overdue"}}
+    ],
+    const.OPTION_NOTIFICATIONS: [
+        {"id": "n1", "name": "Walk", "profile_id": "p1", "targets": []}
+    ],
+}
+
+# What the options form submits when every field is filled in. Deliberately spelled
+# out rather than derived, so a reader can see it covers exactly the seven fields the
+# Configure dialog renders.
+_SUBMISSION: dict[str, Any] = {
+    const.OPTION_SYNC_PROBLEM_SENSORS: False,
+    const.OPTION_PROBLEM_SENSOR_EXCLUDE_ENTITIES: ["binary_sensor.other"],
+    const.OPTION_PROBLEM_SENSOR_EXCLUDE_DEVICES: [],
+    const.OPTION_PROBLEM_SENSOR_EXCLUDE_AREAS: ["garage"],
+    const.OPTION_PROBLEM_SENSOR_EXCLUDE_LABELS: [],
+    const.OPTION_ONE_OFF_RETENTION_DAYS: 7,
+    const.OPTION_SHOPPING_LIST_ENTITY: "todo.shopping_list",
+}
+
+
+def _entry(options: dict[str, Any]) -> Any:
+    """A stand-in config entry — ``options`` is all the helpers read."""
+    return types.SimpleNamespace(options=options)
+
+
+def _normalized() -> dict[str, Any]:
+    """``_FULL`` as it reads back: the profile/notification normalizers fill in
+    their own defaults, so a preserved value equals the *normalized* one, not the
+    raw fixture."""
+    return opts.current_options(_entry(_FULL))
+
+
+# --------------------------------------------------------------------------- merge
+
+
+def test_merge_flow_input_preserves_the_keys_the_form_does_not_render() -> None:
+    """The bug: a save wiped profiles, notifications and dismissed companions."""
+    before = opts.current_options(_entry(_FULL))
+
+    merged = opts.merge_flow_input(_entry(_FULL), _SUBMISSION)
+
+    for key in (
+        const.OPTION_PROFILES,
+        const.OPTION_NOTIFICATIONS,
+        const.OPTION_DISMISSED_COMPANIONS,
+    ):
+        assert merged[key] == before[key], f"{key} was not preserved"
+    assert merged[const.OPTION_PROFILES], "sanity: the fixture must seed profiles"
+    # ...and the fields the form *does* own took their new values.
+    for key, value in _SUBMISSION.items():
+        assert merged[key] == value
+
+
+def test_clearing_the_shopping_picker_turns_the_mirror_off() -> None:
+    """A ``FLOW_OPTIONS`` key missing from the submission was cleared, not omitted.
+
+    The picker has no voluptuous ``default``, so clearing it drops the key entirely.
+    A plain ``{**current, **user_input}`` merge would resurrect the old entity id and
+    the mirror could never be turned off from the Configure dialog.
+    """
+    submission = {
+        k: v for k, v in _SUBMISSION.items() if k != const.OPTION_SHOPPING_LIST_ENTITY
+    }
+
+    merged = opts.merge_flow_input(_entry(_FULL), submission)
+
+    assert merged[const.OPTION_SHOPPING_LIST_ENTITY] == ""
+    # The distinction is what matters: cleared *is not* the same as unrendered.
+    assert merged[const.OPTION_PROFILES] == _normalized()[const.OPTION_PROFILES]
+
+
+def test_clearing_the_other_flow_fields_resets_them() -> None:
+    """Every ``FLOW_OPTIONS`` key follows the same cleared-means-empty rule."""
+    merged = opts.merge_flow_input(_entry(_FULL), {})
+
+    for key in opts.FLOW_OPTIONS:
+        assert merged[key] == opts.current_options(_entry({}))[key], key
+    assert (
+        merged[const.OPTION_NOTIFICATIONS] == _normalized()[const.OPTION_NOTIFICATIONS]
+    )
+
+
+def test_merge_flow_input_normalizes_the_number_selector_float() -> None:
+    """``NumberSelector`` submits ``7.0``; the stored shape is an int."""
+    merged = opts.merge_flow_input(
+        _entry(_FULL), {**_SUBMISSION, const.OPTION_ONE_OFF_RETENTION_DAYS: 7.0}
+    )
+
+    assert merged[const.OPTION_ONE_OFF_RETENTION_DAYS] == 7
+    assert isinstance(merged[const.OPTION_ONE_OFF_RETENTION_DAYS], int)
+
+
+def test_merge_flow_input_ignores_keys_the_form_does_not_own() -> None:
+    """The form can only change what the form renders."""
+    merged = opts.merge_flow_input(
+        _entry(_FULL),
+        {**_SUBMISSION, const.OPTION_PROFILES: [], const.OPTION_NOTIFICATIONS: []},
+    )
+
+    assert merged[const.OPTION_PROFILES] == _normalized()[const.OPTION_PROFILES]
+    assert merged[const.OPTION_NOTIFICATIONS]
+
+
+def test_merge_flow_input_returns_every_option_key() -> None:
+    """The result replaces ``entry.options`` wholesale, so it must be complete."""
+    merged = opts.merge_flow_input(_entry(_FULL), _SUBMISSION)
+
+    assert set(merged) == set(opts.ALL_OPTIONS)
+
+
+def test_merge_flow_input_normalizes_an_unusable_shopping_target() -> None:
+    """A picker value outside the ``todo`` domain collapses to the off switch."""
+    merged = opts.merge_flow_input(
+        _entry(_FULL),
+        {**_SUBMISSION, const.OPTION_SHOPPING_LIST_ENTITY: "sensor.not_a_list"},
+    )
+
+    assert merged[const.OPTION_SHOPPING_LIST_ENTITY] == ""
+
+
+# -------------------------------------------------------------------------- guards
+
+
+def test_every_option_constant_is_a_known_option() -> None:
+    """A new ``OPTION_*`` must reach ``_empty_options``, or it is silently dropped.
+
+    ``current_options`` and ``merge_flow_input`` both build from that factory, so a
+    key it doesn't declare is invisible to every reader and deleted by the options
+    flow's next save — exactly the class of bug this suite exists to prevent.
+    """
+    assert set(opts.ALL_OPTIONS) == _CONST_OPTION_KEYS
+    assert set(opts.current_options(_entry({}))) == _CONST_OPTION_KEYS
+
+
+# One non-default value per option key. A new option has no probe here, which fails
+# the first assertion below and points at the second one.
+_PROBES: dict[str, Any] = {
+    const.OPTION_SYNC_PROBLEM_SENSORS: True,
+    const.OPTION_ONE_OFF_RETENTION_DAYS: 9,
+    const.OPTION_SHOPPING_LIST_ENTITY: "todo.somewhere",
+    const.OPTION_PROBLEM_SENSOR_EXCLUDE_ENTITIES: ["binary_sensor.x"],
+    const.OPTION_PROBLEM_SENSOR_EXCLUDE_DEVICES: ["dev-x"],
+    const.OPTION_PROBLEM_SENSOR_EXCLUDE_AREAS: ["area-x"],
+    const.OPTION_PROBLEM_SENSOR_EXCLUDE_LABELS: ["label-x"],
+    const.OPTION_DISMISSED_COMPANIONS: ["some_domain"],
+    const.OPTION_PROFILES: [{"id": "px", "name": "X", "filter": {"status": "all"}}],
+    const.OPTION_NOTIFICATIONS: [{"id": "nx", "name": "X", "profile_id": "px"}],
+}
+
+
+def test_every_option_has_a_probe() -> None:
+    """Forces a new option to be considered by the coercion guard below."""
+    assert set(_PROBES) == _CONST_OPTION_KEYS, "add a probe for the new option"
+
+
+@pytest.mark.parametrize("key", sorted(_PROBES))
+def test_every_option_has_a_normalize_branch(key: str) -> None:
+    """An option with no coercion branch is ignored by every write path."""
+    empty = opts.current_options(_entry({}))
+
+    merged = opts.current_options(_entry({key: _PROBES[key]}))
+
+    assert merged[key] != empty[key], f"_normalize ignores {key}"
+
+
+def test_flow_options_are_real_options() -> None:
+    """``FLOW_OPTIONS`` names actual option keys, once each."""
+    assert set(opts.FLOW_OPTIONS) <= set(opts.ALL_OPTIONS)
+    assert len(set(opts.FLOW_OPTIONS)) == len(opts.FLOW_OPTIONS)
+
+
+def test_strings_json_covers_exactly_the_flow_form() -> None:
+    """The form's labels and the form's fields are the same set.
+
+    This is the drift guard that needs no Home Assistant: a field added to the
+    Configure dialog needs a label, so eight labels against seven ``FLOW_OPTIONS``
+    fails here — and so does the reverse, a tuple key with no field, which
+    ``merge_flow_input`` would *clear* on every save.
+    ``test_translations_parity.py`` extends the same check to every locale.
+    """
+    data = json.loads(_STRINGS.read_text("utf-8"))["options"]["step"]["init"]["data"]
+
+    assert set(data) == set(opts.FLOW_OPTIONS)
+
+
+def test_current_options_is_idempotent() -> None:
+    """Reading back what a write stored must not change it again.
+
+    ``async_set_options`` skips the write (and the reload) when ``merged == base``,
+    which is only trustworthy while reading and writing agree on every key's shape.
+    """
+    once = opts.current_options(_entry(_FULL))
+
+    assert opts.current_options(_entry(once)) == once
+
+
+def test_current_options_coerces_stored_garbage() -> None:
+    """Whatever is on disk, callers get the declared shape."""
+    stored = {
+        const.OPTION_SYNC_PROBLEM_SENSORS: "yes",
+        const.OPTION_ONE_OFF_RETENTION_DAYS: "not-a-number",
+        const.OPTION_PROBLEM_SENSOR_EXCLUDE_AREAS: None,
+        const.OPTION_DISMISSED_COMPANIONS: [1, 2],
+    }
+
+    result = opts.current_options(_entry(stored))
+
+    assert result[const.OPTION_SYNC_PROBLEM_SENSORS] is True
+    assert result[const.OPTION_ONE_OFF_RETENTION_DAYS] == 0
+    assert result[const.OPTION_PROBLEM_SENSOR_EXCLUDE_AREAS] == []
+    assert result[const.OPTION_DISMISSED_COMPANIONS] == ["1", "2"]
+
+
+def test_current_options_hands_out_fresh_lists() -> None:
+    """Callers mutating a returned list must not corrupt the next read."""
+    first = opts.current_options(_entry(_FULL))
+    first[const.OPTION_PROBLEM_SENSOR_EXCLUDE_AREAS].append("mutated")
+
+    assert (
+        "mutated"
+        not in opts.current_options(_entry(_FULL))[
+            const.OPTION_PROBLEM_SENSOR_EXCLUDE_AREAS
+        ]
+    )
+
+
+def _set_options_schema_keys() -> set[str]:
+    """The option keys ``SET_OPTIONS_SCHEMA`` accepts, read out of ``__init__.py``.
+
+    Parsed rather than imported: ``__init__.py`` pulls in the whole of Home
+    Assistant, and this guard belongs in the tier that runs without it. Every entry
+    is ``vol.Optional(OPTION_*)``, so the constant name is enough.
+    """
+    tree = ast.parse(_INIT_PY.read_text("utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(t, ast.Name) and t.id == "SET_OPTIONS_SCHEMA"
+            for t in node.targets
+        ):
+            continue
+        return {
+            getattr(const, key.args[0].id)
+            for key in ast.walk(node.value)
+            if isinstance(key, ast.Call)
+            and isinstance(key.func, ast.Attribute)
+            and key.func.attr in {"Optional", "Required"}
+            and key.args
+            and isinstance(key.args[0], ast.Name)
+        }
+    raise AssertionError("SET_OPTIONS_SCHEMA not found in __init__.py")
+
+
+def test_the_set_options_service_accepts_every_option() -> None:
+    """The service is the canonical write path, so it must reach every key.
+
+    An option the schema omits can't be set by an automation or a script at all —
+    the panel's websocket command is only a UI shortcut, never the substitute.
+    """
+    assert _set_options_schema_keys() == _CONST_OPTION_KEYS

--- a/tests/unit/test_options.py
+++ b/tests/unit/test_options.py
@@ -311,3 +311,26 @@ def test_the_set_options_service_accepts_every_option() -> None:
     the panel's websocket command is only a UI shortcut, never the substitute.
     """
     assert _set_options_schema_keys() == _CONST_OPTION_KEYS
+
+
+def test_the_defaults_are_all_off() -> None:
+    """An entry that has never been configured behaves as if nothing is enabled.
+
+    Spelled out rather than compared against ``_empty_options``, which would be
+    tautological. Each of these is a user-visible promise: syncing is opt-in, ``0``
+    retention days keeps completed one-offs forever (any other number would start
+    deleting them for people who never touched the setting), and an empty shopping
+    target leaves the mirror off.
+    """
+    assert opts.current_options(_entry({})) == {
+        "sync_problem_sensors": False,
+        "one_off_retention_days": 0,
+        "shopping_list_entity": "",
+        "profiles": [],
+        "notifications": [],
+        "problem_sensor_exclude_entities": [],
+        "problem_sensor_exclude_devices": [],
+        "problem_sensor_exclude_areas": [],
+        "problem_sensor_exclude_labels": [],
+        "dismissed_companions": [],
+    }

--- a/tests/unit/test_shopping_sync.py
+++ b/tests/unit/test_shopping_sync.py
@@ -128,13 +128,9 @@ def _load_module() -> types.ModuleType:
     if existing is not None:
         return existing
     _install_ha_stubs()
-
-    if "hk.options" not in sys.modules or not hasattr(
-        sys.modules["hk.options"], "current_options"
-    ):
-        options = types.ModuleType("hk.options")
-        options.current_options = lambda entry: entry.options
-        sys.modules["hk.options"] = options
+    # ``hk.options`` is the real module (conftest loads it — it imports Home
+    # Assistant only under ``TYPE_CHECKING``), so ``_resolve_target`` runs the real
+    # ``current_options`` here rather than a fake that hands back raw entry options.
 
     spec = importlib.util.spec_from_file_location(
         "hk.shopping_sync", str(_COMPONENT_DIR / "shopping_sync.py")


### PR DESCRIPTION
Fixes #

<sub>(No issue filed for this one — found while reviewing the options flow.)</sub>

## What changed

**The bug.** Home Assistant stores whatever an options flow returns from `async_create_entry` as `entry.options` **verbatim** — the whole object, not a patch. `HomeKeeperOptionsFlow.async_step_init` returned `user_input`, and the Configure dialog's form renders only 7 of the 10 option keys. So every save deleted `profiles`, `notifications` and `dismissed_companions`.

The damage was invisible. `notifier` reads those back through `options.current_options`, which defaults a missing key to `[]` — so saved notification bindings and profiles vanished and notifications simply stopped arriving, with nothing on screen to say why.

`options.py` exists to prevent exactly this ("the key list, defaults, and normalization live here so they can't drift"). The options flow was the one writer that bypassed it entirely — it imported neither helper.

### The fix

- **`options.merge_flow_input`** starts from `current_options` and changes only `FLOW_OPTIONS`. A flow key *missing* from the submission was **cleared** and resets; a key the form doesn't render is **preserved**. That distinction is load-bearing: `shopping_list_entity` has no voluptuous `default` precisely so a cleared picker drops out of the submission, and that absence is how the shopping-list mirror is turned off. A plain `{**current, **user_input}` would resurrect the old entity id — there's a test for that.
- **`current_options` collapses onto `_normalize`** over a new `_empty_options()` factory, so defaults and coercions are declared once. Reading and writing can no longer disagree about a key's shape, which is what makes `async_set_options`' `merged == base` short-circuit trustworthy. Flow submissions normalize too, so `NumberSelector`'s `7.0` is stored as `7`.
- **`config_flow._options_schema`** lifts the form to module level so a test can build it.
- **`options.py`'s two HA imports move under `TYPE_CHECKING`.** They were annotation-only; the module is now runtime-pure, so the fast unit tier covers the merge rules and it joins the mutation allowlist.

### Making it hard to repeat

There were **no tests for the config/options flow at all**, which is why this shipped. Three tiers now, plus drift guards that fail CI when a future option is forgotten:

| Guard | Catches |
| --- | --- |
| every `const.OPTION_*` reaches `_empty_options` | a new key invisible to every reader, deleted by the next flow save |
| every `const.OPTION_*` has a `_normalize` branch | a new key silently ignored by every writer |
| `strings.json` labels == `FLOW_OPTIONS` | a form field not in the tuple (discarded on save), or a tuple key with no field (cleared on save) |
| schema keys == `FLOW_OPTIONS` | the same, directly against the built `vol.Schema` |
| the shopping picker still has no `default` | a `default` here silently breaks "clear the picker to turn the mirror off" |
| `SET_OPTIONS_SCHEMA` accepts every option | a new key unreachable from the canonical service write path |

`tests/integration/test_options_flow.py` drives a real save over HA's flow API and asserts the panel-only keys come back byte-identical — the framework contract no mock can see. **It fails on the old code with `profiles == []`** (verified by reverting the fix and re-running against the container).

`quality_scale.yaml` claimed `config-flow-test-coverage: done` against coverage that did not exist; the comment now names what actually covers it. Conventions recorded in `.amazonq/rules/architecture-and-code.md` and `AGENTS.md`.

### Verified locally

| Check | Result |
| --- | --- |
| `pytest tests/unit` (py3.11, no HA) | 1176 passed, 2 skipped |
| full unit lane (py3.12 + HA, as CI runs it) | 1183 passed |
| `pytest tests/integration` (Docker, real HA) | 139 passed |
| `bash ci/test-mutation-python.sh` | **100.00%** (16/16), threshold 80% |
| `mypy custom_components/home_keeper` | Success, 43 files |
| `ruff check` / `ruff format --check` | clean |
| `vale CHANGELOG.md` (added lines) | clean |

No version bump: this is a bug-fix-only PR and `0.16.0b5` is already published, so the entry sits under `## [Unreleased]`. No panel UI changed, so no screenshots or walkthrough edit.

## Checklist

- [x] Tests run locally (`pytest tests/unit -v`, `bash ci/test-frontend.sh`)
- [x] `CHANGELOG.md` updated — user-facing changes only, with `(Fixes #N)` for each
      issue this fixes (developer-only changes don't need an entry)
- [x] Panel UI changed → n/a, nothing under `frontend/src/` changed
- [x] New user-facing UI surface → n/a, no new surface
- [x] New user-facing feature → n/a, bug fix only

---
_Generated by [Claude Code](https://claude.ai/code/session_015T1NNjZWkp7aVA3fdKcqcm)_