### PR TITLE
release: 0.16.0

### DIFF
--- a/.amazonq/rules/testing-and-workflow.md
+++ b/.amazonq/rules/testing-and-workflow.md
@@ -4,6 +4,12 @@
 - Never push directly to `main`. Work on a feature branch and open a PR; squash
   merge.
 - Update `CHANGELOG.md` for every user-facing change before a release.
+- **Keep every CHANGELOG bullet to three sentences at most.** A bold lead naming the
+  change, then what a user notices, then a caveat or `(Fixes #N)` if one is needed.
+  Cut the worked example, the before-and-after story, the list of every surface the
+  value now appears on, and the API/attribute inventory. Detail belongs in `README.md`,
+  `docs/`, or the PR; the changelog says what changed and stops. One bullet per change,
+  never a second paragraph.
 - Post screenshots to the PR for any change that adds/changes/fixes UI (capture
   via `tests/e2e/screenshots.capture.ts`, commit under `docs/images/`, embed via
   a `raw.githubusercontent.com/.../<commit-sha>/docs/images/<file>.png` URL).

--- a/.amazonq/rules/testing-and-workflow.md
+++ b/.amazonq/rules/testing-and-workflow.md
@@ -37,7 +37,12 @@
   `services.yaml`, and `locales/en.json` (not the other locales or `translations/`,
   since the rules are English-phrase regexes). It's diff-scoped (`filter_mode: added`),
   so only new/changed lines can fail CI. The existing corpus is cleaned up
-  separately. Run locally with `vale sync && vale <paths>`. Disable an accepted false
+  separately. Run locally with `vale sync && vale <paths>`, but treat a clean local run
+  as weak evidence: `lint.yml`'s action pins its own binary and has reported hits a local
+  Vale found nowhere in the file. To be sure, match the rule's `tokens` regexes from
+  `styles/ai-tells/<Rule>.yml` against the text yourself, scoped per **block** (a list
+  item plus its continuation lines is one string, and `[^,]+` spans sentence boundaries).
+  Keep at most one comma after a modal or pronoun in a bullet. Disable an accepted false
   positive per-file in `.vale.ini` (`ai-tells.RuleName = NO`) or inline with
   `<!-- vale ai-tells.RuleName = NO -->` / `... = YES -->`. For example,
   `services.yaml` disables `ColonUsage`, which otherwise fires on every unquoted

--- a/.amazonq/rules/testing-and-workflow.md
+++ b/.amazonq/rules/testing-and-workflow.md
@@ -9,7 +9,8 @@
   Cut the worked example, the before-and-after story, the list of every surface the
   value now appears on, and the API/attribute inventory. Detail belongs in `README.md`,
   `docs/`, or the PR; the changelog says what changed and stops. One bullet per change,
-  never a second paragraph.
+  never a second paragraph. Three sentences is the budget for the **whole bullet**,
+  counting the bold lead as the first, not three per paragraph.
 - Post screenshots to the PR for any change that adds/changes/fixes UI (capture
   via `tests/e2e/screenshots.capture.ts`, commit under `docs/images/`, embed via
   a `raw.githubusercontent.com/.../<commit-sha>/docs/images/<file>.png` URL).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,16 @@
   For an accepted false positive, either disable the rule for that file in
   `.vale.ini` (`ai-tells.RuleName = NO`) or wrap the exception inline with
   `<!-- vale ai-tells.RuleName = NO -->` / `<!-- vale ai-tells.RuleName = YES -->`.
+  **A clean local `vale` run is not proof CI is clean.** The `vale-action` in `lint.yml`
+  pins its own binary, and a locally-installed one can miss hits it reports:
+  `ai-tells.VerbTricolon` fired on a rewritten CHANGELOG bullet in CI while local Vale
+  3.9.1 found nothing in the whole file. When a run matters, check the rule's own regexes
+  against the text directly (`styles/ai-tells/<Rule>.yml` is plain YAML `tokens`). Match
+  Vale's scope when you do: the rules apply per **block**, so a list item and all its
+  continuation lines are one string, and patterns like `[^,]+` happily span sentence
+  boundaries — a "three items in series" rule can fire across two sentences of one
+  bullet. In practice keep at most one comma in a bullet after a modal (`can`, `could`,
+  `will`) or a pronoun (`you`, `we`, `they`); a second one is usually what trips it.
   Diff-scoping only checks added/changed lines, so a wholesale rewrite of a file's
   prose (not just a small edit) can surface pre-existing hits on lines that just
   moved. Run `vale <file>` on the whole file yourself before a rewrite-style PR to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,9 @@
   the inventory of new service fields and entity attributes — those read as release
   notes written for the person who wrote the code. Detail belongs in `README.md`,
   `docs/`, or the PR body; the changelog says what changed and stops. One bullet per
-  change, never a second paragraph. `(Fixes #N)` must land in the bullet's **first**
+  change, never a second paragraph. Three sentences is the budget for the **whole
+  bullet**, counting the bold lead as the first — not three per paragraph, and not three
+  on top of the lead. `(Fixes #N)` must land in the bullet's **first**
   paragraph, because `ci/release-issues.py` quotes the bullet it first appears in.
 - **A stable release's `## [X.Y.Z]` notes describe what changed since the last
   _stable_ release — not since its betas.** When cutting `X.Y.Z` from an `X.Y.ZbN`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,15 @@
 - **Always squash merge PRs.**
 - **CHANGELOG.md** — update for every user-facing change before tagging a release.
   Developer-only changes (CI config, AGENTS.md, IDEAS.md) don't need entries.
+- **Keep every CHANGELOG bullet to three sentences at most.** A bold lead naming the
+  change, then what a user notices, then a caveat or `(Fixes #N)` if one is needed.
+  That is the whole budget. Cut the worked example ("your odometer reads 48,000…"),
+  the before-and-after story, the list of every surface the new value shows up on, and
+  the inventory of new service fields and entity attributes — those read as release
+  notes written for the person who wrote the code. Detail belongs in `README.md`,
+  `docs/`, or the PR body; the changelog says what changed and stops. One bullet per
+  change, never a second paragraph. `(Fixes #N)` must land in the bullet's **first**
+  paragraph, because `ci/release-issues.py` quotes the bullet it first appears in.
 - **A stable release's `## [X.Y.Z]` notes describe what changed since the last
   _stable_ release — not since its betas.** When cutting `X.Y.Z` from an `X.Y.ZbN`
   line, write the section for someone upgrading from the previous stable version and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,123 @@ All notable changes to Home Keeper are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
 
+## [0.16.0] - 2026-08-25
+
+### Added
+
+- **Profiles can now leave tasks out, not just let them in.** A Profile's filter gains
+  **Exclude labels**, **Exclude areas** and **Exclude devices** alongside the existing
+  include pickers. They subtract from whatever the include filters selected, and they
+  win: a task that matched everything else is still dropped if it carries an excluded
+  label, sits in an excluded area, or hangs off an excluded device. Tag the jobs that
+  need a tradesperson `professional` and exclude that one label, and you have an
+  "everything I can do myself" list, without tagging every task that *isn't* a call-out.
+  Exclusions follow the same inheritance as the include pickers, so excluding a label
+  also drops a task that carries it only via its device or area. Because a Profile is
+  the shared saved filter, the exclusions apply everywhere it is used: the notifications
+  built on it, the **Profile** dropdown on the Tasks tab, and the dashboard card's
+  **Filter by profile**. Profiles saved before this release keep working unchanged. The
+  new pickers start empty, and an empty picker excludes nothing. (Fixes #214)
+- **Buy reminders now reach your own shopping list.** Point **Settings → Shopping
+  list** at a to-do list the household already uses. Every auto-created "Buy {part}"
+  reminder is then put on it, so it turns up on your voice assistant and on whatever
+  list widget lives on the fridge tablet. It works both ways. Ticking the line off at
+  the shop completes the Home Keeper reminder and restocks the part. Completing the
+  reminder in Home Keeper ticks the line off to match. Topping the stock up some other
+  way removes the line, because nothing was bought. A line already ticked off is never
+  touched. Only the lines Home Keeper added are ever managed. Leave the setting empty to
+  turn it off. (Fixes #220)
+- **Shopping filter in the panel and dashboard card.** A new "Shopping" option in the
+  task filter bar shows only the auto-created buy tasks (the ones Home Keeper generates
+  when a part's stock hits its reorder point), so you can see at a glance what needs
+  buying without scrolling through every task. The same filter is available as
+  `filter: shopping` on the dashboard card. (Fixes #220)
+- **Stock you measure instead of count.** A spare part can now carry a **stock unit**
+  and a **used per completion** amount, and every spare quantity accepts decimals.
+  Fabric softener topped up a third of a bottle at a time no longer reads as three
+  bottles gone after three refills, and a part measured in millilitres or metres shows
+  real units rather than a bare number. Set both on the part, under Stock and Reorder
+  at. Leave them empty and a part counts whole spares and uses one per completion,
+  exactly as before. The unit follows the amount everywhere it appears: the part's
+  chips, a linked task's detail line, the stock control on the appliance's device page,
+  and the `unit` field the stock events now carry. `home_keeper.adjust_part_stock` takes
+  a decimal `delta` too, so `-250` and `-0.33` are both valid adjustments. (Fixes #220)
+- **Start a usage meter somewhere other than "now", and see the meter in your
+  history.** A usage/meter task used to anchor at whatever the sensor read the moment
+  you created it, which starts every task for an already-serviced machine a full
+  interval late. The task form now has a **Starting reading**: your odometer reads
+  48,000, you change the oil every 10,000 miles, and the last change was at 45,000, so
+  you type 45,000 and the task says *"3,000 of 10,000 used"* straight away and comes
+  due at 55,000. The live hint does the arithmetic as you type, including warning you
+  if the number you typed is above what the sensor currently reads. **Last completed**
+  now appears on sensor tasks too, so the calendar half of "every 10,000 miles or 12
+  months" starts where the meter half does instead of restarting today. (Fixes #235)
+
+  Completing a sensor task also records what the sensor read at the time, next to the
+  note, cost and photo. Every history row shows it, and the pencil edits it, which
+  you need when you back-date a job you did last month and the meter has moved since.
+  Correcting the reading on the most recent completion re-anchors the meter to match,
+  so the history and the progress bar can't contradict each other. The figures are
+  automatable too: `usage_baseline` and `last_completion_reading` join the task's
+  next-due sensor attributes, and `complete_task` / `update_completion` both take a
+  `reading`. (Fixes #235)
+- **Usage/meter tasks now count down on the overview.** A meter task waiting for its
+  sensor to advance used to read only "Monitored" in the task list. It now shows how
+  far off it is, "in 7000 miles", the meter version of the "in 3 days" a time-based
+  task shows, so you can see at a glance which of your metered jobs is closest without
+  opening each one. (Threshold and state tasks, which have no interval to count down,
+  still read "Monitored".)
+
+### Fixed
+
+- **"Mark done" on a notification works before the task is due.** A notification built
+  from a Profile set to **Due soon** (or **All**) shows tasks that aren't overdue yet,
+  and its **Mark done** button did nothing at all when tapped. No completion, nothing in
+  the log, while **Snooze** and **Skip** on the same notification worked. The task then
+  went overdue as if it had been left alone. Tapping the button now completes the task
+  whenever it still reflects the task's current schedule. Taps that no longer do are
+  still ignored, so completing a task somewhere else (or on a second notification
+  covering the same task) can't push it out an extra cycle. (Fixes #216)
+- **A do-once task you already finished no longer sits on the to-do list forever.**
+  Checking off a one-off task (renew the passport, register the car) retires it: it
+  goes dormant and leaves the calendar, the due-date sensors and the panel's active
+  list, landing in the panel's **Completed** section with its record intact. The native
+  `todo.home_keeper_tasks` list kept showing it anyway, unchecked and with its due date
+  gone, and nothing could clear it short of deleting the task and its history. A
+  finished one-off now drops off the to-do list as soon as it's done, and comes back at
+  its due date if you undo the completion. Checking one off a second time (through
+  `todo.update_item`, say) no longer records a second completion for work done once.
+  (Fixes #221)
+- **The dashboard card no longer breaks on an ordinary page reload.** A dashboard using
+  the Home Keeper card could show a configuration error reading "Custom element doesn't
+  exist: home-keeper-card". Reloading with the browser cache disabled brought the card
+  back, and the next normal reload broke it again. Home Keeper handed the card to the
+  frontend in a way that only reaches the browser through the page Home Assistant
+  caches, so a page cached before Home Keeper was installed never loaded it. The card
+  is now registered the way every other custom card is, as a dashboard resource under
+  **Settings > Dashboards > Resources**, which the frontend fetches fresh on every
+  dashboard load. Existing installs get the entry on the next restart, and removing
+  Home Keeper takes it away again. (Fixes #228)
+- **Opening Configure no longer wipes your notifications and profiles.** Saving the
+  integration's options dialog (Settings → Devices & services → Home Keeper →
+  Configure) replaced the whole settings object with just the seven fields on that
+  form. Every notification, every profile, and every companion suggestion you had
+  dismissed was deleted. Notifications then stopped arriving, with nothing on screen
+  to say why. The dialog now changes only its own fields and leaves what you set in
+  the panel alone.
+- **Undoing a meter task's completion keeps your partial progress.** Deleting a
+  usage/meter completion (undoing an accidental "done") reset the meter to zero and
+  left it there. It now reverts to exactly where it was before that completion: 3,000
+  of 10,000 miles goes back to 3,000, not zero. (Fixes #235)
+- **"Mark done" on a notification now clears an auto-buy reminder.** Completing a
+  "Buy {part}" reminder from a notification restocked the part but left the reminder
+  standing until something else happened to settle it, so it kept showing up as due.
+  Every other way of completing it already cleared it.
+- **Documented that auto-clearing sensor tasks consume consumable stock.** When a
+  sensor task with *Clear when back to normal* is linked to a consumable part, the
+  auto-completion draws down one spare from stock, the same as completing by hand. This
+  was always the behavior but was not mentioned in the README or the events reference.
+
 ## [0.16.0b9]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,10 @@ versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
 
 ### Added
 
-- **Profiles can now exclude tasks, not just include them.** A Profile's filter gains
-  **Exclude labels**, **Exclude areas** and **Exclude devices**, which subtract from
-  whatever the include pickers selected and win any tie. Exclusions inherit the same
-  way the include pickers do and apply everywhere the Profile is used, and Profiles
-  saved before this release keep working unchanged. (Fixes #214)
+- **Profiles gain exclusion filters.** A Profile's filter now has an **Exclude**
+  counterpart for its label, area and device pickers. An exclusion beats the include side
+  and inherits the same way it does, so a task carrying an excluded label through its
+  device or area is dropped too. (Fixes #214)
 - **Buy reminders now reach your own shopping list.** Point **Settings → Shopping
   list** at a to-do list the household already uses and every auto-created "Buy {part}"
   reminder is put on it. It works both ways: ticking the line off at the shop completes
@@ -23,11 +22,10 @@ versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
 - **Shopping filter in the panel and dashboard card.** A new "Shopping" option in the
   task filter bar shows only the auto-created buy tasks, and the same filter is
   available as `filter: shopping` on the dashboard card. (Fixes #220)
-- **Stock you measure instead of count.** A spare part can now carry a **stock unit**
-  and a **used per completion** amount, and every spare quantity accepts decimals, so
-  fabric softener topped up a third of a bottle at a time no longer reads as three
-  bottles gone. Leave both empty and a part counts whole spares and uses one per
-  completion, exactly as before. (Fixes #220)
+- **Stock you measure instead of count.** A spare part carries an optional **stock unit**
+  and a **used per completion** amount, and every spare quantity now accepts decimals so
+  fabric softener topped up a third of a bottle no longer reads as three bottles gone.
+  Leaving both fields empty keeps the whole-spare counting from before. (Fixes #220)
 - **Start a usage meter somewhere other than "now".** A usage/meter task's new
   **Starting reading** anchors it where the machine was actually last serviced instead
   of at whatever the sensor reads today, and **Last completed** now appears on sensor
@@ -43,16 +41,15 @@ versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
   from a Profile set to **Due soon** or **All** shows tasks that aren't overdue yet, and
   its **Mark done** button did nothing at all when tapped. It now completes the task
   whenever the notification still reflects that task's current schedule. (Fixes #216)
-- **A do-once task you already finished no longer sits on the to-do list forever.**
-  Checking off a one-off task retires it everywhere else, but `todo.home_keeper_tasks`
-  kept showing it anyway, unchecked and with its due date gone. It now drops off the
-  list as soon as it's done, and comes back at its due date if you undo the completion.
-  (Fixes #221)
+- **A finished do-once task no longer sits on the to-do list forever.** Checking off a
+  one-off task retires it everywhere else, but `todo.home_keeper_tasks` kept showing it
+  unchecked with its due date gone. It now drops off the list as soon as it is done and
+  comes back at its due date if the completion is undone. (Fixes #221)
 - **The dashboard card no longer breaks on an ordinary page reload.** A dashboard using
-  the Home Keeper card could show "Custom element doesn't exist: home-keeper-card",
-  because the card reached the browser only through the page Home Assistant caches. It
-  is now registered as a dashboard resource under **Settings > Dashboards > Resources**,
-  which the frontend fetches fresh on every load, and existing installs get the entry on
+  the Home Keeper card could show "Custom element doesn't exist: home-keeper-card"
+  because the card reached the browser only through the page Home Assistant caches. It is
+  now registered as a dashboard resource under **Settings > Dashboards > Resources**,
+  which the frontend fetches fresh on every load and which existing installs pick up on
   the next restart. (Fixes #228)
 - **Opening Configure no longer wipes your notifications and profiles.** Saving the
   integration's options dialog replaced the whole settings object with just the seven

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,118 +10,66 @@ versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
 
 ### Added
 
-- **Profiles can now leave tasks out, not just let them in.** A Profile's filter gains
-  **Exclude labels**, **Exclude areas** and **Exclude devices** alongside the existing
-  include pickers. They subtract from whatever the include filters selected, and they
-  win: a task that matched everything else is still dropped if it carries an excluded
-  label, sits in an excluded area, or hangs off an excluded device. Tag the jobs that
-  need a tradesperson `professional` and exclude that one label, and you have an
-  "everything I can do myself" list, without tagging every task that *isn't* a call-out.
-  Exclusions follow the same inheritance as the include pickers, so excluding a label
-  also drops a task that carries it only via its device or area. Because a Profile is
-  the shared saved filter, the exclusions apply everywhere it is used: the notifications
-  built on it, the **Profile** dropdown on the Tasks tab, and the dashboard card's
-  **Filter by profile**. Profiles saved before this release keep working unchanged. The
-  new pickers start empty, and an empty picker excludes nothing. (Fixes #214)
+- **Profiles can now exclude tasks, not just include them.** A Profile's filter gains
+  **Exclude labels**, **Exclude areas** and **Exclude devices**, which subtract from
+  whatever the include pickers selected and win any tie. Exclusions inherit the same
+  way the include pickers do and apply everywhere the Profile is used, and Profiles
+  saved before this release keep working unchanged. (Fixes #214)
 - **Buy reminders now reach your own shopping list.** Point **Settings → Shopping
-  list** at a to-do list the household already uses. Every auto-created "Buy {part}"
-  reminder is then put on it, so it turns up on your voice assistant and on whatever
-  list widget lives on the fridge tablet. It works both ways. Ticking the line off at
-  the shop completes the Home Keeper reminder and restocks the part. Completing the
-  reminder in Home Keeper ticks the line off to match. Topping the stock up some other
-  way removes the line, because nothing was bought. A line already ticked off is never
-  touched. Only the lines Home Keeper added are ever managed. Leave the setting empty to
-  turn it off. (Fixes #220)
+  list** at a to-do list the household already uses and every auto-created "Buy {part}"
+  reminder is put on it. It works both ways: ticking the line off at the shop completes
+  the reminder and restocks the part, and only the lines Home Keeper added are ever
+  managed. (Fixes #220)
 - **Shopping filter in the panel and dashboard card.** A new "Shopping" option in the
-  task filter bar shows only the auto-created buy tasks (the ones Home Keeper generates
-  when a part's stock hits its reorder point), so you can see at a glance what needs
-  buying without scrolling through every task. The same filter is available as
-  `filter: shopping` on the dashboard card. (Fixes #220)
+  task filter bar shows only the auto-created buy tasks, and the same filter is
+  available as `filter: shopping` on the dashboard card. (Fixes #220)
 - **Stock you measure instead of count.** A spare part can now carry a **stock unit**
-  and a **used per completion** amount, and every spare quantity accepts decimals.
-  Fabric softener topped up a third of a bottle at a time no longer reads as three
-  bottles gone after three refills, and a part measured in millilitres or metres shows
-  real units rather than a bare number. Set both on the part, under Stock and Reorder
-  at. Leave them empty and a part counts whole spares and uses one per completion,
-  exactly as before. The unit follows the amount everywhere it appears: the part's
-  chips, a linked task's detail line, the stock control on the appliance's device page,
-  and the `unit` field the stock events now carry. `home_keeper.adjust_part_stock` takes
-  a decimal `delta` too, so `-250` and `-0.33` are both valid adjustments. (Fixes #220)
-- **Start a usage meter somewhere other than "now", and see the meter in your
-  history.** A usage/meter task used to anchor at whatever the sensor read the moment
-  you created it, which starts every task for an already-serviced machine a full
-  interval late. The task form now has a **Starting reading**: your odometer reads
-  48,000, you change the oil every 10,000 miles, and the last change was at 45,000, so
-  you type 45,000 and the task says *"3,000 of 10,000 used"* straight away and comes
-  due at 55,000. The live hint does the arithmetic as you type, including warning you
-  if the number you typed is above what the sensor currently reads. **Last completed**
-  now appears on sensor tasks too, so the calendar half of "every 10,000 miles or 12
-  months" starts where the meter half does instead of restarting today. (Fixes #235)
-
-  Completing a sensor task also records what the sensor read at the time, next to the
-  note, cost and photo. Every history row shows it, and the pencil edits it, which
-  you need when you back-date a job you did last month and the meter has moved since.
-  Correcting the reading on the most recent completion re-anchors the meter to match,
-  so the history and the progress bar can't contradict each other. The figures are
-  automatable too: `usage_baseline` and `last_completion_reading` join the task's
-  next-due sensor attributes, and `complete_task` / `update_completion` both take a
-  `reading`. (Fixes #235)
-- **Usage/meter tasks now count down on the overview.** A meter task waiting for its
-  sensor to advance used to read only "Monitored" in the task list. It now shows how
-  far off it is, "in 7000 miles", the meter version of the "in 3 days" a time-based
-  task shows, so you can see at a glance which of your metered jobs is closest without
-  opening each one. (Threshold and state tasks, which have no interval to count down,
-  still read "Monitored".)
+  and a **used per completion** amount, and every spare quantity accepts decimals, so
+  fabric softener topped up a third of a bottle at a time no longer reads as three
+  bottles gone. Leave both empty and a part counts whole spares and uses one per
+  completion, exactly as before. (Fixes #220)
+- **Start a usage meter somewhere other than "now".** A usage/meter task's new
+  **Starting reading** anchors it where the machine was actually last serviced instead
+  of at whatever the sensor reads today, and **Last completed** now appears on sensor
+  tasks too. Completing a sensor task also records what the sensor read at the time,
+  which every history row shows and the pencil edits. (Fixes #235)
+- **Usage/meter tasks now count down on the overview.** A meter task shows how far off
+  it is, "in 7000 miles", rather than only "Monitored". (Threshold and state tasks,
+  which have no interval to count down, still read "Monitored".)
 
 ### Fixed
 
 - **"Mark done" on a notification works before the task is due.** A notification built
-  from a Profile set to **Due soon** (or **All**) shows tasks that aren't overdue yet,
-  and its **Mark done** button did nothing at all when tapped. No completion, nothing in
-  the log, while **Snooze** and **Skip** on the same notification worked. The task then
-  went overdue as if it had been left alone. Tapping the button now completes the task
-  whenever it still reflects the task's current schedule. Taps that no longer do are
-  still ignored, so completing a task somewhere else (or on a second notification
-  covering the same task) can't push it out an extra cycle. (Fixes #216)
+  from a Profile set to **Due soon** or **All** shows tasks that aren't overdue yet, and
+  its **Mark done** button did nothing at all when tapped. It now completes the task
+  whenever the notification still reflects that task's current schedule. (Fixes #216)
 - **A do-once task you already finished no longer sits on the to-do list forever.**
-  Checking off a one-off task (renew the passport, register the car) retires it: it
-  goes dormant and leaves the calendar, the due-date sensors and the panel's active
-  list, landing in the panel's **Completed** section with its record intact. The native
-  `todo.home_keeper_tasks` list kept showing it anyway, unchecked and with its due date
-  gone, and nothing could clear it short of deleting the task and its history. A
-  finished one-off now drops off the to-do list as soon as it's done, and comes back at
-  its due date if you undo the completion. Checking one off a second time (through
-  `todo.update_item`, say) no longer records a second completion for work done once.
+  Checking off a one-off task retires it everywhere else, but `todo.home_keeper_tasks`
+  kept showing it anyway, unchecked and with its due date gone. It now drops off the
+  list as soon as it's done, and comes back at its due date if you undo the completion.
   (Fixes #221)
 - **The dashboard card no longer breaks on an ordinary page reload.** A dashboard using
-  the Home Keeper card could show a configuration error reading "Custom element doesn't
-  exist: home-keeper-card". Reloading with the browser cache disabled brought the card
-  back, and the next normal reload broke it again. Home Keeper handed the card to the
-  frontend in a way that only reaches the browser through the page Home Assistant
-  caches, so a page cached before Home Keeper was installed never loaded it. The card
-  is now registered the way every other custom card is, as a dashboard resource under
-  **Settings > Dashboards > Resources**, which the frontend fetches fresh on every
-  dashboard load. Existing installs get the entry on the next restart, and removing
-  Home Keeper takes it away again. (Fixes #228)
+  the Home Keeper card could show "Custom element doesn't exist: home-keeper-card",
+  because the card reached the browser only through the page Home Assistant caches. It
+  is now registered as a dashboard resource under **Settings > Dashboards > Resources**,
+  which the frontend fetches fresh on every load, and existing installs get the entry on
+  the next restart. (Fixes #228)
 - **Opening Configure no longer wipes your notifications and profiles.** Saving the
-  integration's options dialog (Settings → Devices & services → Home Keeper →
-  Configure) replaced the whole settings object with just the seven fields on that
-  form. Every notification, every profile, and every companion suggestion you had
-  dismissed was deleted. Notifications then stopped arriving, with nothing on screen
-  to say why. The dialog now changes only its own fields and leaves what you set in
-  the panel alone.
+  integration's options dialog replaced the whole settings object with just the seven
+  fields on that form, deleting every notification, every profile and every dismissed
+  companion suggestion. The dialog now changes only its own fields.
 - **Undoing a meter task's completion keeps your partial progress.** Deleting a
-  usage/meter completion (undoing an accidental "done") reset the meter to zero and
-  left it there. It now reverts to exactly where it was before that completion: 3,000
-  of 10,000 miles goes back to 3,000, not zero. (Fixes #235)
+  usage/meter completion reset the meter to zero and left it there. It now reverts to
+  where it was before that completion, so 3,000 of 10,000 miles goes back to 3,000.
+  (Fixes #235)
 - **"Mark done" on a notification now clears an auto-buy reminder.** Completing a
   "Buy {part}" reminder from a notification restocked the part but left the reminder
-  standing until something else happened to settle it, so it kept showing up as due.
-  Every other way of completing it already cleared it.
-- **Documented that auto-clearing sensor tasks consume consumable stock.** When a
-  sensor task with *Clear when back to normal* is linked to a consumable part, the
-  auto-completion draws down one spare from stock, the same as completing by hand. This
-  was always the behavior but was not mentioned in the README or the events reference.
+  standing until something else settled it. Every other way of completing it already
+  cleared it.
+- **Documented that auto-clearing sensor tasks consume consumable stock.** A sensor task
+  with *Clear when back to normal* linked to a consumable part draws down one spare on
+  auto-completion, the same as completing it by hand. This was always the behavior but
+  was not mentioned in the README or the events reference.
 
 ## [0.16.0b9]
 

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor", "number"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.16.0b9"
+PANEL_VERSION = "0.16.0"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -21,5 +21,5 @@
   "requirements": [
     "Babel>=2.12"
   ],
-  "version": "0.16.0b9"
+  "version": "0.16.0"
 }


### PR DESCRIPTION
Cuts the stable **0.16.0** from the `0.16.0b1`..`b9` beta line, and caps CHANGELOG bullets at three sentences.

## What changed

The three files `RELEASE.md` calls for, plus the two instruction files. No code changes:

- `custom_components/home_keeper/manifest.json` — `version` `0.16.0b9` → `0.16.0`
- `custom_components/home_keeper/const.py` — `PANEL_VERSION` `0.16.0b9` → `0.16.0`
- `CHANGELOG.md` — new `## [0.16.0] - 2026-08-25` section
- `AGENTS.md` + `.amazonq/rules/testing-and-workflow.md` — the new three-sentence cap

The section is written for someone upgrading from **0.15.0**, not as a beta-to-beta
diff. Work introduced over the betas is filed under **Added** as a 0.15.0 user would
perceive it, even where a later beta reshaped it mid-stream; only changes to behaviour
that existed in 0.15.0 are under **Fixed**.

### The three-sentence cap

The entries had grown into release notes written for whoever wrote the code: worked
examples, before-and-after stories, and an inventory of every new service field and
entity attribute. Both instruction files now cap a bullet at three sentences for the
**whole bullet**, counting the bold lead as the first. The 0.16.0 section is rewritten
to it, 117 lines down to 65.

Detail moves to `README.md`, `docs/`, or this PR. What survived the trim is everything a
user needs: the defaults ("leave both fields empty keeps the whole-spare counting"), the
two-way sync caveat, and the exclusion-inheritance behaviour. What went is the odometer
walkthrough, the surface-by-surface tours, and the `usage_baseline` /
`last_completion_reading` API inventory.

### Issues the release closes

`notify-issues` reads this section, so it is the release's issue list. Every issue a
commit since `v0.15.0` referenced with a closing keyword is in it:

| Issue | Where it lands |
| --- | --- |
| #214 Profile exclusions | Added |
| #220 Shopping list, filter, measured stock | Added (three bullets) |
| #235 Custom meter start, undo restores progress | Added + Fixed |
| #216 "Mark done" before due | Fixed |
| #221 One-off task stuck on the to-do list | Fixed |
| #228 Card missing on reload | Fixed |

Verified with the release tooling rather than by eye, before and again after the trim:
`ci/release-issues.py` parses all six with the intended summary quote, and its
`missing()` cross-check against the commit range since `v0.15.0` returns empty.

Also written into `AGENTS.md`, because it bit once here: `(Fixes #N)` must sit in the
bullet's **first** paragraph, since `release-issues.py` quotes the bullet where an issue
first appears.

> [!IMPORTANT]
> **#228 will be closed by this release, and its reporter last said it is still
> broken.** After `0.16.0b6` shipped the Lovelace-resource fix, @anton264 reported the
> same error persisting, confirmed the resource was registered and HA restarted, and
> reproduced it on iPad, iPhone, Safari and Chrome on macOS before falling back to the
> to-do list card. The last message on the thread is an unanswered question about
> whether one more reload clears a cached bad state. Flagged before cutting and the
> release was confirmed; keeping `(Fixes #228)` follows the documented convention that
> the section lists every issue the commits reference. Drop that one line before merge
> if you would rather the issue stay open.

### A note on the Vale gate

An earlier revision of this PR claimed "Vale reports zero hits on the added lines". That
claim was weaker than it sounded, and CI proved it: the `vale` job failed on
`ai-tells.VerbTricolon` in the rewritten Profiles bullet while a local Vale 3.9.1 found
nothing anywhere in the file.

Checking the rule's own regexes at block scope found **four** bullets matching, not the
one reviewdog had reached — Profiles, measured stock, do-once and dashboard card — all
the same shape: a modal or pronoun followed by three comma-separated chunks, which the
rule spans across sentence boundaries inside a single list item. All four are reworded;
`vale` is green. Re-running every `existence` and `substitution` rule in the ai-tells
package per bullet now reports zero hits on the section.

Why a local run can't be trusted here, and the block-scope/one-comma heuristic, are now
recorded in `AGENTS.md` and the Amazon Q rules.

## Checklist

- [x] Tests run locally — `pytest tests/unit -q`: 1286 passed, 2 skipped
- [x] `CHANGELOG.md` updated, with `(Fixes #N)` for each issue this ships
- [ ] Panel UI changed → n/a, no source changes in this PR
- [ ] New user-facing UI surface → n/a, no new surface
- [ ] New user-facing feature → n/a, this is the stable cut of the beta line

`ci/check-changelog-release-gap.py` passes locally, and every bullet is within the
three-sentence cap.