### PR TITLE
fix(panel): keep the sidebar panel up across a config-entry reload (Fixes #247)

### DIFF
--- a/.amazonq/rules/architecture-and-code.md
+++ b/.amazonq/rules/architecture-and-code.md
@@ -455,6 +455,26 @@ variables (`var(--primary-color)`, `var(--divider-color)`) — see the upload pr
 bar (`.hk-upload`). HA has broken us this way before (issue #144, `ha-dialog`'s slot
 API).
 
+### Frontend registrations outlive the config entry — never tear one down on unload
+The sidebar panel and the card's Lovelace resource are registered against the *HA
+run*, not the entry: both name a static module URL that
+`async_register_static_paths` serves until restart, and setup re-registers each one
+identically. An ordinary unload is almost always the first half of a **reload**, and
+reloads are routine here — saving options, a synced problem sensor appearing, a
+purged one-off, a language change. Dropping the registration in
+`async_unload_entry` therefore deletes it for as long as setup takes, on a schedule
+the user never asked for.
+
+For the panel that is user-visible damage, not churn: HA's `partial-panel-resolver`
+answers `home-keeper` disappearing out of `hass.panels` by navigating to the default
+panel, so a reload throws anyone reading the panel back to their dashboard. It reads
+as random because it is a race with the frontend's `get_panels` refetch — a fast
+reload usually wins, a slow one never does (#247). Tear both down in
+`async_remove_entry` instead, plus the panel when `entry.disabled_by` is set (HA
+sets it *before* unloading, and a disabled entry is the one unload that isn't coming
+back). Services are different: re-registering them is invisible, so they still go on
+the last loaded entry's unload.
+
 ### A dashboard asset ships as a Lovelace resource, not just an extra module URL
 `frontend.add_extra_js_url` reaches the browser exactly one way: `IndexView` renders an
 inline `import("<url>")` per extra module into the app-shell HTML — a response with no
@@ -798,6 +818,20 @@ The appliance/asset feature lives in `assets.py` (pure model — no HA imports, 
   `hass` itself — the HA-aware caller (`store.py`, `websocket_api.py`,
   `companions.py`) threads `hass.config.language` in, the same pattern
   `store.reconcile_part_tasks` already established for wear-part task names.
+- **Warm the tables in the executor before anything asks for a string.**
+  `backend_i18n` has no HA import by design, so it cannot dispatch its own reads the
+  way `notifier.py` does (#150) — and its `functools.cache` only helps *after* the
+  first read, which lands on whichever loop-bound caller gets there first (the
+  problem-sensor reconcile during setup, a websocket error reply, a CSV export). HA's
+  blocking-call detector logs every one of those as `Detected blocking call to
+  read_text ... inside the event loop` (#247). `async_setup_entry` runs
+  `backend_i18n.preload` through `hass.async_add_executor_job` before it touches the
+  store, so every later `resolve_*` is a cache hit; `preload` always warms English
+  alongside the requested language, because that is the fallback both resolvers
+  reach for. Add a table to this module and you add it to `preload` —
+  `tests/unit/test_backend_i18n_preload.py` checks *every* cached table, and
+  `tests/integration/test_event_loop_blocking.py` reads HA's own log back to catch
+  anything the unit lane can't see.
 
 ## Companion discovery (implemented)
 - Home Keeper surfaces integrations that work with it in the panel's **Settings →

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
 
 - **Home Keeper no longer throws you back to your dashboard.** Anything that reloaded
   the integration took the sidebar panel down until setup finished, and Home Assistant
-  navigates away from a panel that vanishes under it. The panel now survives a reload.
+  drops you out of a panel that vanishes under it. The panel now survives a reload.
   (Fixes #247)
 - **"Detected blocking call" warnings from Home Keeper are gone.** The integration read
   its backend string tables on Home Assistant's event loop the first time it needed a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to Home Keeper are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
 
+## [0.17.0] - 2026-08-26
+
+### Added
+
+- **Tree view for the appliance list.** A View toggle on the Appliances tab
+  switches between the flat list and a tree that nests child devices under their
+  parents. (Fixes #215)
+
+### Fixed
+
+- **Home Keeper no longer throws you back to your dashboard.** Anything that reloaded
+  the integration took the sidebar panel down until setup finished, and Home Assistant
+  navigates away from a panel that vanishes under it. The panel now survives a reload.
+  (Fixes #247)
+- **"Detected blocking call" warnings from Home Keeper are gone.** The integration read
+  its backend string tables on Home Assistant's event loop the first time it needed a
+  translated message. Startup now reads them off the loop instead.
+
 ## [0.17.0b1]
 
 ### Added

--- a/custom_components/home_keeper/__init__.py
+++ b/custom_components/home_keeper/__init__.py
@@ -1537,6 +1537,14 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # HA sets ``disabled_by`` before unloading, so the sidebar entry still goes
         # away when the user turns the integration off. Deleting it is handled in
         # ``async_remove_entry``.
+        #
+        # The one case this trades away: when the *setup* half of a reload fails, the
+        # sidebar entry now stays up against an entry in ``SETUP_ERROR``/``SETUP_RETRY``
+        # instead of vanishing. That is the better half of the trade — every websocket
+        # command already answers ``integration_not_loaded`` when it finds no loaded
+        # coordinator (see ``websocket_api._not_loaded``), so the panel reports the
+        # real state, and HA is usually about to retry setup anyway. Dropping the
+        # sidebar entry instead would hide that Home Keeper is even installed.
         if entry.disabled_by is not None:
             panel.async_unregister_panel(hass)
     return unloaded

--- a/custom_components/home_keeper/__init__.py
+++ b/custom_components/home_keeper/__init__.py
@@ -32,6 +32,7 @@ from homeassistant.helpers.start import async_at_started
 from homeassistant.util import dt as dt_util
 
 from . import (
+    backend_i18n,
     card,
     companions,
     devices,
@@ -480,6 +481,12 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Home Keeper from a config entry."""
+    # Read the backend string tables in the executor, before anything on the loop can
+    # ask for a string and read them itself. Everything downstream — the coordinator's
+    # first refresh, the problem-sensor reconcile, every websocket error reply — then
+    # resolves out of a warm cache. See ``backend_i18n.preload`` (#247).
+    await hass.async_add_executor_job(backend_i18n.preload, hass.config.language)
+
     store = HomeKeeperStore(hass)
     await store.load()
 
@@ -1505,16 +1512,33 @@ _SERVICES = (
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unloaded = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    # Only tear down the panel/services when the last entry goes away. Gate on
-    # *loaded* entries, not ``async_entries``: HA removes the entry from the registry
-    # only *after* this unload returns (and a disabled entry stays registered), so
+    # Only tear down when the last entry goes away. Gate on *loaded* entries, not
+    # ``async_entries``: HA removes the entry from the registry only *after* this
+    # unload returns (and a disabled entry stays registered), so
     # ``async_entries(DOMAIN)`` is never empty here and the teardown was dead code —
-    # leaving the panel pointing at a dead backend and all services registered until
-    # restart. ``async_loaded_entries`` excludes the entry currently unloading.
+    # leaving all services registered until restart. ``async_loaded_entries``
+    # excludes the entry currently unloading.
     if unloaded and not hass.config_entries.async_loaded_entries(DOMAIN):
-        panel.async_unregister_panel(hass)
         for service in _SERVICES:
             hass.services.async_remove(DOMAIN, service)
+        # The sidebar panel is deliberately *not* dropped on an ordinary unload,
+        # because most unloads are the first half of a reload — and a reload is
+        # routine here (saving options, a synced problem sensor appearing, a purged
+        # one-off). Removing the panel deletes ``home-keeper`` from ``hass.panels``
+        # for as long as setup takes, and Home Assistant's ``partial-panel-resolver``
+        # answers a panel disappearing under an open page by navigating to the
+        # default one: #247's reporter was thrown back to their dashboard "every 10
+        # seconds or so". Nothing about the registration is entry-scoped — it names a
+        # static module URL served for the whole HA run and is re-registered
+        # identically — so leaving it up costs nothing. ``card.py`` takes the same
+        # stance, for the same reason.
+        #
+        # A *disabled* entry is the one unload that isn't coming back on its own, and
+        # HA sets ``disabled_by`` before unloading, so the sidebar entry still goes
+        # away when the user turns the integration off. Deleting it is handled in
+        # ``async_remove_entry``.
+        if entry.disabled_by is not None:
+            panel.async_unregister_panel(hass)
     return unloaded
 
 
@@ -1526,9 +1550,11 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     our stored tasks/assets document and the uploaded-documents blob tree so no
     residue is left behind.
     """
-    # The card's Lovelace resource is not entry-scoped state, so HA won't reap it.
-    # Removal — not unload, which also runs on every reload — is the one point where
-    # dropping it is right; left behind it would point at a 404 forever.
+    # Neither the sidebar panel nor the card's Lovelace resource is entry-scoped
+    # state, so HA won't reap either. Removal — not unload, which also runs on every
+    # reload — is the one point where dropping them is right; left behind, both point
+    # at a backend that is never coming back.
+    panel.async_unregister_panel(hass)
     await card.async_unregister_card_resource(hass)
     discard_edge_state(hass, entry.entry_id)
     store = HomeKeeperStore(hass)

--- a/custom_components/home_keeper/backend_i18n.py
+++ b/custom_components/home_keeper/backend_i18n.py
@@ -99,3 +99,32 @@ def resolve_string(lang: str, key: str, **params: Any) -> str:
         key, key
     )
     return _interpolate(template, params)
+
+
+def preload(lang: str) -> None:
+    """Read every string table for *lang* into cache. **Blocking** — call from an
+    executor, never from the event loop.
+
+    Each table above is read from disk exactly once per language and memoized, so
+    the cost is a one-off — but it lands on whichever caller happens to get there
+    first, and every one of those callers is on Home Assistant's event loop: the
+    problem-sensor reconcile during setup, a websocket error reply, an inventory
+    export. Home Assistant's blocking-call detector catches it and logs a
+    ``Detected blocking call to read_text ... inside the event loop`` warning
+    naming this file, which is what issue #247's reporter pasted. (``notifier.py``
+    had the same problem in #150 and solved it the other way — dispatching each
+    lookup through ``hass.async_add_executor_job`` — but that is not available
+    here, because the callers are the pure modules and this module has no Home
+    Assistant import to hand them one.)
+
+    So the loop-bound callers never do the reading: ``async_setup_entry`` runs this
+    once in the executor before anything can ask for a string, and every later
+    ``resolve_*`` is a cache hit. English is always included — it is the fallback
+    both resolvers reach for when a key is missing from the caller's language, so
+    warming only that language would leave the second read on the loop.
+
+    Idempotent: a second call (an entry reload, a second entry) hits the caches.
+    """
+    for wanted in dict.fromkeys((lang, _DEFAULT_LANG)):
+        _exceptions(wanted)
+        _backend_strings(wanted)

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor", "number"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.17.0b1"
+PANEL_VERSION = "0.17.0"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -21,5 +21,5 @@
   "requirements": [
     "Babel>=2.12"
   ],
-  "version": "0.17.0b1"
+  "version": "0.17.0"
 }

--- a/custom_components/home_keeper/panel.py
+++ b/custom_components/home_keeper/panel.py
@@ -96,6 +96,12 @@ async def async_register_panel(hass: HomeAssistant) -> None:
 
 
 def async_unregister_panel(hass: HomeAssistant) -> None:
-    """Remove the sidebar panel (static path persists for the HA lifetime)."""
+    """Remove the sidebar panel (static path persists for the HA lifetime).
+
+    Only for an unload the entry isn't coming back from — the integration removed,
+    or disabled. An ordinary unload is usually the first half of a reload, and
+    taking the panel down mid-reload navigates anyone viewing it to their default
+    dashboard (#247); see ``__init__.async_unload_entry``.
+    """
     if PANEL_URL_PATH in hass.data.get("frontend_panels", {}):
         frontend.async_remove_panel(hass, PANEL_URL_PATH)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,7 @@ _COMPONENT_DIR = _CUSTOM_COMPONENTS_DIR / "home_keeper"
 _PKG = "custom_components.home_keeper"
 _PURE_MODULES = (
     "const",
+    "backend_i18n",
     "recurrence",
     "models",
     "assets",

--- a/tests/integration/test_event_loop_blocking.py
+++ b/tests/integration/test_event_loop_blocking.py
@@ -1,0 +1,72 @@
+"""Integration test: nothing in Home Keeper reads a file on the event loop (#247).
+
+The log the reporter of #247 pasted is Home Assistant's own blocking-call detector
+catching ``backend_i18n`` opening its string tables straight from the loop thread:
+
+    Detected blocking call to read_text with args
+    (PosixPath('/config/custom_components/home_keeper/backend_strings/en.json'),)
+    inside the event loop by custom integration 'home_keeper'
+
+``backend_i18n`` deliberately has no Home Assistant import — the pure modules
+(``problem_tasks``, ``inventory``, ``companions_catalog``) call it, so it cannot
+reach for ``hass.async_add_executor_job`` itself — and its ``functools.cache`` only
+helps *after* the first read. Those first reads land wherever the first caller
+happens to be: the problem-sensor reconcile during setup, a websocket error reply,
+a CSV export. ``notifier``'s equivalent was #150; this is the same bug in the other
+half of the backend's string handling.
+
+The assertion is the reporter's log itself, read back through ``/api/error_log``.
+That covers every path in the integration, not just the two provoked below —
+those exist so a refactor that stops resolving strings altogether can't make this
+pass by doing nothing.
+"""
+
+import json
+
+import websockets.sync.client
+from conftest import HA_URL, call_service
+
+_WS_URL = HA_URL.replace("http://", "ws://") + "/api/websocket"
+
+
+def _ws_call(ha, payload: dict) -> dict:
+    token = ha.headers["Authorization"].split(" ", 1)[1]
+    with websockets.sync.client.connect(_WS_URL) as ws:
+        assert json.loads(ws.recv())["type"] == "auth_required"
+        ws.send(json.dumps({"type": "auth", "access_token": token}))
+        assert json.loads(ws.recv())["type"] == "auth_ok"
+        ws.send(json.dumps({"id": 1, **payload}))
+        return json.loads(ws.recv())
+
+
+def _error_log(ha) -> str:
+    r = ha.get(f"{HA_URL}/api/error_log", timeout=30)
+    r.raise_for_status()
+    return r.text
+
+
+def test_backend_string_lookups_never_block_the_event_loop(ha):
+    # Provoke both string tables from the loop. `translations/<lang>.json` backs a
+    # websocket error reply...
+    reply = _ws_call(
+        ha, {"type": "home_keeper/complete_task", "task_id": "no-such-task-247"}
+    )
+    assert not reply.get("success"), reply
+    # ...and the message must be the *resolved* template, not the bare key: a
+    # lookup that silently fell back would leave nothing for this test to measure.
+    assert reply["error"]["message"] == "Task not found: no-such-task-247", reply
+
+    # ...while `backend_strings/<lang>.json` backs the inventory CSV's headers.
+    export = call_service(ha, "home_keeper", "export_inventory", {}, True)
+    csv = export.get("service_response", export)["csv"]
+    assert csv.splitlines()[0].startswith("Name,"), csv.splitlines()[0]
+
+    offenders = [
+        line
+        for line in _error_log(ha).splitlines()
+        if "Detected blocking call" in line and "home_keeper" in line
+    ]
+    assert offenders == [], (
+        "Home Assistant caught Home Keeper doing file I/O on the event loop:\n"
+        + "\n".join(offenders)
+    )

--- a/tests/integration/test_panel_stability.py
+++ b/tests/integration/test_panel_stability.py
@@ -1,0 +1,138 @@
+"""Integration test: a config-entry reload must not take the sidebar panel down (#247).
+
+The reporter of #247 was thrown out of the Home Keeper panel and back to their
+default dashboard "every 10 seconds or so", starting with the Settings tab's
+**Add notification** button. That button saves through
+``options.async_set_options``, which reloads the config entry — and unloading the
+entry used to call ``frontend.async_remove_panel``. So a reload deleted
+``home-keeper`` from ``hass.panels`` and put it back a moment later, and Home
+Assistant's ``partial-panel-resolver`` reacts to a panel disappearing out from
+under the page by navigating to the default panel. Whether you were bounced came
+down to whether the frontend's ``get_panels`` refetch landed inside the window,
+which is why it looked random: the wider the window (a big store, many
+integrations, a slow box), the more reliably it fired. Reproduced here by holding
+the panel unregistered for a few seconds during setup — the browser leaves
+``/home-keeper`` for ``/home/overview`` every time.
+
+The panel is not entry-scoped state to begin with: it points at a static module
+URL that ``async_register_static_paths`` serves for the whole HA run, and it is
+re-registered with exactly the same config on the way back in. So the invariant
+below is the strong one — a reload must not touch it *at all* — rather than "it
+comes back quickly enough". ``card.py`` already takes this stance for the card's
+Lovelace resource, for the same reason.
+
+``panels_updated`` is the observable: Home Assistant fires it on every
+``async_register_built_in_panel`` and every ``async_remove_panel``. Zero events
+across a reload means the sidebar entry never moved.
+"""
+
+import json
+import time
+
+import websockets.sync.client
+from conftest import HA_URL, call_service
+from ha_registry import ws_send
+
+_WS_URL = HA_URL.replace("http://", "ws://") + "/api/websocket"
+
+PANEL_URL_PATH = "home-keeper"
+
+#: How long to keep listening for a stray ``panels_updated`` after the reload has
+#: returned. The reload itself is synchronous, so this only has to cover a task
+#: racing just behind it.
+_SETTLE_SECONDS = 5
+
+
+def _entry_id(ha) -> str:
+    token = ha.headers["Authorization"].split(" ", 1)[1]
+    entries = ws_send(token, {"type": "config_entries/get", "domain": "home_keeper"})
+    assert entries.get("success"), entries
+    return entries["result"][0]["entry_id"]
+
+
+def _panels_updated_during(ha, trigger) -> tuple[list[dict], dict]:
+    """Run *trigger* with a ``panels_updated`` subscription open.
+
+    Returns the events seen and the panel table as it stands afterwards, both read
+    over the one connection so the subscription is provably live before *trigger*
+    runs.
+    """
+    token = ha.headers["Authorization"].split(" ", 1)[1]
+    with websockets.sync.client.connect(_WS_URL) as ws:
+        assert json.loads(ws.recv())["type"] == "auth_required"
+        ws.send(json.dumps({"type": "auth", "access_token": token}))
+        assert json.loads(ws.recv())["type"] == "auth_ok"
+
+        ws.send(
+            json.dumps(
+                {"id": 1, "type": "subscribe_events", "event_type": "panels_updated"}
+            )
+        )
+        subscribed = json.loads(ws.recv())
+        assert subscribed.get("success"), subscribed
+
+        trigger()
+
+        events: list[dict] = []
+        deadline = time.monotonic() + _SETTLE_SECONDS
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            try:
+                msg = json.loads(ws.recv(timeout=remaining))
+            except TimeoutError:
+                break
+            if msg.get("id") == 1 and msg.get("type") == "event":
+                events.append(msg["event"])
+
+        ws.send(json.dumps({"id": 2, "type": "get_panels"}))
+        while True:
+            msg = json.loads(ws.recv(timeout=10))
+            if msg.get("id") == 2 and msg.get("type") == "result":
+                assert msg.get("success"), msg
+                return events, msg["result"]
+
+
+def test_reloading_the_entry_never_removes_the_sidebar_panel(ha):
+    entry_id = _entry_id(ha)
+
+    def reload():
+        r = ha.post(f"{HA_URL}/api/config/config_entries/entry/{entry_id}/reload")
+        r.raise_for_status()
+
+    events, panels = _panels_updated_during(ha, reload)
+
+    assert events == [], (
+        f"a config-entry reload moved the sidebar panel ({len(events)} "
+        "panels_updated events). Removing and re-adding the panel deletes it from "
+        "hass.panels for as long as setup takes, and the frontend navigates anyone "
+        "viewing it to their default dashboard (#247)"
+    )
+    assert PANEL_URL_PATH in panels
+
+
+def test_saving_options_never_removes_the_sidebar_panel(ha):
+    """The reporter's own trigger: saving from the panel's Settings tab.
+
+    Every Settings save (a new notification, a profile, a changed toggle) goes
+    through the same ``home_keeper/set_options`` websocket command as this service,
+    and that path reloads the entry to re-run the problem-sensor reconcile.
+    """
+
+    def save():
+        # A real change, not a no-op: `async_set_options` short-circuits without
+        # reloading when the merged options equal what is already stored, which
+        # would make this assert nothing.
+        call_service(ha, "home_keeper", "set_options", {"one_off_retention_days": 3})
+
+    try:
+        events, panels = _panels_updated_during(ha, save)
+    finally:
+        call_service(ha, "home_keeper", "set_options", {"one_off_retention_days": 0})
+
+    assert events == [], (
+        "saving Home Keeper's options moved the sidebar panel — this is exactly "
+        "what threw the reporter of #247 out of the panel on Add notification"
+    )
+    assert PANEL_URL_PATH in panels

--- a/tests/unit/test_backend_i18n_preload.py
+++ b/tests/unit/test_backend_i18n_preload.py
@@ -1,0 +1,85 @@
+"""``backend_i18n.preload`` must leave every string table warm (#247).
+
+The point of ``preload`` is that no ``resolve_exception``/``resolve_string`` call
+ever reads a file, because the reading was done once in an executor during
+``async_setup_entry``. Miss a table and the module goes straight back to opening
+JSON on Home Assistant's event loop the first time something asks for one of its
+keys — the warning the reporter of #247 pasted.
+
+``tests/integration/test_event_loop_blocking.py`` asserts the outcome against Home
+Assistant's own blocking-call detector. This is the fast-lane guard on the piece
+that has to stay in step by hand: a table added to this module has to be added to
+``preload`` too, so the check below is written against *every* cached table the
+module defines rather than the two that exist today.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+backend_i18n = sys.modules["hk.backend_i18n"]
+
+
+def _cached_tables() -> list:
+    """Every ``functools.cache``d table in the module (what ``preload`` must fill)."""
+    return [
+        value
+        for value in vars(backend_i18n).values()
+        if callable(value)
+        and hasattr(value, "cache_info")
+        and hasattr(value, "cache_clear")
+    ]
+
+
+def test_preload_warms_every_cached_table_for_the_language_and_english():
+    tables = _cached_tables()
+    assert tables, "expected backend_i18n to memoize its string tables"
+    for table in tables:
+        table.cache_clear()
+
+    backend_i18n.preload("de")
+
+    for table in tables:
+        entries = table.cache_info().currsize
+        assert entries == 2, (
+            f"{table.__name__} holds {entries} cached languages after "
+            "preload('de') — it must be warm for both the requested language and "
+            "the English fallback, or the first resolve does file I/O on the loop"
+        )
+
+
+def test_resolving_after_preload_reads_no_files(monkeypatch):
+    for table in _cached_tables():
+        table.cache_clear()
+    backend_i18n.preload("en")
+
+    reads: list[Path] = []
+    real_read_text = Path.read_text
+
+    def spy(self: Path, *args, **kwargs):
+        reads.append(self)
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", spy)
+
+    # One key from each table, resolved (not falling through to the bare key) — a
+    # miss would prove the table empty and make the "no reads" assertion vacuous.
+    assert (
+        backend_i18n.resolve_exception("en", "task_not_found", task_id="t1")
+        == "Task not found: t1"
+    )
+    assert backend_i18n.resolve_string("en", "inventory.csv.name") == "Name"
+    assert reads == [], f"resolving read files after preload: {reads}"
+
+
+def test_preload_is_idempotent():
+    """An entry reload calls it again; that must not re-read anything."""
+    for table in _cached_tables():
+        table.cache_clear()
+    backend_i18n.preload("fr")
+    before = [table.cache_info().misses for table in _cached_tables()]
+
+    backend_i18n.preload("fr")
+
+    assert [table.cache_info().misses for table in _cached_tables()] == before

--- a/tests/unit/test_release_issues.py
+++ b/tests/unit/test_release_issues.py
@@ -522,6 +522,7 @@ _KNOWN_ISSUES = frozenset(
         221,
         228,
         235,
+        247,
     }
 )
 


### PR DESCRIPTION
Fixes #247

## What changed

### The bounce (the reported crash)

`async_unload_entry` called `frontend.async_remove_panel`, so a config-entry
**reload** deleted `home-keeper` from `hass.panels` and put it back once setup
finished. Home Assistant's `partial-panel-resolver` answers a panel disappearing
out from under the page by moving the viewer to the default panel — so a reload
throws whoever is reading the panel back to their dashboard.

That explains both halves of the report. The reporter's first trigger, **Add
notification**, saves through `options.async_set_options`, which reloads the entry.
It then "just went random" because reloads are routine here: a synced problem sensor
appearing, an auto-buy reminder created or retired, a purged one-off, a language
change.

Nothing about the registration is entry-scoped: it names a static module URL that
`async_register_static_paths` serves for the whole HA run, and setup re-registers it
identically. So the panel is now dropped in `async_remove_entry`, plus on unload when
`entry.disabled_by` is set — HA sets that *before* unloading, and a disabled entry is
the one unload that isn't coming back. Services still go on the last loaded entry's
unload; re-registering those is invisible. `card.py` already took this stance for the
card's Lovelace resource, for the same reason.

### The blocking-call warnings (the pasted log)

The log in the issue is HA's blocking-call detector catching `backend_i18n` opening
its string tables straight from the loop thread. That module deliberately has no Home
Assistant import — the pure modules (`problem_tasks`, `inventory`,
`companions_catalog`) call it — so it cannot dispatch its own reads the way
`notifier.py` does for #150, and its `functools.cache` only helps *after* the first
read. That first read lands on whichever loop-bound caller gets there first.

`async_setup_entry` now warms both tables through `hass.async_add_executor_job`
before it touches the store, so every later `resolve_*` is a cache hit. `preload`
always warms English alongside the configured language, because that is the fallback
both resolvers reach for.

Those warnings are **not** the reported crash, and the reporter's own "not sure if
related" was right. Their log shows 4 occurrences across three hours — the cache fills
once per process, so it cannot produce a symptom recurring every ten seconds. Fixed
because it is a real Platinum-scale violation that arrived in the same report.

### Tests (all failing before the change)

| Test | Asserts |
| --- | --- |
| `tests/integration/test_panel_stability.py` | A reload — and an options save, the reporter's own trigger — produces **no** `panels_updated` events at all. Two before the fix (remove, then re-add). |
| `tests/integration/test_event_loop_blocking.py` | HA's own blocking-call detector, read back through `/api/error_log`, names nothing of ours. Provokes both string tables first so it can't pass by doing nothing. |
| `tests/unit/test_backend_i18n_preload.py` | `preload` warms *every* cached table in the module, not just the two that exist today; resolving after it reads no files. |

Verified in a real browser too, and it needs no help to reproduce. Sitting on
`/home-keeper` and reloading the config entry sent Chromium to `/home/overview` on
**3 of 3 runs** against `main`, and left it on `/home-keeper` on **3 of 3** with this
branch. The removal and re-registration are only ~19 ms apart, so the window is far
tighter than it needs to be — the frontend loses that race every time, which is why
the reporter could not get through ten seconds of use.

### Release

Cuts **0.17.0 stable**, rolling the `0.17.0b1` tree view up into `### Added` as
AGENTS.md prescribes for a stable section. That is deliberate rather than another
beta: #247 is a regression every 0.16.0 user is hitting now, and this repo releases
off a single `main` line, so a `0.16.1` patch off the stable tag isn't a shape the
release process supports. `ci/release-issues.py --version 0.17.0` resolves #215 and
#247, so `notify-issues` closes both.

### Docs

`.amazonq/rules/architecture-and-code.md` gains the two conventions this
established: frontend registrations outlive the config entry and are never torn down
on an ordinary unload, and `backend_i18n`'s tables are warmed in the executor at
setup.

## Checklist

- [x] Tests run locally — unit 1291 passed, frontend 647 passed, integration 156
      passed, e2e 65 passed, `ruff check`/`format` clean, `vale` clean on the new
      CHANGELOG lines
- [x] `CHANGELOG.md` updated, with `(Fixes #247)` in the bullet's first paragraph
- [x] Panel UI unchanged (backend only) — no screenshots needed
- [x] No new user-facing UI surface — walkthrough untouched
- [x] Not a new feature — no beta bump or `preview-release` label; version goes
      straight to `0.17.0` stable as discussed above

> [!NOTE]
> `mypy` was not run locally: it needs Home Assistant installed, and HA's Python
> floor is above what this session's interpreter offers (3.11), so a local install
> would silently resolve a stale HA — exactly what `ci/check-ha-version.py` exists to
> catch. `lint.yml` covers it, and passed.
