### PR TITLE
release: 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ All notable changes to Home Keeper are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
 
+## [0.18.0] - 2026-08-29
+
+### Added
+
+- **Send tasks to your to-do lists.** A Profile in *Settings → Profiles* mirrors the
+  tasks it selects onto any Home Assistant to-do list (such as a Todoist project), and
+  checking an item off there completes the task in Home Keeper. Recurring tasks add a
+  fresh item each time they fall due, leaving the checked-off one as your record.
+  (Fixes #239)
+- **Services take a task's name, not just its id.** Every `task_id`, `asset_id`,
+  `part_id` and `document_id` field now accepts the name you gave the thing, and the
+  panel prints the id with a copy button for when two share one. Home Keeper reports an
+  ambiguous name instead of guessing which you meant.
+- **Snooze a problem you can't fix right now.** A task mirroring a `problem` sensor now
+  accepts Snooze, and its reminders show that button instead of Mark done. Marking one
+  done is still blocked since only the integration that owns the sensor can decide
+  it's fixed.
+
+### Changed
+
+- **Profile status labels now spell out what's included.** The choices were always
+  cumulative, so the old *Due soon* already covered overdue tasks too. The new names
+  are *Overdue only*, *Overdue and due soon* and *Every scheduled task*.
+
+### Fixed
+
+- **Synced problem sensors show up in Profiles again.** Picking any Profile used to
+  hide every mirrored `problem` sensor. (Fixes #248)
+- **To-do items show the right due date outside UTC.** A task due at local midnight showed
+  the previous day on `todo.home_keeper_tasks` while the panel showed the correct one. A
+  wear part's last-replaced date shifted the same way when the replacement was back-dated.
+  (Fixes #250)
+
 ## [0.18.0b4]
 
 ### Added

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor", "number"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.18.0b4"
+PANEL_VERSION = "0.18.0"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -21,5 +21,5 @@
   "requirements": [
     "Babel>=2.12"
   ],
-  "version": "0.18.0b4"
+  "version": "0.18.0"
 }


### PR DESCRIPTION
Cuts the stable **0.18.0** from the `0.18.0b1`–`0.18.0b4` beta line.

## What changed

- `custom_components/home_keeper/manifest.json` — `version` `0.18.0b4` → `0.18.0`
- `custom_components/home_keeper/const.py` — `PANEL_VERSION` `0.18.0b4` → `0.18.0`
- `CHANGELOG.md` — new `## [0.18.0] - 2026-08-29` section

The section is written for someone upgrading from `0.17.0`, not beta-to-beta:

- **Added** — the profile task mirror to external to-do lists (`Fixes #239`),
  services accepting names wherever they take an id, and Snooze on
  problem-sensor tasks.
- **Changed** — the Profile status labels renamed to *Overdue only* /
  *Overdue and due soon* / *Every scheduled task* (those tiers existed in
  `0.17.0`, so this reads as a change for an upgrader).
- **Fixed** — the two issues fixed by commits since `v0.17.0`: `Fixes #248`
  (synced problem sensors hidden in Profiles) and `Fixes #250` (to-do due
  dates outside UTC).

`python3 ci/release-issues.py --version 0.18.0 --json` resolves #239, #248 and
#250, so `notify-issues` will comment on and close all three on publication.

No code changes, so no screenshots and no walkthrough edit.

## Checklist

- [x] Tests run locally (`pytest tests/unit` — 1516 passed, 2 skipped)
- [x] `CHANGELOG.md` updated, with `(Fixes #N)` for each issue this release ships
- [x] Panel UI unchanged → no screenshots needed
- [x] No new UI surface → no walkthrough change needed
- [x] Version bumped in `manifest.json` + `const.py` (stable cut, not a beta, so
      no `preview-release` label)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1N31SKNwC6BPdbxGSjW4o)_