### PR TITLE
fix: read the device registry through a version-tolerant shim (HA 2026.9)

### DIFF
--- a/.amazonq/rules/architecture-and-code.md
+++ b/.amazonq/rules/architecture-and-code.md
@@ -89,6 +89,10 @@ command for admins; Home Keeper follows that rather than inventing a weaker line
   tier assert on the option merge rules every write path shares. Keep it that way —
   reach for `hass.<something>` at import time and `tests/unit/test_options.py` stops
   running without the HA harness.
+- `device_compat.py` sits on the same boundary for the same reason: it only ever calls
+  methods on a `DeviceRegistry` it is handed, so its `homeassistant` import is
+  `TYPE_CHECKING`-only and `tests/unit/test_device_compat.py` can drive both registry
+  shapes with plain fakes. Both modules are in the mutmut `only_mutate` allowlist.
 
 ## Datetimes & timezones
 - All datetimes are timezone-aware. Use `homeassistant.util.dt` (`dt_util`) at the
@@ -258,6 +262,18 @@ command for admins; Home Keeper follows that rather than inventing a weaker line
   `PROBLEM` `binary_sensor` (`assets.part_is_low`) for each `assets.part_has_reorder`
   part. Both enumerate via `coordinator.virtual_asset_parts(predicate)` and prune stale
   registry entries by unique-id shape (mirroring the asset-date-sensor cleanup).
+- **Read the device registry through `device_compat.py`, never `DeviceRegistry`
+  directly.** Home Assistant 2026.9 made `async_get` answer with a `ChildDeviceEntry`
+  (a separate class with no `connections`/`manufacturer`/`model`) as well as a
+  `DeviceEntry`, and turned `DeviceRegistry.devices` from an id-keyed mapping into a
+  collection of entries — so iterating it yields ids on one core and entries on the
+  next. `lint.yml` type-checks against *stable* HA, where `ChildDeviceEntry` has no
+  name, so the codebase keeps annotating registry devices as `dr.DeviceEntry` and
+  confines the approximation to that one module: `resolve_device` for a lookup by id,
+  `all_devices` to enumerate, `device_connections` for the one attribute a child
+  lacks. A child device is a valid attach target (HA links entities to either kind) —
+  don't filter them out. Reading any other `DeviceEntry`-only attribute off a resolved
+  device needs a helper there too, not a bare attribute access.
 - `diagnostics.py` provides **both** config-entry and **per-device**
   (`async_get_device_diagnostics`) downloads; the per-device one scopes to the device's
   appliance + its tasks. A device-level *action* was deliberately **not** added (the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Home Keeper are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
 
+## [0.19.0b1]
+
+### Fixed
+
+- **Ready for Home Assistant 2026.9.** That release reshapes the device registry and
+  adds child devices, so Home Keeper reads both shapes and a task or appliance you
+  attached to a device still finds it after the upgrade. (Fixes #253)
+
 ## [0.18.0] - 2026-08-29
 
 ### Added

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor", "number"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.18.0"
+PANEL_VERSION = "0.19.0b1"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/coordinator.py
+++ b/custom_components/home_keeper/coordinator.py
@@ -31,6 +31,7 @@ from .const import (
     EVENT_TASK_OVERDUE,
     OPTION_ONE_OFF_RETENTION_DAYS,
 )
+from .device_compat import resolve_device
 from .options import current_options
 from .reconcile import buy_source
 from .store import HomeKeeperStore
@@ -312,9 +313,7 @@ class HomeKeeperCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
         Single source of truth for "is this an existing device we can merge onto?"
         so the DeviceInfo and name-prefix decisions can't drift apart.
         """
-        if not device_id:
-            return None
-        return dr.async_get(self.hass).async_get(device_id)
+        return resolve_device(dr.async_get(self.hass), device_id)
 
     def task_uses_existing_device(self, task: dict[str, Any]) -> bool:
         """True when the task's per-task entities merge onto an existing device.

--- a/custom_components/home_keeper/device_compat.py
+++ b/custom_components/home_keeper/device_compat.py
@@ -4,11 +4,17 @@ Home Assistant 2026.9 reshaped two parts of ``homeassistant.helpers.device_regis
 that Home Keeper leans on:
 
 * **Child devices.** A device can now be registered as a *child* of another, and a
-  child is its own class (``ChildDeviceEntry``) rather than a ``DeviceEntry`` — it
-  carries only the attributes both kinds share, so no ``connections``, no
-  ``manufacturer``, no ``model``. ``DeviceRegistry.async_get`` answers with either
-  kind, and ``Entity.device_entry`` accepts either, so a child device is a perfectly
-  good thing to attach a task or an appliance to and Home Keeper keeps taking one.
+  child is its own class (``ChildDeviceEntry``) rather than a ``DeviceEntry``. Both
+  derive from ``BaseDeviceEntry``, so a child still carries ``id``, ``identifiers``,
+  ``name``, ``name_by_user``, ``area_id``, ``labels``, ``config_entry_id`` and
+  ``disabled_by`` — every attribute Home Keeper reads off a device except one. What a
+  child drops is the hardware description: ``connections``, ``manufacturer``,
+  ``model``, ``model_id``, ``hw_version``, ``sw_version``, ``serial_number``,
+  ``entry_type``, ``configuration_url`` and ``via_device_id``, which are the names
+  ``ChildDeviceEntry.__getattr__`` answers through a deprecation shim until 2027.9
+  removes it. ``DeviceRegistry.async_get`` answers with either kind, and
+  ``Entity.device_entry`` accepts either, so a child device is a perfectly good thing
+  to attach a task or an appliance to and Home Keeper keeps taking one.
 * **``DeviceRegistry.devices``.** It used to be a mapping keyed by device id and is now
   a collection of entries, so iterating the old one yields ids and the new one yields
   entries. ``.values()`` — the one spelling that answers on both today — is deprecated

--- a/custom_components/home_keeper/device_compat.py
+++ b/custom_components/home_keeper/device_compat.py
@@ -1,0 +1,84 @@
+"""Device-registry lookups that work across the Home Assistant versions we support.
+
+Home Assistant 2026.9 reshaped two parts of ``homeassistant.helpers.device_registry``
+that Home Keeper leans on:
+
+* **Child devices.** A device can now be registered as a *child* of another, and a
+  child is its own class (``ChildDeviceEntry``) rather than a ``DeviceEntry`` — it
+  carries only the attributes both kinds share, so no ``connections``, no
+  ``manufacturer``, no ``model``. ``DeviceRegistry.async_get`` answers with either
+  kind, and ``Entity.device_entry`` accepts either, so a child device is a perfectly
+  good thing to attach a task or an appliance to and Home Keeper keeps taking one.
+* **``DeviceRegistry.devices``.** It used to be a mapping keyed by device id and is now
+  a collection of entries, so iterating the old one yields ids and the new one yields
+  entries. ``.values()`` — the one spelling that answers on both today — is deprecated
+  from 2026.9 and gone in 2027.9.
+
+Home Keeper still annotates registry devices as ``dr.DeviceEntry`` everywhere, because
+``ChildDeviceEntry`` does not exist on the stable Home Assistant that ``lint.yml``
+type-checks against: naming it would fail that gate, and there is no older name that
+covers both kinds. So the annotation is a deliberate approximation, every lookup that
+can now answer with a child comes through this module, and the one attribute a child
+genuinely lacks gets an explicit answer here instead of an ``AttributeError`` (or, on
+2026.9 exactly, a deprecation warning) somewhere further in.
+
+Home Assistant imports are ``TYPE_CHECKING``-only, which keeps this module pure Python
+and unit-testable in isolation — the ``recurrence.py``/``models.py`` contract. Keep it
+that way: it means the two registry shapes can be exercised with plain fakes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from homeassistant.helpers import device_registry as dr
+
+
+def resolve_device(
+    registry: dr.DeviceRegistry, device_id: str | None
+) -> dr.DeviceEntry | None:
+    """Resolve *device_id* to a registry device, child devices included.
+
+    Returns ``None`` for an empty *device_id*, so callers holding an optional
+    reference (most of ours) need no guard of their own.
+
+    Typed as ``DeviceEntry`` deliberately — see the module docstring. From Home
+    Assistant 2026.9 this may really hand back a ``ChildDeviceEntry``, which offers
+    every attribute Home Keeper reads off a device except ``connections``; that one
+    goes through :func:`device_connections`.
+    """
+    if not device_id:
+        return None
+    # The lookup's declared type widens to a union in HA 2026.9 that we cannot name
+    # (module docstring), so the approximation is applied here, once.
+    device: Any = registry.async_get(device_id)
+    return device
+
+
+def all_devices(registry: dr.DeviceRegistry) -> list[dr.DeviceEntry]:
+    """Every main device in the registry.
+
+    ``DeviceRegistry.devices`` is a mapping keyed by device id before Home Assistant
+    2026.9 and a collection of entries from 2026.9 on, so iterating it yields ids on
+    one and entries on the other. Ask which shape we were handed rather than calling
+    ``.values()``, which answers on both today but is deprecated from 2026.9.
+    """
+    devices: Any = registry.devices
+    if isinstance(devices, Mapping):
+        return list(devices.values())
+    return list(devices)
+
+
+def device_connections(device: dr.DeviceEntry) -> set[tuple[str, str]]:
+    """*device*'s connections, or an empty set for a device that cannot have any.
+
+    Only main devices have connections. A child device answers the attribute through a
+    backwards-compatibility shim that logs a deprecation warning and stops answering in
+    Home Assistant 2027.9, so key off ``parent_device_id`` — which only a child carries
+    — rather than reading through the shim.
+    """
+    if getattr(device, "parent_device_id", None) is not None:
+        return set()
+    return device.connections

--- a/custom_components/home_keeper/device_trigger.py
+++ b/custom_components/home_keeper/device_trigger.py
@@ -34,6 +34,7 @@ from homeassistant.helpers.typing import ConfigType
 from .api_surface import triggers_for
 from .const import ASSET_IDENTIFIER_PREFIX, DOMAIN
 from .coordinator import HomeKeeperCoordinator
+from .device_compat import resolve_device
 
 # trigger_type -> bus event, taken from the API-surface model rather than repeated
 # here: the triggers this platform offers and the ones the Developer Guide documents
@@ -77,7 +78,7 @@ def _filters(hass: HomeAssistant, device_id: str) -> tuple[dict | None, dict | N
     that kind (so that trigger type isn't offered). See the module docstring for why the
     task filter keys on ``task_id`` for a self-owned device but ``device_id`` otherwise.
     """
-    device = dr.async_get(hass).async_get(device_id)
+    device = resolve_device(dr.async_get(hass), device_id)
     if device is None:
         return None, None
     coord = _coordinator(hass)
@@ -130,7 +131,7 @@ def _attach_filter(hass: HomeAssistant, device_id: str, trigger_type: str) -> di
     and staying silent until the automation is reloaded. It also picks up tasks
     attached to the device after the automation was created (the old snapshot didn't).
     """
-    device = dr.async_get(hass).async_get(device_id)
+    device = resolve_device(dr.async_get(hass), device_id)
     if device is None:
         return _NO_MATCH
     if trigger_type in ASSET_TRIGGERS:

--- a/custom_components/home_keeper/devices.py
+++ b/custom_components/home_keeper/devices.py
@@ -30,6 +30,7 @@ from .const import (
     DOMAIN,
     PANEL_URL_PATH,
 )
+from .device_compat import all_devices, device_connections, resolve_device
 from .store import HomeKeeperStore
 
 _LOGGER = logging.getLogger(__name__)
@@ -307,7 +308,7 @@ async def async_heal_split_device_ids(
     # which live devices came from the same original, or the two copies look unrelated:
     # they point at different halves of the same split.
     canonical: dict[str, str] = {}
-    for device in registry.devices.values():
+    for device in all_devices(registry):
         # Explicit loop rather than a comprehension: composite_device_id is
         # `str | None`, and a truthiness guard inside a comprehension doesn't narrow
         # the value expression for the type checker.
@@ -481,7 +482,7 @@ def _reconcile_existing(registry: dr.DeviceRegistry, asset: dict[str, Any]) -> b
     Returns ``True`` if the asset dict was mutated (so the caller persists it).
     """
     device_id = asset.get("device_id")
-    device = registry.async_get(device_id) if device_id else None
+    device = resolve_device(registry, device_id)
     changed = False
     if device is None:
         # The referenced device may have been recreated under a new id by its
@@ -500,7 +501,7 @@ def _reconcile_existing(registry: dr.DeviceRegistry, asset: dict[str, Any]) -> b
     # Refresh the reconciliation snapshot from the live device (only marking the
     # asset dirty when it actually changed, to avoid needless writes).
     identifiers = [list(i) for i in device.identifiers]
-    connections = [list(c) for c in device.connections]
+    connections = [list(c) for c in device_connections(device)]
     if asset.get("identifiers") != identifiers:
         asset["identifiers"] = identifiers
         changed = True

--- a/custom_components/home_keeper/devices.py
+++ b/custom_components/home_keeper/devices.py
@@ -30,6 +30,10 @@ from .const import (
     DOMAIN,
     PANEL_URL_PATH,
 )
+
+# Every device-registry *read* goes through device_compat, never straight at the
+# registry: Home Assistant 2026.9 changed both what ``async_get`` can answer with and
+# what iterating ``registry.devices`` yields. Read that module before adding one here.
 from .device_compat import all_devices, device_connections, resolve_device
 from .store import HomeKeeperStore
 

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -21,5 +21,5 @@
   "requirements": [
     "Babel>=2.12"
   ],
-  "version": "0.18.0"
+  "version": "0.19.0b1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,10 @@ only_mutate = [
     # Imports Home Assistant only under ``TYPE_CHECKING``, so the fast unit tier runs
     # it directly (tests/unit/test_options.py) — see "Pure, HA-free core".
     "custom_components/home_keeper/options.py",
+    # Also TYPE_CHECKING-only, and driven by tests/unit/test_device_compat.py: the two
+    # device-registry shapes it reconciles are only distinguishable by behaviour, so a
+    # mutant that iterates the wrong one has to be caught by an assertion.
+    "custom_components/home_keeper/device_compat.py",
 ]
 pytest_add_cli_args_test_selection = ["tests/unit"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,9 @@ _PURE_MODULES = (
     "tags",
     "card_resource",
     "resolve",
+    # ``device_compat`` imports Home Assistant only under ``TYPE_CHECKING``, so the
+    # two device-registry shapes it reconciles are testable here with plain fakes.
+    "device_compat",
     # Keep ``task_mirror`` after the siblings it imports (shopping/profiles/
     # reconcile/transitions) and before ``options``, which imports *it*: a module
     # first pulled in by a sibling and then re-executed here would leave two

--- a/tests/unit/test_device_compat.py
+++ b/tests/unit/test_device_compat.py
@@ -1,0 +1,151 @@
+"""Unit tests for the cross-version device-registry lookups (#253).
+
+Home Assistant 2026.9 changed two shapes Home Keeper reads from the device registry:
+``DeviceRegistry.devices`` stopped being a mapping keyed by device id, and
+``DeviceRegistry.async_get`` started answering with child devices, which carry no
+``connections``. Both shapes have to keep working while a released Home Keeper spans
+the two Home Assistant versions, and only one of them can be exercised at a time
+against a real container — so the shapes themselves are pinned here.
+
+The fakes below stand in for the two eras deliberately: the mapping fake iterates like
+the pre-2026.9 ``ActiveDeviceRegistryItems`` (a ``UserDict``, so iteration yields
+**ids**), and the collection fake iterates like the 2026.9 view (which yields
+**entries**). A helper that iterated the wrong one would silently return device ids
+where entries belong, which is exactly the failure this guards.
+
+``tests/unit/test_device_heal.py`` covers the repair that consumes ``all_devices``, and
+the real ``DeviceRegistry`` contract is exercised against a genuine Home Assistant by
+``tests/integration`` and ``tests/upgrade``.
+"""
+
+from dataclasses import dataclass, field
+
+import hk_device_compat as device_compat
+
+
+@dataclass(frozen=True)
+class FakeDevice:
+    """A main device: has ``connections``, has no parent."""
+
+    id: str
+    connections: set = field(default_factory=set)
+
+
+@dataclass(frozen=True)
+class FakeChildDevice:
+    """A 2026.9 child device: has a parent, and no ``connections`` attribute at all."""
+
+    id: str
+    parent_device_id: str
+
+
+class MappingRegistry:
+    """Pre-2026.9: ``devices`` is a mapping, so iterating it yields device ids."""
+
+    def __init__(self, devices):
+        self.devices = {d.id: d for d in devices}
+
+    def async_get(self, device_id):
+        return self.devices.get(device_id)
+
+
+class _EntryCollection:
+    """The 2026.9 ``devices`` view: a collection of entries, and not a mapping."""
+
+    def __init__(self, devices):
+        self._devices = list(devices)
+
+    def __iter__(self):
+        return iter(self._devices)
+
+    def __len__(self):
+        return len(self._devices)
+
+
+class CollectionRegistry:
+    """2026.9 and later: ``devices`` is a collection, so iterating yields entries."""
+
+    def __init__(self, devices):
+        self._by_id = {d.id: d for d in devices}
+        self.devices = _EntryCollection(devices)
+
+    def async_get(self, device_id):
+        return self._by_id.get(device_id)
+
+
+DEV_A = FakeDevice("a", {("mac", "aa:bb:cc:dd:ee:ff")})
+DEV_B = FakeDevice("b")
+CHILD = FakeChildDevice("c", parent_device_id="a")
+
+
+# ── all_devices: both registry shapes yield entries ──────────────────────────
+
+
+def test_a_mapping_registry_yields_entries_not_ids():
+    assert device_compat.all_devices(MappingRegistry([DEV_A, DEV_B])) == [DEV_A, DEV_B]
+
+
+def test_a_collection_registry_yields_its_entries():
+    assert device_compat.all_devices(CollectionRegistry([DEV_A, DEV_B])) == [
+        DEV_A,
+        DEV_B,
+    ]
+
+
+def test_an_empty_registry_yields_nothing_in_either_shape():
+    assert device_compat.all_devices(MappingRegistry([])) == []
+    assert device_compat.all_devices(CollectionRegistry([])) == []
+
+
+def test_all_devices_returns_a_list_the_caller_can_hold():
+    # The registry mutates its containers in place, so callers get a snapshot: a view
+    # would change under a caller that removes devices while iterating.
+    registry = MappingRegistry([DEV_A, DEV_B])
+    devices = device_compat.all_devices(registry)
+    registry.devices.clear()
+    assert devices == [DEV_A, DEV_B]
+
+
+# ── resolve_device ───────────────────────────────────────────────────────────
+
+
+def test_resolve_device_returns_the_registered_device():
+    assert device_compat.resolve_device(MappingRegistry([DEV_A]), "a") is DEV_A
+
+
+def test_resolve_device_returns_none_for_an_unknown_id():
+    assert device_compat.resolve_device(MappingRegistry([DEV_A]), "nope") is None
+
+
+def test_resolve_device_resolves_a_child_device():
+    # A child device is a legitimate attach target: HA links entities to either kind.
+    assert device_compat.resolve_device(CollectionRegistry([CHILD]), "c") is CHILD
+
+
+def test_resolve_device_answers_none_for_an_absent_reference_without_asking():
+    # The empty-id guard is the caller's `if device_id` folded in, so it must not
+    # reach the registry: `async_get(None)` is not a lookup the registry accepts.
+    class Exploding:
+        def async_get(self, device_id):
+            raise AssertionError(f"registry consulted for {device_id!r}")
+
+    assert device_compat.resolve_device(Exploding(), None) is None
+    assert device_compat.resolve_device(Exploding(), "") is None
+
+
+# ── device_connections ───────────────────────────────────────────────────────
+
+
+def test_a_main_device_reports_its_connections():
+    assert device_compat.device_connections(DEV_A) == {("mac", "aa:bb:cc:dd:ee:ff")}
+
+
+def test_a_main_device_without_connections_reports_an_empty_set():
+    assert device_compat.device_connections(DEV_B) == set()
+
+
+def test_a_child_device_reports_no_connections_instead_of_raising():
+    # Asking a real ChildDeviceEntry for `connections` goes through a compatibility
+    # shim that logs a deprecation and stops answering in HA 2027.9; the fake has no
+    # such shim, so reading the attribute here would raise outright.
+    assert device_compat.device_connections(CHILD) == set()

--- a/tests/unit/test_device_heal.py
+++ b/tests/unit/test_device_heal.py
@@ -188,6 +188,38 @@ class FakeRegistry:
         return None
 
 
+class ModernFakeRegistry(FakeRegistry):
+    """``FakeRegistry`` with Home Assistant 2026.9's ``devices`` shape.
+
+    Up to 2026.8 ``DeviceRegistry.devices`` was a mapping keyed by device id, which is
+    what :class:`FakeRegistry` models; from 2026.9 it is a collection of entries, so
+    iterating it yields the entries themselves. The repair reads every device from it,
+    so it has to cope with both — see ``device_compat.all_devices``.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        by_id = self.devices
+        self.devices = _EntryCollection(by_id.values())
+        self._by_id = by_id
+
+    def async_get(self, device_id: str) -> FakeDevice | None:
+        return self._by_id.get(device_id)
+
+
+class _EntryCollection:
+    """A collection of device entries: iterable, sized, and not a mapping."""
+
+    def __init__(self, devices):
+        self._devices = list(devices)
+
+    def __iter__(self):
+        return iter(self._devices)
+
+    def __len__(self):
+        return len(self._devices)
+
+
 class FakeStore:
     """Task/asset storage with the two repoint methods the repair drives.
 
@@ -624,4 +656,20 @@ def test_heal_feeds_the_composite_map_to_the_duplicate_merge():
     )
     store = FakeStore()
     heal(FakeRegistry([survivor]), store)
+    assert store.merged == {"zwave_real": DEAD_THERMOSTAT}
+
+
+def test_heal_reads_every_device_from_a_2026_9_shaped_registry():
+    """The same merge map, off the collection-shaped ``devices`` of HA 2026.9 (#253).
+
+    Iterating the old mapping yields device *ids*, so a helper that iterated the new
+    collection the same way would hand the merge step strings instead of entries.
+    """
+    survivor = FakeDevice(
+        "zwave_real",
+        config_entries=frozenset({ZWAVE_ENTRY}),
+        composite_device_id=DEAD_THERMOSTAT,
+    )
+    store = FakeStore()
+    heal(ModernFakeRegistry([survivor]), store)
     assert store.merged == {"zwave_real": DEAD_THERMOSTAT}

--- a/tests/unit/test_release_issues.py
+++ b/tests/unit/test_release_issues.py
@@ -526,6 +526,7 @@ _KNOWN_ISSUES = frozenset(
         247,
         248,
         250,
+        253,
     }
 )
 


### PR DESCRIPTION
Fixes #253

## What changed

The nightly `ha-beta` run went red on the **`typing`** job only (`upgrade`, `integration` and `e2e` all passed). Five mypy errors against HA `2026.9.0b1`:

```
devices.py:310: "Collection[DeviceEntry]" has no attribute "values"                    [attr-defined]
devices.py:503: Item "ChildDeviceEntry" of "DeviceEntry | ChildDeviceEntry"
                has no attribute "connections"                                          [union-attr]
coordinator.py:306: Incompatible return value type (got "DeviceEntry | ChildDeviceEntry | None",
                expected "DeviceEntry | None")                                          [return-value]
device_trigger.py:86,139: Argument 1 to "_hk_identifier" has incompatible type
                "DeviceEntry | ChildDeviceEntry"; expected "DeviceEntry"                [arg-type]
```

Both come from one upstream rework of `homeassistant.helpers.device_registry` in 2026.9:

- **Child devices.** A device can now be registered as a child of another, and a child is its own class (`ChildDeviceEntry`) rather than a `DeviceEntry` — it carries only the attributes both kinds share, so no `connections`, `manufacturer` or `model`. `DeviceRegistry.async_get` answers with either kind.
- **`DeviceRegistry.devices`** stopped being an id-keyed mapping and became a collection of entries. Iterating the old one yields **ids**, the new one yields **entries**; `.values()` answers on both today but is deprecated from 2026.9 and removed in 2027.9.

`lint.yml` type-checks against *stable* Home Assistant, where `ChildDeviceEntry` has no name at all, so the union cannot be spelled in an annotation that holds for both cores. Registry devices therefore keep their `dr.DeviceEntry` annotation, and every lookup that can now answer with a child goes through a new **`device_compat.py`**:

| helper | replaces | why |
| --- | --- | --- |
| `resolve_device(registry, device_id)` | `registry.async_get(...)` | one documented place where the `DeviceEntry` annotation approximates the 2026.9 union |
| `all_devices(registry)` | `registry.devices.values()` | asks which shape it was handed instead of using the deprecated spelling |
| `device_connections(device)` | `device.connections` | keys off `parent_device_id`, so it never reads through the child's compatibility shim |

A child device stays a **valid attach target** — Home Assistant links entities to either kind (`Entity.device_entry: AnyDeviceEntry`) — so nothing is filtered out. Reading `connections` off a real `ChildDeviceEntry` would otherwise go through a shim that logs a deprecation warning and stops answering in 2027.9; `device_connections` returns an empty set instead.

`device_compat.py` imports Home Assistant only under `TYPE_CHECKING` (the `options.py` precedent), which keeps it in the pure tier — that is what lets the two registry shapes be exercised with plain fakes rather than a container that can only ever be one core at a time.

### Testing

- `tests/unit/test_device_compat.py` (new, 11 tests) — both registry shapes, child-device resolution, the empty-id guard, and connections on main vs child devices. Confirmed the shape tests fail if `all_devices` iterates naively.
- `tests/unit/test_device_heal.py` — a `ModernFakeRegistry` with the 2026.9 collection shape, asserting the split repair still builds the same merge map from it.
- `pyproject.toml` — `device_compat.py` added to the mutmut `only_mutate` allowlist. **15/15 mutants killed** (100%).
- `tests/unit/test_release_issues.py` — `253` added to the pinned issue set.

Verified locally:

| check | result |
| --- | --- |
| `mypy` vs HA `2026.9.0b1` (py3.14) | ✅ 49 files, no issues (was 5 errors) |
| `mypy` vs HA `2026.8.3` (py3.14) | ✅ 49 files, no issues |
| `pytest tests/unit` | ✅ 1529 passed, 2 skipped |
| integration suite vs `HA_TAG=beta` (2026.9.0b2) | ✅ 167 passed |
| integration suite vs `HA_TAG=stable` (2026.8.3) | ✅ 167 passed |
| `ruff check` / `ruff format --check` | ✅ clean |
| `vale CHANGELOG.md` | ✅ no hits on added lines |

The 2026.9 container log also confirms the `device_registry.devices` deprecation warning is gone.

### Version

Bumped to `0.19.0b1` (`manifest.json` + `const.py`) with a matching CHANGELOG section — `main` was still on the just-shipped stable `0.18.0`, so the post-stable bump was due and the fix needs a version to ship on.

### Not fixed here — two *new* 2026.9 deprecation warnings

The 2026.9 container logs two warnings that HA `2026.8.3` does not emit. Neither fails anything today, both break in **HA 2027.8**, and both name Home Keeper and tell the user to file a bug report:

1. `devices.py:436` — `async_get_or_create(via_device=...)`; use `via_device_id`. Small: `via_device_id` is accepted on 2026.8 too, and `_reconcile_virtual` already corrects the parent link with it right after create.
2. `devices.py:572` — `async_get_device(identifiers=...)`, deprecated "because device identifiers and connections are no longer unique across config entries"; use `async_get_device_by_identifier` / `async_get_device_by_connection` / `async_get_devices`. Larger: those helpers do not exist on 2026.8, and `async_get_devices` returns *all* matches where the old call resolved to one — which is load-bearing for `_resolve_by_snapshot`'s foreign-device preference in the #183 split repair.

Left out to keep this PR to the failure the nightly reported; happy to take either on in a follow-up.

## Checklist

- [x] Tests run locally (`pytest tests/unit -v`; no frontend change, so `ci/test-frontend.sh` not applicable)
- [x] `CHANGELOG.md` updated — `(Fixes #253)` in the new `## [0.19.0b1]` section
- [x] Panel UI changed → n/a, no UI change
- [x] New user-facing UI surface → n/a, no new surface
- [x] New user-facing feature → n/a (bug fix); version still bumped to `0.19.0b1` because `main` sat on the shipped stable


---
_Generated by [Claude Code](https://claude.ai/code/session_01QehZpzrrj2HyjJKNnz9HNo)_