### PR TITLE
fix(todo): date to-do items in Home Assistant's timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to Home Keeper are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
 
+## [0.18.0b2]
+
+### Fixed
+
+- **To-do items show the right due date outside UTC.** A task due at local midnight showed
+  the previous day on `todo.home_keeper_tasks` while the panel showed the correct one. A
+  wear part's last-replaced date shifted the same way when the replacement was back-dated.
+  (Fixes #250)
+
 ## [0.18.0b1]
 
 ### Fixed

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor", "number"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.18.0b1"
+PANEL_VERSION = "0.18.0b2"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -21,5 +21,5 @@
   "requirements": [
     "Babel>=2.12"
   ],
-  "version": "0.18.0b1"
+  "version": "0.18.0b2"
 }

--- a/custom_components/home_keeper/store.py
+++ b/custom_components/home_keeper/store.py
@@ -1536,7 +1536,17 @@ class HomeKeeperStore:
         asset = self._assets.get(src["asset_id"])
         if not asset:
             return
-        when_date = when.date().isoformat() if hasattr(when, "date") else str(when)[:10]
+        # ``as_local`` first (#250): *when* carries the offset the caller supplied — UTC
+        # for a completion back-dated through the panel's date picker — and a bare
+        # ``.date()`` would take the calendar date in that offset. ``last_replaced`` is
+        # a date-only string that ``reconcile`` re-anchors the part's recurrence to, so
+        # a one-day shift here shifts the whole wear cycle. The ``hasattr`` guard keeps
+        # the true branch a datetime: a plain ``date`` has no ``.date()`` method.
+        when_date = (
+            dt_util.as_local(when).date().isoformat()
+            if hasattr(when, "date")
+            else str(when)[:10]
+        )
         for part in asset.get("parts", []):
             if part.get("id") == src.get("part_id"):
                 part["last_replaced"] = when_date

--- a/custom_components/home_keeper/todo.py
+++ b/custom_components/home_keeper/todo.py
@@ -83,7 +83,14 @@ class HomeKeeperTodoListEntity(
                     uid=task["id"],
                     summary=task["name"],
                     status=TodoItemStatus.NEEDS_ACTION,
-                    due=due.date() if due else None,
+                    # ``as_local`` before ``date()``, never ``due.date()`` (#250). A
+                    # stored ``next_due`` carries whatever offset it was written with —
+                    # a completion made "now" gets the local one, one entered through
+                    # the panel's date picker gets UTC — and ``.date()`` takes the
+                    # calendar date *in that offset*. A task due at local midnight then
+                    # reads as the previous day here while the panel reads it right,
+                    # and everything downstream of the entity inherits the shift.
+                    due=dt_util.as_local(due).date() if due else None,
                     description=task.get("notes") or None,
                 )
             )

--- a/tests/integration/test_assets.py
+++ b/tests/integration/test_assets.py
@@ -6,6 +6,8 @@ can attach to that virtual device (its per-task entities merge onto the same pag
 and that the asset CRUD services round-trip.
 """
 
+from datetime import UTC, datetime, timedelta
+
 from conftest import call_service, list_states
 
 
@@ -354,6 +356,69 @@ def test_wear_part_next_due_does_not_drift_on_asset_edit(ha):
     due_after = _part_tasks_for(ha, asset["id"])[0]["next_due"]
     call_service(ha, "home_keeper", "delete_asset", {"asset_id": asset["id"]})
     assert due_after == due_before, f"next_due drifted: {due_before} -> {due_after}"
+
+
+def test_back_dated_part_completion_stamps_the_local_date(ha):
+    """Regression (#250): last_replaced took the date in the completion's own offset.
+
+    Same root cause as the to-do due date, one layer deeper. A completion back-dated
+    through the panel's date picker arrives on a UTC offset, and the store's part stamp
+    used to call ``.date()`` on it directly. The container runs on America/New_York, so
+    02:00 UTC belongs to the previous local day — and because ``reconcile`` re-anchors
+    the part's recurrence to ``last_replaced``, a one-day shift here moves the whole
+    wear cycle, not just a label.
+    """
+    import time
+    import uuid
+
+    # Yesterday in UTC, at 02:00 — 21:00 or 22:00 the day before in New York, which
+    # side of a DST change it lands on. Always in the past, so it stays valid whenever
+    # the suite runs (a future last_replaced is rejected on the asset-edit path).
+    utc_day = (datetime.now(UTC) - timedelta(days=1)).date()
+    completed_at = f"{utc_day.isoformat()}T02:00:00+00:00"
+    expected_local = (utc_day - timedelta(days=1)).isoformat()
+
+    name = f"Timezone part probe {uuid.uuid4().hex[:8]}"
+    call_service(
+        ha,
+        "home_keeper",
+        "add_asset",
+        {
+            "name": name,
+            "parts": [
+                {
+                    "name": "Gasket",
+                    "type": "wear",
+                    "replace_interval": 12,
+                    "replace_unit": "months",
+                }
+            ],
+        },
+    )
+    asset = None
+    for _ in range(20):
+        asset = _newest_asset_named(ha, name)
+        if asset and _part_tasks_for(ha, asset["id"]):
+            break
+        time.sleep(1)
+    assert asset and _part_tasks_for(ha, asset["id"]), (
+        "wear part should have created a task"
+    )
+    try:
+        task = _part_tasks_for(ha, asset["id"])[0]
+        call_service(
+            ha,
+            "home_keeper",
+            "complete_task",
+            {"task_id": task["id"], "completed_at": completed_at},
+        )
+        refreshed = _newest_asset_named(ha, name)
+        part = next(p for p in refreshed["parts"] if p["name"] == "Gasket")
+        assert part["last_replaced"] == expected_local, (
+            f"completed at {completed_at}; last_replaced must be the local date"
+        )
+    finally:
+        call_service(ha, "home_keeper", "delete_asset", {"asset_id": asset["id"]})
 
 
 def test_subdevice_has_warranty_independent_and_parent_seeded(ha):

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -19,7 +19,7 @@ def _list_tasks(ha):
     return resp.get("service_response", resp)["tasks"]
 
 
-def _todo_summaries(ha):
+def _todo_items(ha):
     """The to-do list's actual items, not just the count the entity state carries."""
     resp = call_service(
         ha,
@@ -29,7 +29,11 @@ def _todo_summaries(ha):
         return_response=True,
     )
     payload = resp.get("service_response", resp)
-    return [item["summary"] for item in payload["todo.home_keeper_tasks"]["items"]]
+    return payload["todo.home_keeper_tasks"]["items"]
+
+
+def _todo_summaries(ha):
+    return [item["summary"] for item in _todo_items(ha)]
 
 
 def test_todo_entity_exists_with_seeded_tasks(ha):
@@ -87,6 +91,48 @@ def test_completed_one_off_leaves_the_todo_list(ha):
         # ...and the completion history stayed at the single real completion.
         task = next(t for t in _list_tasks(ha) if t["id"] == task_id)
         assert len(task["completions"]) == 1
+    finally:
+        call_service(ha, "home_keeper", "delete_task", {"task_id": task_id})
+
+
+def test_todo_due_date_uses_home_assistants_timezone(ha):
+    """Regression (#250): a UTC-stored next_due showed the previous local day.
+
+    The container runs on America/New_York (ha_config/configuration.yaml), so a due
+    time of 02:00 UTC is 22:00 the day before, locally. The entity used to call
+    ``.date()`` on the parsed timestamp, which read the date in whatever offset the
+    store happened to hold — the 15th here, one day past what the panel showed.
+
+    This has to be an integration assertion: what is being pinned is the date Home
+    Assistant's own ``todo.get_items`` hands to a card, a digest or an automation, and
+    a unit test that stubs ``dt_util`` cannot see that contract.
+    """
+    name = "Timezone todo probe"
+    resp = call_service(
+        ha,
+        "home_keeper",
+        "add_task",
+        {
+            "name": name,
+            "recurrence_type": "one-off",
+            # A one-off's next_due is its stored due verbatim, so this pins the exact
+            # offset the bug needs: 2026-07-14 22:00 EDT.
+            "due": "2026-07-15T02:00:00+00:00",
+        },
+        return_response=True,
+    )
+    task_id = resp.get("service_response", resp)["task_id"]
+    try:
+        item = next(i for i in _todo_items(ha) if i["summary"] == name)
+        assert item["due"] == "2026-07-14", (
+            "the to-do item must be dated in HA's timezone, not the stored offset"
+        )
+        # The panel reads next_due directly, and the two surfaces must agree about
+        # which day that instant falls on.
+        task = next(t for t in _list_tasks(ha) if t["id"] == task_id)
+        assert task["next_due"].startswith("2026-07-15T02:00:00"), (
+            "the stored instant itself is correct and must not have been rewritten"
+        )
     finally:
         call_service(ha, "home_keeper", "delete_task", {"task_id": task_id})
 

--- a/tests/unit/test_release_issues.py
+++ b/tests/unit/test_release_issues.py
@@ -524,6 +524,7 @@ _KNOWN_ISSUES = frozenset(
         235,
         247,
         248,
+        250,
     }
 )
 

--- a/tests/unit/test_todo.py
+++ b/tests/unit/test_todo.py
@@ -21,7 +21,7 @@ import importlib.util
 import sys
 import types
 import typing
-from datetime import date, datetime, timedelta, timezone
+from datetime import UTC, date, datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -165,6 +165,19 @@ def _install_ha_stubs() -> None:
                 return None
 
         dt_mod.parse_datetime = parse_datetime
+    # Guarded separately from ``parse_datetime``: ``test_calendar.py`` installs its own
+    # ``homeassistant.util.dt`` carrying only ``parse_datetime``/``now``, so folding
+    # these into that branch would make load order between the suites matter.
+    if not hasattr(dt_mod, "DEFAULT_TIME_ZONE"):
+        dt_mod.DEFAULT_TIME_ZONE = UTC
+    if not hasattr(dt_mod, "as_local"):
+
+        def as_local(value):
+            # Reads the module global at call time, like HA's own implementation, so a
+            # test can point "local" somewhere by monkeypatching DEFAULT_TIME_ZONE.
+            return value.astimezone(dt_mod.DEFAULT_TIME_ZONE)
+
+        dt_mod.as_local = as_local
     util.dt = dt_mod
 
 
@@ -291,6 +304,58 @@ def test_armed_one_off_is_listed_with_its_due_date() -> None:
     assert item.status is TodoItemStatus.NEEDS_ACTION
     assert item.due == date(2026, 7, 15)
     assert item.description == "bring photos"
+
+
+# --- todo_items: the due date is a *local* calendar date (#250) ---------------
+
+
+def test_due_date_is_taken_in_home_assistants_timezone(monkeypatch) -> None:
+    """#250: a ``+00:00`` next_due at local midnight showed the previous day.
+
+    The reporter's own numbers, on Europe/London in BST. Their task's last completion
+    was entered through the panel's date picker, which sends local midnight expressed
+    in UTC, so ``next_due`` landed on ``+00:00``. Taking ``.date()`` in that offset
+    read the 26th while the panel and ``list_tasks`` both read the 27th.
+    """
+    monkeypatch.setattr(todo.dt_util, "DEFAULT_TIME_ZONE", timezone(timedelta(hours=1)))
+    entity, _store, _calls = _entity(
+        _task("vacuum", "floating", next_due="2026-08-26T23:00:00+00:00")
+    )
+    (item,) = entity.todo_items
+    assert item.due == date(2026, 8, 27)
+
+
+def test_due_date_shifts_back_when_local_trails_the_stored_offset(monkeypatch) -> None:
+    """The opposite direction, so the conversion cannot pass by doing nothing.
+
+    ``2026-07-15T01:00:00+01:00`` is 2026-07-14 20:00 in a UTC-4 zone, so the local
+    date is the 14th even though the stored string opens with the 15th. A fix that
+    only ever moved dates forward, or that read the stored offset again, fails here.
+    """
+    monkeypatch.setattr(
+        todo.dt_util, "DEFAULT_TIME_ZONE", timezone(timedelta(hours=-4))
+    )
+    entity, _store, _calls = _entity(
+        _task("filter", "floating", next_due="2026-07-15T01:00:00+01:00")
+    )
+    (item,) = entity.todo_items
+    assert item.due == date(2026, 7, 14)
+
+
+def test_due_date_is_unchanged_when_the_offset_already_matches_local(
+    monkeypatch,
+) -> None:
+    """A next_due already written in the local offset keeps its date.
+
+    This is the majority case — a completion made "now" is stored with HA's own
+    offset — and it is why the bug hid for so long: those tasks were always right.
+    """
+    monkeypatch.setattr(todo.dt_util, "DEFAULT_TIME_ZONE", timezone(timedelta(hours=1)))
+    entity, _store, _calls = _entity(
+        _task("live", "floating", next_due="2026-08-27T00:00:00+01:00")
+    )
+    (item,) = entity.todo_items
+    assert item.due == date(2026, 8, 27)
 
 
 def test_skipped_one_off_is_dropped() -> None:

--- a/tests/unit/test_todo.py
+++ b/tests/unit/test_todo.py
@@ -173,8 +173,11 @@ def _install_ha_stubs() -> None:
     if not hasattr(dt_mod, "as_local"):
 
         def as_local(value):
-            # Reads the module global at call time, like HA's own implementation, so a
-            # test can point "local" somewhere by monkeypatching DEFAULT_TIME_ZONE.
+            # Reads the module global at call time, like HA's own implementation.
+            # Nothing here patches it — a test that needs a different "local" swaps
+            # `todo.dt_util` wholesale via `_local_tz`, for the reason spelled out
+            # there — so this only ever resolves to UTC. It exists so the tests that
+            # don't care about the zone can still call `todo_items` under the stubs.
             return value.astimezone(dt_mod.DEFAULT_TIME_ZONE)
 
         dt_mod.as_local = as_local
@@ -309,6 +312,33 @@ def test_armed_one_off_is_listed_with_its_due_date() -> None:
 # --- todo_items: the due date is a *local* calendar date (#250) ---------------
 
 
+def _local_tz(monkeypatch, offset_hours: int) -> None:
+    """Pin the entity's idea of "local" to a fixed offset, for one test.
+
+    Swaps the ``dt_util`` reference on ``hk.todo`` rather than reaching into Home
+    Assistant's own ``dt_util.DEFAULT_TIME_ZONE``. That global is owned by the test
+    framework: ``pytest-homeassistant-custom-component``'s ``verify_cleanup`` fixture
+    asserts it is still UTC at teardown, and it tears down *before* monkeypatch undoes
+    a patch, so setting it errors every test that does — visible only in the CI lane
+    that installs real Home Assistant. Patching the module attribute keeps the whole
+    substitution inside ``todo.py``'s namespace, so this behaves the same either way.
+
+    What it pins is the unit-level contract: the entity must ask ``as_local`` for the
+    zone before taking a date. That the real ``as_local`` resolves HA's configured zone
+    is Home Assistant's business, asserted end-to-end by the integration suite.
+    """
+    zone = timezone(timedelta(hours=offset_hours))
+    real = todo.dt_util
+    monkeypatch.setattr(
+        todo,
+        "dt_util",
+        types.SimpleNamespace(
+            parse_datetime=real.parse_datetime,
+            as_local=lambda value: value.astimezone(zone),
+        ),
+    )
+
+
 def test_due_date_is_taken_in_home_assistants_timezone(monkeypatch) -> None:
     """#250: a ``+00:00`` next_due at local midnight showed the previous day.
 
@@ -317,7 +347,7 @@ def test_due_date_is_taken_in_home_assistants_timezone(monkeypatch) -> None:
     in UTC, so ``next_due`` landed on ``+00:00``. Taking ``.date()`` in that offset
     read the 26th while the panel and ``list_tasks`` both read the 27th.
     """
-    monkeypatch.setattr(todo.dt_util, "DEFAULT_TIME_ZONE", timezone(timedelta(hours=1)))
+    _local_tz(monkeypatch, 1)
     entity, _store, _calls = _entity(
         _task("vacuum", "floating", next_due="2026-08-26T23:00:00+00:00")
     )
@@ -332,9 +362,7 @@ def test_due_date_shifts_back_when_local_trails_the_stored_offset(monkeypatch) -
     date is the 14th even though the stored string opens with the 15th. A fix that
     only ever moved dates forward, or that read the stored offset again, fails here.
     """
-    monkeypatch.setattr(
-        todo.dt_util, "DEFAULT_TIME_ZONE", timezone(timedelta(hours=-4))
-    )
+    _local_tz(monkeypatch, -4)
     entity, _store, _calls = _entity(
         _task("filter", "floating", next_due="2026-07-15T01:00:00+01:00")
     )
@@ -350,7 +378,7 @@ def test_due_date_is_unchanged_when_the_offset_already_matches_local(
     This is the majority case — a completion made "now" is stored with HA's own
     offset — and it is why the bug hid for so long: those tasks were always right.
     """
-    monkeypatch.setattr(todo.dt_util, "DEFAULT_TIME_ZONE", timezone(timedelta(hours=1)))
+    _local_tz(monkeypatch, 1)
     entity, _store, _calls = _entity(
         _task("live", "floating", next_due="2026-08-27T00:00:00+01:00")
     )


### PR DESCRIPTION
Fixes #250

## What changed

`todo_items` called `.date()` on the parsed `next_due`. `dt_util.parse_datetime` returns an aware datetime carrying **whatever offset the stored string has**, so `.date()` took the calendar date *in that offset* rather than in Home Assistant's zone.

The reporter's numbers, on Europe/London in BST: `next_due` of `2026-08-26T23:00:00+00:00` is Thursday 27 August 00:00 local. The panel and `list_tasks` said the 27th; `todo.home_keeper_tasks` said the 26th.

Why only some tasks: a completion made *now* is stored with the local offset and happens to project correctly. One entered through the panel's date picker goes through `haDateTimeToIso` → `new Date(...).toISOString()`, which is the right instant expressed in UTC — and those are the rows that shift. Invisible at UTC±0, and invisible everywhere during northern-hemisphere winter.

**A second instance of the same bug, found while tracing it.** `store._stamp_part_replacement` did the same thing to a completion timestamp, and that value becomes a wear part's `last_replaced`, which `reconcile` re-anchors the part's recurrence to. A back-dated part replacement therefore shifted the whole wear cycle a day, not just a label. Same root cause, same trigger, same one-line fix.

Both now convert with `dt_util.as_local` before projecting to a date.

### Why render time and not write time

The issue offers both layers. The stored instant was always correct — only the projection to a calendar date was wrong — and converting on read also repairs tasks already on disk, which normalizing at write time cannot. A write-time change would also be undone by any automation calling `complete_task` with a `Z` timestamp.

### Checked and not affected

`calendar.py` (emits aware datetimes, HA localizes them), the `next_due` timestamp sensor (aware, `device_class: timestamp`), `notifications.py` (day arithmetic on deltas, never a date projection), and the panel (`toLocaleDateString()`). `assets.py` and the metadata date sensor slice date-only strings, where there is no offset to get wrong.

### Tests

- `tests/unit/test_todo.py` — the reporter's case (UTC-stored due under UTC+1 → next day) and its mirror (UTC+1-stored due under UTC-4 → previous day), so the conversion cannot pass by doing nothing, plus the already-matching-offset case that was always right. `_local_tz` pins "local" by swapping the `dt_util` reference on the `hk.todo` module; see the second commit for why it must not touch Home Assistant's own global.
- `tests/integration/test_lifecycle.py` — the container runs on America/New_York, so this pins the date Home Assistant's own `todo.get_items` hands to a card or an automation. A unit test that stubs `dt_util` cannot see that contract.
- `tests/integration/test_assets.py` — a back-dated wear-part completion has to stamp `last_replaced` with the local date.

All four fail on the parent commit with exactly the reported one-day shift, and pass on this one.

### A note on the second commit

The first push was red: *1313 passed, 3 errors*. The new tests patched `dt_util.DEFAULT_TIME_ZONE`, and `pytest-homeassistant-custom-component`'s `verify_cleanup` fixture asserts that global is still UTC at teardown — it tears down before monkeypatch's undo, so every test that set it errored. It surfaced only in the lane that installs real Home Assistant; the hand-built stubs in the unit file kept a local run green.

`97d4527` swaps the module's own `dt_util` reference instead, so nothing reaches into Home Assistant's state and the suite behaves the same either way. The failure was reproduced locally first with a fixture mimicking `verify_cleanup`'s teardown ordering, and both directional tests still fail on the unfixed entity.

### Release

`v0.18.0b1` is already published, so this opens `0.18.0b2` (`manifest.json` + `const.py` + a new CHANGELOG section) rather than editing a shipped section — `changelog-release-gap` would otherwise fail, and the entry would document a fix that never ships.

## Checklist

- [x] Tests run locally — 1306 unit + 160 integration, all green
- [x] `CHANGELOG.md` updated with `(Fixes #250)`
- [x] Panel UI changed → n/a, no change under `frontend/src/`
- [x] New user-facing UI surface → n/a, no new surface
- [x] New user-facing feature → n/a (bug fix); version still bumped, because the top CHANGELOG section was already released
