### PR TITLE
release: 0.16.0b8

### DIFF
--- a/.amazonq/rules/testing-and-workflow.md
+++ b/.amazonq/rules/testing-and-workflow.md
@@ -229,6 +229,17 @@ gate); CI publishes it to the job summary.
   `PANEL_VERSION` → next `bN`, plus a matching `## [X.Y.0bN]` CHANGELOG section)
   so it reaches beta testers. Fold into the current top beta if it's still
   unreleased; otherwise open the next `bN`. Bug-fix/developer-only PRs don't.
+- **`lint.yml`'s `changelog-release-gap` job guards the "fold into the current top
+  beta" rule above.** `release.yml` keys off `manifest.json`'s version and skips
+  tagging silently when that version is already tagged — so a PR that edits the top
+  `## [X.Y.ZbN]` CHANGELOG section without bumping the version, after that version
+  has already shipped, merges clean and then never actually ships (#236 did exactly
+  this: it landed ~50 minutes after `v0.16.0b7` was tagged, reusing the b7 heading,
+  and sat unreleased on `main` until #237 caught it). `ci/check-changelog-release-gap.py`
+  compares the top section between the PR's merge-base and `HEAD`: unchanged content,
+  or a version bump, or a still-unreleased top section, all pass; changed content
+  under an already-tagged version fails. Pure logic lives in `check()`, tested in
+  `tests/unit/test_check_changelog_release_gap.py`.
 - **Always add the `preview-release` label to a new-feature PR** once it's open, so
   `preview-release.yml` publishes an installable ephemeral pre-release
   (`X.Y.Z.dev<pr>`) from the PR head for pre-merge HACS testing (auto-deleted on

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,3 +59,19 @@ jobs:
           fail_level: any
           reporter: github-pr-review
           filter_mode: added
+
+  changelog-release-gap:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # ci/check-changelog-release-gap.py needs the base branch's history and
+          # every release tag to tell an already-shipped section from one still
+          # being iterated.
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+      - name: Guard against editing an already-released CHANGELOG section
+        run: python3 ci/check-changelog-release-gap.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -387,7 +387,11 @@ siblings instead of their fakes.
 
 ## CI
 
-- `lint.yml` — ruff lint + format check, and **mypy** strict typing (HA installed).
+- `lint.yml` — ruff lint + format check, **mypy** strict typing (HA installed), vale
+  prose linting, and `changelog-release-gap` — fails a PR that edits the top
+  `## [X.Y.ZbN]` CHANGELOG section without a version bump once that version is
+  already a published release tag (the gap that let #236 merge without ever
+  shipping as a beta; see "Always cut a beta release for a new feature" above).
 - `test.yml` — vitest, pytest unit, HACS validation, hassfest.
 - `mutation.yml` — mutation testing (mutmut + Stryker) on the code a PR changed;
   fails below an 80% mutation score. `skip-mutation` label bypasses it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,9 @@ All notable changes to Home Keeper are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
 
-## [0.16.0b7]
+## [0.16.0b8]
 
 ### Added
-
-- **Stock you measure instead of count.** A spare part can now carry a **stock unit**
-  and a **used per completion** amount, and every spare quantity accepts decimals.
-  Fabric softener topped up a third of a bottle at a time no longer reads as three
-  bottles gone after three refills, and a part measured in millilitres or metres shows
-  real units rather than a bare number. Set both on the part, under Stock and Reorder
-  at. Leave them empty and a part counts whole spares and uses one per completion,
-  exactly as before. The unit follows the amount everywhere it appears: the part's
-  chips, a linked task's detail line, the stock control on the appliance's device page,
-  and the `unit` field the stock events now carry. `home_keeper.adjust_part_stock` takes
-  a decimal `delta` too, so `-250` and `-0.33` are both valid adjustments. (Fixes #220)
 
 - **Start a usage meter somewhere other than "now", and see the meter in your
   history.** A usage/meter task used to anchor at whatever the sensor read the moment
@@ -40,6 +29,21 @@ versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
   automatable too: `usage_baseline` and `last_completion_reading` join the task's
   next-due sensor attributes, and `complete_task` / `update_completion` both take a
   `reading`. (Fixes #235)
+
+## [0.16.0b7]
+
+### Added
+
+- **Stock you measure instead of count.** A spare part can now carry a **stock unit**
+  and a **used per completion** amount, and every spare quantity accepts decimals.
+  Fabric softener topped up a third of a bottle at a time no longer reads as three
+  bottles gone after three refills, and a part measured in millilitres or metres shows
+  real units rather than a bare number. Set both on the part, under Stock and Reorder
+  at. Leave them empty and a part counts whole spares and uses one per completion,
+  exactly as before. The unit follows the amount everywhere it appears: the part's
+  chips, a linked task's detail line, the stock control on the appliance's device page,
+  and the `unit` field the stock events now carry. `home_keeper.adjust_part_stock` takes
+  a decimal `delta` too, so `-250` and `-0.33` are both valid adjustments. (Fixes #220)
 
 ### Fixed
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,7 +20,12 @@ the GitHub release automatically. No manual `git tag` step.
    1. Read the version from `manifest.json`.
    2. Verify a matching `## [X.Y.Z]` entry exists in `CHANGELOG.md` and that
       `PANEL_VERSION` matches. If either check fails, the workflow fails loudly.
-   3. Skip silently if tag `vX.Y.Z` already exists.
+   3. Skip silently if tag `vX.Y.Z` already exists. This is why a PR must bump the
+      version for *every* release, including a beta iteration: folding a new entry
+      into an already-tagged `## [X.Y.Z]` section without bumping the version merges
+      clean and then ships nothing, because this step sees nothing new to tag.
+      `lint.yml`'s `changelog-release-gap` job (`ci/check-changelog-release-gap.py`)
+      catches that case at PR time.
    4. Build `dist/home-keeper-panel.js` from TypeScript via Rollup.
    5. Build `home_keeper.zip` (the HACS asset).
    6. Push tag `vX.Y.Z` and create the GitHub Release with the changelog section as

--- a/ci/check-changelog-release-gap.py
+++ b/ci/check-changelog-release-gap.py
@@ -66,7 +66,12 @@ def check(
     tag_exists: Callable[[str], bool],
     section: Callable[[str, str], str],
 ) -> str | None:
-    """Return a failure message, or None if the PR's changelog top section is clean."""
+    """Return a failure message, or None if the PR's changelog top section is clean.
+
+    A version bump always short-circuits here: once the top heading itself changes,
+    ``base_version`` and ``head_version`` name two different sections, so there is
+    nothing to compare them for and ``release.yml`` will see a new tag to cut.
+    """
     base_version = top_version(base_changelog)
     head_version = top_version(head_changelog)
     if base_version is None or head_version is None or base_version != head_version:

--- a/ci/check-changelog-release-gap.py
+++ b/ci/check-changelog-release-gap.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Fail a PR that edits an already-released CHANGELOG section without a version bump.
+
+``release.yml`` cuts a release by reading ``manifest.json``'s version and tagging it
+— but only if that tag doesn't already exist; if it does, the job skips silently (see
+RELEASE.md). A PR that adds a new entry under the *current* top ``## [X.Y.Z]``
+CHANGELOG section without bumping ``manifest.json``/``const.py`` therefore merges
+clean, and then goes nowhere: the entry documents a change that will never actually
+ship, because nothing about the merge told ``release.yml`` there was anything new to
+publish.
+
+This happened for real: PR #236 folded a feature into the just-released
+``## [0.16.0b7]`` section instead of opening a new beta. ``release.yml`` read the
+unchanged version, saw ``v0.16.0b7`` already tagged, and skipped — the feature sat on
+``main`` unreleased until PR #237 caught it and cut ``0.16.0b8``. See AGENTS.md,
+"Always cut a beta release for a new feature."
+
+The check compares ``CHANGELOG.md``'s *top* section between the PR's merge-base and
+``HEAD``:
+
+* Version unchanged, section content unchanged  -> fine, nothing new to ship.
+* Version bumped                                -> fine, ``release.yml`` will see a
+  new tag to cut.
+* Version unchanged, section content changed, and that version is not yet a
+  published tag -> fine, the beta is still being iterated (AGENTS.md: "fold the
+  feature into it").
+* Version unchanged, section content changed, and that version *is* already a
+  published tag -> fail. The new content will never ship as written.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import re
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+_TOP_VERSION = re.compile(r"^## \[([^\]]+)\]", re.MULTILINE)
+
+
+def _load_release_issues():
+    # The filename has a hyphen, so it is not importable as a module name.
+    spec = importlib.util.spec_from_file_location(
+        "release_issues", ROOT / "ci" / "release-issues.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def top_version(changelog: str) -> str | None:
+    """The version in *changelog*'s first ``## [X.Y.Z]`` heading, or None."""
+    match = _TOP_VERSION.search(changelog)
+    return match.group(1) if match else None
+
+
+def check(
+    base_changelog: str,
+    head_changelog: str,
+    tag_exists: Callable[[str], bool],
+    section: Callable[[str, str], str],
+) -> str | None:
+    """Return a failure message, or None if the PR's changelog top section is clean."""
+    base_version = top_version(base_changelog)
+    head_version = top_version(head_changelog)
+    if base_version is None or head_version is None or base_version != head_version:
+        return None
+
+    if section(base_changelog, base_version) == section(head_changelog, head_version):
+        return None
+
+    if not tag_exists(base_version):
+        return None
+
+    return (
+        f"CHANGELOG.md's '## [{base_version}]' section changed, but v{base_version} "
+        "is already a published release. release.yml keys off an unchanged "
+        "manifest.json/const.py version and will skip re-publishing it, so this "
+        "entry will never ship. Bump manifest.json + const.py (PANEL_VERSION) to the "
+        "next beta and open a new '## [X.Y.ZbN]' CHANGELOG section for it -- see "
+        "AGENTS.md, 'Always cut a beta release for a new feature.'"
+    )
+
+
+def _git(*args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=ROOT, capture_output=True, text=True, check=False
+    )
+    if result.returncode != 0:
+        sys.exit(
+            f"[changelog-release-gap] git {' '.join(args)} failed: "
+            f"{result.stderr.strip()}"
+        )
+    return result.stdout
+
+
+def _file_at(ref: str, path: str) -> str | None:
+    result = subprocess.run(
+        ["git", "show", f"{ref}:{path}"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout if result.returncode == 0 else None
+
+
+def _tag_exists(version: str) -> bool:
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", f"refs/tags/v{version}"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base",
+        default="origin/main",
+        help="branch to diff against (default: origin/main)",
+    )
+    args = parser.parse_args()
+
+    merge_base = _git("merge-base", args.base, "HEAD").strip()
+    if not merge_base:
+        sys.exit(
+            f"[changelog-release-gap] could not find a merge base with {args.base}"
+        )
+
+    base_changelog = _file_at(merge_base, "CHANGELOG.md")
+    head_changelog = _file_at("HEAD", "CHANGELOG.md")
+    if base_changelog is None or head_changelog is None:
+        # No CHANGELOG.md on one side -- nothing for this guard to compare.
+        return 0
+
+    message = check(
+        base_changelog, head_changelog, _tag_exists, _load_release_issues().section
+    )
+    if message is None:
+        return 0
+
+    print(f"::error::{message}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor", "number"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.16.0b7"
+PANEL_VERSION = "0.16.0b8"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -21,5 +21,5 @@
   "requirements": [
     "Babel>=2.12"
   ],
-  "version": "0.16.0b7"
+  "version": "0.16.0b8"
 }

--- a/tests/unit/test_check_changelog_release_gap.py
+++ b/tests/unit/test_check_changelog_release_gap.py
@@ -69,6 +69,17 @@ class TestCheck:
         message = check(base, head, tag_exists=lambda v: True, section=_section)
         assert message is None
 
+    def test_version_bump_short_circuits_before_checking_any_tag(self):
+        # base_version != head_version names two different sections -- there is
+        # nothing to compare them for, so tag_exists() must never even be asked.
+        def tag_exists(version: str) -> bool:
+            raise AssertionError("tag_exists() called despite a version bump")
+
+        base = "## [0.16.0b7]\n\nold entry\n"
+        head = "## [0.16.0b8]\n\nold entry\n"  # identical body, only the heading moved
+        message = check(base, head, tag_exists=tag_exists, section=_section)
+        assert message is None
+
     def test_unchanged_section_on_a_released_version_is_clean(self):
         text = "## [0.16.0b7]\n\nsame entry\n"
         message = check(text, text, tag_exists=lambda v: True, section=_section)

--- a/tests/unit/test_check_changelog_release_gap.py
+++ b/tests/unit/test_check_changelog_release_gap.py
@@ -1,0 +1,116 @@
+"""Unit tests for ``ci/check-changelog-release-gap.py``.
+
+The script exists to catch exactly the bug PR #236 shipped: a feature folded into a
+CHANGELOG section whose version had already been tagged and released, so
+``release.yml`` saw nothing new and silently skipped publishing it. ``check()`` is
+pure — the git/tag lookups are injected — so the four cases it has to tell apart are
+pinned here without touching a real repository.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _ROOT / "ci" / "check-changelog-release-gap.py"
+
+
+def _load():
+    # The filename has a hyphen, so it is not importable as a module name.
+    spec = importlib.util.spec_from_file_location(
+        "check_changelog_release_gap", _SCRIPT
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_mod = _load()
+top_version = _mod.top_version
+check = _mod.check
+
+
+def _section(changelog: str, version: str) -> str:
+    """A minimal stand-in for release-issues.section(): the heading's own text."""
+    heading = f"## [{version}]"
+    out: list[str] = []
+    found = False
+    for line in changelog.splitlines():
+        if not found:
+            if line.startswith(heading):
+                found = True
+                out.append(line)
+            continue
+        if line.startswith("## ["):
+            break
+        out.append(line)
+    return "\n".join(out) + "\n" if found else ""
+
+
+class TestTopVersion:
+    def test_reads_the_first_heading(self):
+        text = "# Changelog\n\n## [0.16.0b8]\n\nstuff\n\n## [0.16.0b7]\n\nolder\n"
+        assert top_version(text) == "0.16.0b8"
+
+    def test_ignores_a_version_mentioned_in_prose(self):
+        text = "# Changelog\n\nSee 0.15.0 for history.\n\n## [0.16.0]\n\nstuff\n"
+        assert top_version(text) == "0.16.0"
+
+    def test_no_heading_at_all(self):
+        assert top_version("# Changelog\n\nnothing here\n") is None
+
+
+class TestCheck:
+    def test_version_bumped_is_always_clean(self):
+        base = "## [0.16.0b7]\n\nold entry\n"
+        head = "## [0.16.0b8]\n\nnew entry\n"
+        message = check(base, head, tag_exists=lambda v: True, section=_section)
+        assert message is None
+
+    def test_unchanged_section_on_a_released_version_is_clean(self):
+        text = "## [0.16.0b7]\n\nsame entry\n"
+        message = check(text, text, tag_exists=lambda v: True, section=_section)
+        assert message is None
+
+    def test_new_entry_folded_into_an_unreleased_beta_is_clean(self):
+        # AGENTS.md's normal workflow: several PRs land into the same unreleased
+        # beta section before it's ever tagged.
+        base = "## [0.16.0b7]\n\nfirst entry\n"
+        head = "## [0.16.0b7]\n\nfirst entry\nsecond entry\n"
+        message = check(base, head, tag_exists=lambda v: False, section=_section)
+        assert message is None
+
+    def test_new_entry_folded_into_an_already_released_beta_fails(self):
+        # This is PR #236's bug: v0.16.0b7 already tagged, entry added anyway.
+        base = "## [0.16.0b7]\n\nfirst entry\n"
+        head = "## [0.16.0b7]\n\nfirst entry\nsecond entry\n"
+        message = check(base, head, tag_exists=lambda v: True, section=_section)
+        assert message is not None
+        assert "0.16.0b7" in message
+        assert "next beta" in message
+
+    def test_checks_the_version_that_was_actually_edited(self):
+        calls: list[str] = []
+
+        def tag_exists(version: str) -> bool:
+            calls.append(version)
+            return True
+
+        base = "## [0.16.0b7]\n\nfirst entry\n"
+        head = "## [0.16.0b7]\n\nfirst entry\nsecond entry\n"
+        check(base, head, tag_exists=tag_exists, section=_section)
+        assert calls == ["0.16.0b7"]
+
+    def test_missing_top_heading_on_either_side_is_clean(self):
+        head = "## [0.16.0]\n\nx\n"
+        assert check("no heading", head, lambda v: True, _section) is None
+        assert check(head, "no heading", lambda v: True, _section) is None
+
+    def test_a_stable_release_is_covered_too(self):
+        # The guard isn't beta-specific -- a stable's top section can hit the same bug.
+        base = "## [0.16.0]\n\nfirst entry\n"
+        head = "## [0.16.0]\n\nfirst entry\nsneaked-in entry\n"
+        message = check(base, head, tag_exists=lambda v: True, section=_section)
+        assert message is not None


### PR DESCRIPTION
## What changed

#236 (custom starting reading + reading-in-history for usage/meter tasks) merged to
`main` reusing the `0.16.0b7` version string, but `v0.16.0b7` had already been tagged
and published ~50 minutes earlier by #234's merge. `release.yml` read the unchanged
version, saw the `v0.16.0b7` tag already existed, and skipped silently — so the
feature landed on `main` without ever going out as an installable beta.

This PR has two parts:

**1. The release bump #236 should have carried:**
- `manifest.json` + `const.py` (`PANEL_VERSION`) → `0.16.0b8`
- `CHANGELOG.md` — moved the "Start a usage meter…" entry (`Fixes #235`) out of the
  now-immutable `## [0.16.0b7]` section (which matches what actually shipped in that
  release: the stock-units feature and the options-flow fix) into a new
  `## [0.16.0b8]` section

**2. A CI safeguard against this recurring** (per Amazon Q's review on this PR):
`lint.yml`'s new `changelog-release-gap` job runs
`ci/check-changelog-release-gap.py`, which compares `CHANGELOG.md`'s top
`## [X.Y.ZbN]` section between a PR's merge-base and `HEAD`. It fails when the
version is unchanged but the section's content changed *and* that version is
already a published release tag — exactly the gap #236 fell into. Verified against
the real repo history: run against #236's actual base/head commits it fails with the
message telling the author to bump the version; run against this PR's own diff (a
genuine version bump) it passes. Documented in `RELEASE.md`, `AGENTS.md` and
`.amazonq/rules/testing-and-workflow.md`.

## Checklist

- [x] Tests run locally (`pytest tests/unit -v` — 1276 passed, 2 skipped; `ruff check`
      / `ruff format --check` clean)
- [x] `CHANGELOG.md` updated — `(Fixes #235)` moved into the new `0.16.0b8` section
- [ ] Panel UI changed → N/A (no UI change)
- [ ] New user-facing UI surface → N/A (#236 already extended the tour; this PR just
      fixes the version it ships under, plus a CI-only safeguard)
- [x] New user-facing feature → version bumped to the next beta (`manifest.json` +
      `const.py`)