### PR TITLE
fix(todo-sync): hold an unconfirmed add instead of adding it twice

### DIFF
--- a/.amazonq/rules/architecture-and-code.md
+++ b/.amazonq/rules/architecture-and-code.md
@@ -991,10 +991,22 @@ The appliance/asset feature lives in `assets.py` (pure model — no HA imports, 
   - **Vanish semantics deliberately diverge from the shopping-list sync.** With `two_way`
     and `vanish_as_completed` on, a tracked open item that disappeared completes the
     task — required for providers (Todoist) whose `todo` entity drops completed items —
-    but only when the entry captured a `uid` (an add that never confirmably landed is
-    re-added, never completed). Otherwise a vanish means deleted → recreate (strict
-    self-healing). With `two_way` off the inbound direction is inert and a ticked item
-    freezes its entry so phase 2 doesn't re-add against the user's wishes.
+    but only when the entry captured a `uid`. Otherwise a vanish means deleted → recreate
+    (strict self-healing). With `two_way` off the inbound direction is inert and a ticked
+    item freezes its entry so phase 2 doesn't re-add against the user's wishes.
+  - **A write's own outcome outranks a later read of the list.** `todo.add_item` returns
+    nothing, so a fresh entry has no `uid` and is matched by summary next pass — but some
+    lists don't make an added item readable straight away (HA's CalDAV entity refreshes
+    its cache in a fire-and-forget task where `local_todo` and Todoist await theirs). So
+    "I can't see it" is **not** proof the add failed: reading it that way added the item
+    twice, permanently, since the bookkeeping only ever points at one copy. An
+    unconfirmed entry is therefore *held* — stamped with `added_at`, carried forward
+    **verbatim** because the summary is its only handle — until `UNCONFIRMED_GRACE`
+    (20 min, chosen to clear CalDAV's 15-minute poll) expires, then re-added so a
+    genuinely lost add still repairs. The same stamp gates the ticked-item arm, or a
+    summary match onto the predecessor we just ticked off would complete the task twice
+    and strand its replacement. Wall clock, not a pass count: the driver runs up to four
+    passes back to back with no delay between them.
   - **Content is capability-gated in the planner**, not the driver: due dates
     (`SET_DUE_DATE_ON_ITEM`, written date-only like our own `todo.py`) and
     descriptions (`SET_DESCRIPTION_ON_ITEM`, carrying the task's notes) are neither

--- a/.amazonq/rules/testing-and-workflow.md
+++ b/.amazonq/rules/testing-and-workflow.md
@@ -4,6 +4,12 @@
 - Never push directly to `main`. Work on a feature branch and open a PR; squash
   merge.
 - Update `CHANGELOG.md` for every user-facing change before a release.
+- **User-facing text is drafted by a Sonnet 4.5 subagent** (`model: sonnet`), not written
+  inline: `CHANGELOG.md` bullets, `README.md`, the canonical `docs/*.md`, `strings.json`,
+  `services.yaml` descriptions, the frontend locale. Hand it the diff, the surrounding
+  section for voice, and the house rules it must satisfy; review and edit the draft before
+  committing. Commit messages, PR bodies and code comments stay inline — they are not
+  user-facing.
 - **Keep every CHANGELOG bullet to three sentences at most.** A bold lead naming the
   change, then what a user notices, then a caveat or `(Fixes #N)` if one is needed.
   Cut the worked example, the before-and-after story, the list of every surface the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,15 @@
   try the feature via HACS *before* merge. The build is ephemeral and auto-deletes
   when the PR closes (see RELEASE.md → "Preview releases"). Bug-fix-only /
   developer-only PRs don't need it.
+- **Always have a Sonnet 4.5 subagent write user-facing text.** Any prose a *user* reads —
+  `CHANGELOG.md` bullets, `README.md`, the canonical `docs/*.md`, `strings.json`,
+  `services.yaml` descriptions, the frontend locale — is drafted by a subagent spawned
+  with `model: sonnet`, not written inline. Give it the diff, the surrounding section for
+  voice, and the house rules it has to satisfy (the three-sentence CHANGELOG budget, the
+  `(Fixes #N)` placement, the vale AI-tells style), then review what comes back and edit
+  it yourself before committing — the subagent drafts, you are still responsible for what
+  ships. Commit messages, PR bodies and code comments are *not* user-facing text and stay
+  inline.
 - **Always run tests locally before pushing.** Never use CI as the test runner.
   - Pure-logic unit tests need only `pip install pytest PyYAML`: `pytest tests/unit -v`.
     (`PyYAML` is for the API-surface gate below, which reads `services.yaml`; without

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to Home Keeper are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
 
+## [0.20.0b1]
+
+### Fixed
+
+- **Sending a task to a CalDAV to-do list (Nextcloud, Baikal, Radicale) no longer
+  creates a duplicate.** The duplicate was permanent: editing the task afterward
+  updated only one copy and deleting it left the other behind on the server. The same
+  timing could also complete a recurring task twice and skip its next occurrence.
+
 ## [0.19.0] - 2026-09-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -788,12 +788,11 @@ remotely completes nothing and the item returns on the next pass. That refusal i
 the point of requiring the scan.
 
 **A to-do item you add on the list yourself never becomes a Home Keeper task.** The
-sync is a delivery surface: it puts Home Keeper's tasks onto the list, and anything
-you write there stays exactly where you put it. Home Keeper leaves it alone — no
-import, no rename, no delete. A Home Keeper task carries recurrence, a device, labels
-and completion history, and a plain to-do line holds none of that. The one thing that
-travels inward is a checkmark: ticking off one of Home Keeper's own items completes
-the task behind it, and that is the whole inbound direction.
+sync is a delivery surface. It puts Home Keeper's tasks onto the list. Anything else
+on that list stays yours. Home Keeper only ever touches the items it wrote itself.
+A Home Keeper task carries recurrence, a device and completion history that a plain
+to-do line cannot hold. The one thing that travels inward is a checkmark. Ticking
+off one of Home Keeper's own items completes the task behind it.
 
 - **CalDAV lists work too** (Nextcloud, Baikal, Radicale). Home Assistant polls a
   CalDAV server every 15 minutes, so ticking an item off there can take that long to

--- a/README.md
+++ b/README.md
@@ -787,6 +787,20 @@ A task that requires an NFC/RFID tag scan still syncs. Checking its item off
 remotely completes nothing and the item returns on the next pass. That refusal is
 the point of requiring the scan.
 
+**A to-do item you add on the list yourself never becomes a Home Keeper task.** The
+sync is a delivery surface: it puts Home Keeper's tasks onto the list, and anything
+you write there stays exactly where you put it. Home Keeper leaves it alone — no
+import, no rename, no delete. A Home Keeper task carries recurrence, a device, labels
+and completion history, and a plain to-do line holds none of that. The one thing that
+travels inward is a checkmark: ticking off one of Home Keeper's own items completes
+the task behind it, and that is the whole inbound direction.
+
+- **CalDAV lists work too** (Nextcloud, Baikal, Radicale). Home Assistant polls a
+  CalDAV server every 15 minutes, so ticking an item off there can take that long to
+  reach Home Keeper.
+- **In Nextcloud, point the sync at a task list.** The default **Personal** calendar
+  holds only events, so it never appears as a to-do list in Home Assistant at all.
+
 **The Todoist recipe.** Install Home Assistant's own
 [Todoist integration](https://www.home-assistant.io/integrations/todoist/) and give it
 your Todoist API token. Every Todoist project then shows up as a `todo` entity. Point

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor", "number"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.19.0"
+PANEL_VERSION = "0.20.0b1"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -21,5 +21,5 @@
   "requirements": [
     "Babel>=2.12"
   ],
-  "version": "0.19.0"
+  "version": "0.20.0b1"
 }

--- a/custom_components/home_keeper/store.py
+++ b/custom_components/home_keeper/store.py
@@ -159,7 +159,8 @@ class HomeKeeperStore:
         self._shopping_items: dict[str, dict[str, Any]] = {}
         # Which item on which external to-do list stands for which task, for which
         # profile (``todo_list.sync_key(profile_id, task_id) -> {entity_id, uid,
-        # summary, due, last_completed, added_at}``). Keyed per *profile* rather than per task
+        # summary, due, last_completed, added_at}``). Keyed per *profile* rather than
+        # per task
         # because two syncs can hold the same task on two different lists, and one
         # entry could not describe both. Bookkeeping for ``todo_list_sync.py``,
         # kept out of the task for the same reason as the shopping map: the moment

--- a/custom_components/home_keeper/store.py
+++ b/custom_components/home_keeper/store.py
@@ -159,7 +159,7 @@ class HomeKeeperStore:
         self._shopping_items: dict[str, dict[str, Any]] = {}
         # Which item on which external to-do list stands for which task, for which
         # profile (``todo_list.sync_key(profile_id, task_id) -> {entity_id, uid,
-        # summary, due, last_completed}``). Keyed per *profile* rather than per task
+        # summary, due, last_completed, added_at}``). Keyed per *profile* rather than per task
         # because two syncs can hold the same task on two different lists, and one
         # entry could not describe both. Bookkeeping for ``todo_list_sync.py``,
         # kept out of the task for the same reason as the shopping map: the moment

--- a/custom_components/home_keeper/todo_list.py
+++ b/custom_components/home_keeper/todo_list.py
@@ -132,6 +132,12 @@ CAP_DESCRIPTION = "description"
 # Wall clock rather than a count of passes, deliberately: ``TodoSyncDriver`` runs up
 # to four passes back to back with no delay between them, so "unseen for two passes"
 # can elapse in milliseconds — entirely inside the window we are waiting out.
+#
+# What comes back to look once it expires is the coordinator's periodic sweep
+# (``todo_list_sync.async_schedule_sweep``, every ``coordinator.SCAN_INTERVAL``),
+# because a grace running out is neither a store mutation nor a list state change
+# and so wakes nothing by itself. That sweep has to stay unconditional for this to
+# repair at all; its docstring says so.
 UNCONFIRMED_GRACE = timedelta(minutes=20)
 
 # Separator joining a profile id to a task id in a bookkeeping key. Profile ids are
@@ -329,6 +335,9 @@ def _added_stamp(entry: dict[str, Any], *, now: datetime) -> str:
     """
     stamped = entry.get("added_at")
     try:
+        # ``str`` because the store holds these entries as opaque JSON and hands
+        # back whatever is in the document: a number, or a value some other write
+        # left behind, must read as "cannot be trusted" rather than raise.
         if stamped and datetime.fromisoformat(str(stamped)) <= now:
             return str(stamped)
     except (TypeError, ValueError):

--- a/custom_components/home_keeper/todo_list.py
+++ b/custom_components/home_keeper/todo_list.py
@@ -41,16 +41,30 @@ The rules that shape a plan:
   a tracked open item that disappeared as completed — required for providers like
   Todoist whose ``todo`` entity drops completed items instead of reporting them.
   The completion is **uid-gated**: an entry that never captured a uid has no proof
-  its add ever landed, so it is re-added, never completed. With the toggle off (or
-  two-way sync off) a vanished item is treated as deleted and recreated — the
-  strict self-healing reading.
+  its add ever landed, so it is held (see below) and eventually re-added, never
+  completed. With the toggle off (or two-way sync off) a vanished item is treated
+  as deleted and recreated — the strict self-healing reading.
+* **A write's own outcome outranks a later read of the list.** ``todo.add_item``
+  answers with nothing, so a fresh entry carries no uid and is matched by summary on
+  a later pass. Some lists do not make an added item readable straight away — Home
+  Assistant's CalDAV entity refreshes its cached items in a fire-and-forget task,
+  where ``local_todo`` and Todoist both await theirs — so "I cannot see it" is *not*
+  proof the add failed. Reading it that way added the item a second time, and the
+  duplicate was permanent: the bookkeeping points at one copy, so every later edit
+  moved only that one and deleting the task orphaned the other. An unconfirmed entry
+  is therefore **held** rather than re-added, for :data:`UNCONFIRMED_GRACE` — long
+  enough to clear the slowest provider's visibility lag, after which a genuinely lost
+  add is repaired rather than leaving the task with no item for good.
 * **Two-way is per profile.** With ``two_way`` off the inbound direction is inert:
   ticks and vanishes never complete tasks; a ticked item freezes its bookkeeping
   entry so the sync does not argue with the user by re-adding the task.
 
 Bookkeeping (persisted by the store, silently) is a flat map
 ``sync_key(profile_id, task_id) -> entry`` with entries shaped
-``{"entity_id", "uid", "summary", "due", "last_completed"}``. ``last_completed``
+``{"entity_id", "uid", "summary", "due", "last_completed", "added_at"}``.
+``added_at`` stamps when an item was added but not yet seen on the list, and is
+dropped the moment one is resolved; it is what bounds the hold described above.
+``last_completed``
 snapshots the task's own ``last_completed`` at bind time; a live value strictly
 newer means "completed inside Home Keeper since it was synced", while an undone
 completion moves the value backwards and therefore reads as plain content drift.
@@ -108,6 +122,17 @@ __all__ = [
 # writes or compares these fields for entities whose capability set includes them.
 CAP_DUE_DATE = "due"
 CAP_DESCRIPTION = "description"
+
+# How long an entry whose add we could not confirm is held before it is re-added.
+# It is a *staleness budget*, not a formula: it has to comfortably clear the slowest
+# provider's visibility lag, and the slowest known is Home Assistant's CalDAV entity,
+# which polls every 15 minutes. A grace below that could fire before the provider had
+# any chance to show the item, recreating the duplicate this exists to prevent.
+#
+# Wall clock rather than a count of passes, deliberately: ``TodoSyncDriver`` runs up
+# to four passes back to back with no delay between them, so "unseen for two passes"
+# can elapse in milliseconds — entirely inside the window we are waiting out.
+UNCONFIRMED_GRACE = timedelta(minutes=20)
 
 # Separator joining a profile id to a task id in a bookkeeping key. Profile ids are
 # uuid hex and task ids are opaque, so the first ``:`` is unambiguous.
@@ -270,15 +295,68 @@ def desired_by_sync(
     return wanted
 
 
-def _entry(entity_id: str, item_uid: Any, want: dict[str, Any]) -> dict[str, Any]:
-    """The bookkeeping entry binding *want* to the item now holding it."""
+def _entry(
+    entity_id: str,
+    item_uid: Any,
+    want: dict[str, Any],
+    *,
+    added_at: str | None = None,
+) -> dict[str, Any]:
+    """The bookkeeping entry binding *want* to the item now holding it.
+
+    *added_at* is set only where we have added an item we have not seen back yet, so
+    resolving one against the live list clears it by simply not passing it on.
+    """
     return {
         "entity_id": entity_id,
         "uid": item_uid,
         "summary": str(want["name"]),
         "due": str(want["due"]),
         "last_completed": want["last_completed"],
+        "added_at": added_at,
     }
+
+
+def _added_stamp(entry: dict[str, Any], *, now: datetime) -> str:
+    """The stamp to hold *entry* under, replacing one that cannot be trusted.
+
+    Re-stamping rather than keeping whatever is there matters because the hold is
+    open-ended until the stamp ages out: a value that is unparsable, or in the
+    future because the clock jumped backwards before NTP corrected it, would never
+    age out at all. That turns "hold, never duplicate" into "hold, never deliver" —
+    a silent, permanent absence, which is the failure this whole path exists to
+    avoid, only pointing the other way.
+    """
+    stamped = entry.get("added_at")
+    try:
+        if stamped and datetime.fromisoformat(str(stamped)) <= now:
+            return str(stamped)
+    except (TypeError, ValueError):
+        pass
+    return now.isoformat()
+
+
+def _add_unconfirmed(
+    entry: dict[str, Any],
+    *,
+    now: datetime,
+    grace: timedelta = UNCONFIRMED_GRACE,
+) -> bool:
+    """Whether a uid-less entry we cannot resolve should be added again.
+
+    "I cannot see it" is not proof the add failed — see the module docstring — so
+    the answer is normally no, and both unreadable cases answer no as well: a
+    missing stamp starts the clock this pass, and an unparsable one is not evidence
+    of anything. The safe direction is always the one that cannot duplicate, which
+    is the same call :func:`completed_since` makes about an unparsable timestamp.
+    """
+    stamped = entry.get("added_at")
+    if not stamped:
+        return False
+    try:
+        return now - datetime.fromisoformat(str(stamped)) > grace
+    except (TypeError, ValueError):
+        return False
 
 
 def plan_sync(
@@ -288,6 +366,7 @@ def plan_sync(
     desired: dict[str, dict[str, dict[str, Any]]],
     items_by_entity: dict[str, list[dict[str, Any]]],
     capabilities: dict[str, frozenset[str]],
+    now: datetime,
 ) -> TodoListPlan:
     """Decide what every sync wants done this pass.
 
@@ -372,10 +451,27 @@ def plan_sync(
             # is the one mistake there is no undo for.
             if want is None:
                 continue
-            sync = profile["sync"]
-            if entry.get("uid") and sync["two_way"] and sync["vanish_as_completed"]:
-                plan.complete.append(CompleteOp(key, task_id))
-                settled.add(key)
+            if entry.get("uid"):
+                sync = profile["sync"]
+                if sync["two_way"] and sync["vanish_as_completed"]:
+                    plan.complete.append(CompleteOp(key, task_id))
+                    settled.add(key)
+                continue
+            if _add_unconfirmed(entry, now=now):
+                # The hold is up. Whatever happened to that add, waiting longer
+                # will not tell us, and a task with no item is worse than a
+                # second one — fall through so pass two puts a fresh line on.
+                continue
+            # Added, not seen back yet. The add call already answered whether it
+            # landed; a list that cannot show it yet does not overrule that.
+            # Holding the key here is the whole mechanism — pass two skips a key
+            # already in ``tracked`` — and the entry is carried over *verbatim*
+            # because for a uid-less entry the summary is the handle: it has to
+            # keep saying what we wrote, not what we now want, or a task renamed
+            # while its item was invisible would never match it again.
+            held = dict(entry)
+            held["added_at"] = _added_stamp(entry, now=now)
+            plan.tracked[key] = held
             continue
 
         identity = item_identity(item)
@@ -387,6 +483,16 @@ def plan_sync(
             if want is not None and not completed_since(
                 entry.get("last_completed"), want["last_completed"]
             ):
+                if entry.get("added_at") and not _add_unconfirmed(entry, now=now):
+                    # An add we have not confirmed, resolving to a *ticked-off*
+                    # line: on a list that keeps completed items this is the
+                    # predecessor we ticked off ourselves last cycle, matched by
+                    # summary because our new item is not readable yet. Reading it
+                    # as the household's tick completes the task a second time and
+                    # strands the new item for good. Wait for a list that can show
+                    # it — an open item wins over a ticked one the moment it can.
+                    plan.tracked[key] = dict(entry)
+                    continue
                 if profile["sync"]["two_way"]:
                     plan.complete.append(CompleteOp(key, task_id))
                     settled.add(key)
@@ -479,8 +585,9 @@ def plan_sync(
             # No uid: ``todo.add_item`` answers with nothing. The next pass binds
             # one by summary (see ``todo_items.resolve_tracked``), and until then
             # the summary is a perfectly good handle for
-            # ``update_item``/``remove_item``.
-            plan.tracked[key] = _entry(target, None, want)
+            # ``update_item``/``remove_item``. The stamp starts the hold that keeps
+            # a list too slow to show the new item from earning a second one.
+            plan.tracked[key] = _entry(target, None, want, added_at=now.isoformat())
     return plan
 
 

--- a/custom_components/home_keeper/todo_list_sync.py
+++ b/custom_components/home_keeper/todo_list_sync.py
@@ -156,7 +156,11 @@ class TodoListSync(TodoSyncDriver):
         enriched = notifier.effective_filter_tasks(
             self._hass, list(store.get_tasks().values())
         )
-        desired = todo_list.desired_by_sync(synced, enriched, now=dt_util.now())
+        # One instant for the whole pass: what a profile surfaces and how long an
+        # unconfirmed add has been waiting are two readings of the same "now", and
+        # taking the clock twice would let them disagree across the reads between.
+        now = dt_util.now()
+        desired = todo_list.desired_by_sync(synced, enriched, now=now)
         if not force and not todo_list.needs_pass(
             tracked=tracked, desired=desired, synced=synced
         ):
@@ -180,6 +184,7 @@ class TodoListSync(TodoSyncDriver):
             desired=desired,
             items_by_entity=items_by_entity,
             capabilities=capabilities,
+            now=now,
         )
         settled = await self._apply(plan, before=tracked)
         if self._stopped:

--- a/custom_components/home_keeper/todo_list_sync.py
+++ b/custom_components/home_keeper/todo_list_sync.py
@@ -133,6 +133,16 @@ class TodoListSync(TodoSyncDriver):
         And a task *falling due* is not a store mutation, so no task event fires
         for it: the periodic pass is what puts a newly-overdue chore on the list.
         Costs nothing until something is configured or synced.
+
+        A third thing rests on this now, and on it being **unconditional**: an add
+        we could not confirm is held rather than repeated
+        (``todo_list.UNCONFIRMED_GRACE``), and nothing about that grace expiring
+        is a store mutation or a list state change either. This pass is the only
+        thing that comes back to look, so gating it on ``needs_pass`` — which
+        answers False for a held entry, correctly, since a pending write is not
+        drift — would turn every such hold into a permanent one. The early-out
+        below is deliberately about having *nothing tracked at all*, which a held
+        entry is not.
         """
         if self._stopped:
             return

--- a/docs/CALDAV_SYNC_FINDINGS.md
+++ b/docs/CALDAV_SYNC_FINDINGS.md
@@ -27,7 +27,7 @@ below for what is still open.
 
 | Piece | What was used |
 | --- | --- |
-| Home Assistant | `ghcr.io/home-assistant/home-assistant:stable`, the repo's `tests/integration` compose stack |
+| Home Assistant | **2026.8.3** (`ghcr.io/home-assistant/home-assistant:stable` as of 2026-09-01), the repo's `tests/integration` compose stack |
 | CalDAV server | `nextcloud:apache` 34.0.3, SQLite, on a shared Docker network |
 | HA integration | built-in `caldav`, pointed at `http://nextcloud/remote.php/dav` |
 | Python CalDAV lib | `caldav` 2.1.0 (vendored in the HA image) |
@@ -36,6 +36,13 @@ below for what is still open.
 Reproduction scripts are not committed — they drove HA over its REST/WebSocket API and
 Nextcloud over raw CalDAV `REPORT`/`PUT`/`DELETE`, so every assertion below is against
 the bytes on the server, not against Home Assistant's view of them.
+
+**Every claim below about Home Assistant's internals was read out of the running
+2026.8.3 container**, not from memory or documentation. They are nonetheless
+**version-dependent**: the `caldav` refresh behaviour that Finding 1 turns on is an
+implementation detail nobody upstream owes us, and it could be fixed (or changed) in any
+release. Re-check them against the installed version before relying on them, and prefer a
+fix that does not depend on them holding.
 
 ---
 
@@ -171,6 +178,19 @@ The reasoning is sound for a list that answers reads honestly. It assumes "I can
 it" implies "the add failed". On CalDAV it usually means "the add succeeded and the
 cache has not caught up".
 
+Two adjacent races are worth ruling out explicitly, because both are natural things to
+suspect and neither is what is happening:
+
+- **A refresh landing between `plan_sync`'s two loops.** It cannot. `plan_sync` is pure
+  and synchronous over an `items_by_entity` snapshot captured before it is called, with
+  no `await` anywhere inside, so both loops see byte-identical input. The window is
+  strictly *between* passes.
+- **A half-built list snapshot.** Also no. `WebDavTodoListEntity.async_update` assigns
+  `self._attr_todo_items` once, wholesale, after the executor job returns the complete
+  search result — there is no moment where a caller sees half a list. What *can* happen is
+  an older complete snapshot overwriting a newer one when two fire-and-forget refreshes
+  are in flight, which is the same missing-recent-item shape and not a separate bug.
+
 ### Reproduction
 
 Sync a profile with 10–11 matching tasks onto a fresh CalDAV list, four times, clearing
@@ -237,8 +257,20 @@ The resemblance is suggestive, not evidence.
    ever delays the case where the call succeeded, which is the case that must not re-add.
 3. **Both.** (2) is the correctness fix; (1) also shortens every other latency below.
 
-Option 2 alone closes the reported bug and touches only `todo_list.py`, already on the
-mutation allowlist.
+Option 2 touches only `todo_list.py`, already on the mutation allowlist, which is why it
+looks like the contained one. **It is a sketch, not a design** — these have to be settled
+before it is written, and one of them may sink it:
+
+- Where does the counter live? `plan.tracked` is rebuilt from scratch each pass, so the
+  count has to be carried on the persisted entry, which widens the bookkeeping shape.
+- What happens on the pass where the uid finally binds while the item is still invisible?
+  That combination should not arise (the uid is read *off* the resolved item), but the
+  transition needs stating rather than assuming.
+- The `claimed` and `settled` sets span the whole plan, so an entry held back rather than
+  dropped must not claim an identity it has not resolved — otherwise two profiles syncing
+  onto one list could deadlock each other out of a line.
+
+Neither option is validated here. Both are directions.
 
 ---
 
@@ -406,8 +438,9 @@ answer is:
 - No push. HA reads the server on a 15-minute poll, shortened only by Home Keeper's own
   writes forcing a refresh (Finding 2).
 - No uid returned on create, so the sync must bind by summary on a later pass — which is
-  what Finding 1 exploits. Two tasks with the same name on one list are only ever
-  distinguished by that binding.
+  the window Finding 1 falls into. Once a uid *is* bound the sync resolves by it first
+  (`resolve_tracked` tries uid, then falls back to summary), so same-named tasks are only
+  ambiguous during that first window, not permanently.
 - Due dates are date-only in practice. Home Keeper deliberately writes `DUE;VALUE=DATE`
   (`desired_by_sync` truncates `next_due` to a date, because "a to-do list works in that
   granularity"), so a task's **time of day never reaches the server** and changing only

--- a/docs/CALDAV_SYNC_FINDINGS.md
+++ b/docs/CALDAV_SYNC_FINDINGS.md
@@ -5,14 +5,21 @@ against a real Nextcloud 34.0.3 talking to Home Assistant's built-in `caldav`
 integration, with Home Keeper's profile to-do sync pointed at the resulting `todo.*`
 entity.
 
-**Headline: the feature already works, and it broke for the reporter for a reason
-Home Keeper owns.** No new "CalDAV support" is needed — HA's `caldav` integration
-already exposes a task list as a `todo` entity, and Home Keeper's existing profile sync
-drives it. But CalDAV lists have one property no other supported provider has, and
-Home Keeper's sync mishandles it: **an item added to a CalDAV list is not readable back
-for up to a second afterwards.** Home Keeper reads the list, does not find the item it
-just added, concludes the add failed, and adds it again. The duplicate is permanent, and
-every later edit reaches only one of the two copies.
+**Headline: the feature already works, and a separate bug was found while testing it.**
+No new "CalDAV support" is needed — HA's `caldav` integration already exposes a task list
+as a `todo` entity, and Home Keeper's existing profile sync drives it two-way. But CalDAV
+lists have one property no other supported provider has, and Home Keeper's sync
+mishandles it: **an item added to a CalDAV list is not readable back for up to a second
+afterwards.** Home Keeper reads the list, does not find the item it just added, concludes
+the add failed, and adds it again. The duplicate is permanent, and every later edit
+reaches only one of the two copies.
+
+**That bug is not, on the evidence here, what the reporter hit.** It reproduced only on a
+*bulk* first sync — a burst of adds, always duplicating the tail — and never on a single
+add. The reporter's failing case was one task created in Home Keeper, and every
+single-task run in this session synced cleanly and propagated its due-date change within
+seconds. **Their symptom was not reproduced.** See "The one thing that did not reproduce"
+below for what is still open.
 
 ---
 
@@ -73,15 +80,18 @@ Every one of these was confirmed by reading the VTODOs back off Nextcloud.
 | Delete the task in Home Keeper | Its item is removed from the server |
 | A VTODO written in Nextcloud that Home Keeper never wrote | Left strictly alone — not imported, not deleted |
 
-So the reporter's tests 2, 4 and 5 are working as designed, and the sync is genuinely
-two-way. The three things they hit that are *not* fine follow.
+So the reporter's second and third observations — completing on the server, and deleting
+in Home Keeper — are working as designed, and the sync is genuinely two-way. Notably,
+**the due-date change they reported as broken worked every time it was tried here**, on a
+single task, within seconds.
 
 ---
 
 ## Finding 1 — Home Keeper mints permanent duplicate items on CalDAV lists
 
-**Severity: high. Reproduced 4 times out of 4.** This is the bug behind the reporter's
-"changing the due date never reflected into Nextcloud".
+**Severity: high. Reproduced 4 times out of 4** on a bulk first sync. Found while
+testing; **not** something the reporter described, and see the caveat at the end of this
+section before treating it as their bug.
 
 ### The precondition CalDAV alone has
 
@@ -176,7 +186,7 @@ round 4: HK wants 10, server has 12  dupes={'Replace furnace filter': (3, 2), 'R
 The duplicated entries are always at the tail of the add burst, which is exactly the part
 still invisible when the follow-up pass reads.
 
-### Why the reporter saw "the due date never reflected"
+### What a duplicate does to later edits
 
 Once a duplicate exists, Home Keeper's bookkeeping points at exactly one of the two
 copies and never learns about the other. Planting the duplicate by hand and then changing
@@ -197,9 +207,19 @@ orphan on the server permanently:
 after delete:  Dupe probe | DUE:20261005 | UID:planted-duplicate
 ```
 
-In the Nextcloud Tasks app the two copies are indistinguishable. A user who changes the
-due date and happens to be looking at the orphan sees exactly what was reported: a task
-that syncs on create, and then never updates again.
+In the Nextcloud Tasks app the two copies are indistinguishable, so a user looking at the
+orphan would see a task that syncs on create and then never updates again — which *reads*
+like the reported symptom.
+
+**Do not treat that as the explanation.** Two things argue against it:
+
+- The duplicate never appeared on a single add, only at the tail of a burst. The
+  reporter's failing case was one task created in Home Keeper.
+- Nobody in #267 reported seeing duplicate items, and two identical entries in the
+  Nextcloud Tasks app are hard to miss — especially for someone methodical enough to
+  write up five numbered test cases.
+
+The resemblance is suggestive, not evidence.
 
 ### Fix options
 
@@ -300,6 +320,47 @@ unsupported-feature paths already get.
 
 ---
 
+## The one thing that did not reproduce — the reporter's due-date symptom
+
+Their first observation was: a task created in Home Keeper reached Nextcloud, then
+changing its due date in Home Keeper never reached Nextcloud, over 13 hours and several
+reloads of both integrations.
+
+**That did not happen once here.** Every single-task run created the item and then moved
+its `DUE` within seconds of the change:
+
+```
+after add_task:     CalDAV probe | DUE;VALUE=DATE:20261005 | DESCRIPTION:first notes
+after due change:   CalDAV probe | DUE;VALUE=DATE:20261224 | DESCRIPTION:first notes
+after rename:       CalDAV probe renamed | DUE;VALUE=DATE:20261224
+after notes change: CalDAV probe renamed | DUE;VALUE=DATE:20261224 | DESCRIPTION:second notes
+```
+
+The update path itself is sound. Home Assistant's `todo.update_item` merges over the
+existing item (`dataclasses.asdict(found)` then the changed fields) rather than replacing
+it, so a due-only update keeps the summary and description; and `_api_items_factory`
+serializes `due` with `isoformat()`, so the planner's `str(item["due"])[:10]` comparison
+reads the right date whether the server stored a `DATE` or a `DATE-TIME`.
+
+Hypotheses still open, roughly in order of how much they'd explain:
+
+1. **They changed the time of day, not the date.** `desired_by_sync` truncates `next_due`
+   to a date, so a change that leaves the date alone produces no CalDAV write at all and
+   would look exactly like this — indefinitely, through any number of reloads. This is
+   the only hypothesis that survives 13 hours without needing anything to be broken.
+2. **The task stopped matching the profile in a way that produced no visible change.**
+   Worth asking which Include tier their profile uses.
+3. **Their `todo.update_item` was failing** — a uid Nextcloud no longer had, a permission
+   problem — which `_call` swallows at `debug` level, so nothing would appear in a normal
+   log. Finding 3's silence applies here too.
+
+**What to ask them:** which field they edited and whether the *date* changed; their
+profile's Include tier; and a `custom_components.home_keeper` debug log across one edit.
+Without that this stays unexplained — and the honest reply on #267 says so rather than
+offering the duplicate as an answer.
+
+---
+
 ## What is expected, and what Home Keeper can and cannot do
 
 Worth stating plainly, because the issue thread has two different asks tangled together.
@@ -343,10 +404,13 @@ answer is:
 ## Suggested follow-ups
 
 1. **Fix Finding 1** — the duplicate is data the user has to clean up by hand, and it
-   silently breaks every later edit. Option 2 above is the contained fix.
-2. **README**: a short CalDAV/Nextcloud paragraph in "Send tasks to your to-do lists",
+   silently breaks every later edit. Option 2 above is the contained fix. This stands on
+   its own merits; it is not contingent on it being the reporter's bug.
+2. **Get the missing detail on the due-date symptom** before claiming it is understood —
+   which field they edited and whether the date itself moved, their profile's Include
+   tier, and a `custom_components.home_keeper` debug log across one edit.
+3. **README**: a short CalDAV/Nextcloud paragraph in "Send tasks to your to-do lists",
    covering the task-list-not-Personal-calendar gotcha and the 15-minute inbound delay.
-3. **Reply on #267** with the working/not-working split above, so the reporter knows the
-   feature is there and what specifically misfired.
 4. Consider warning (not just `debug`-logging) on repeated write failures against a
-   configured sync target.
+   configured sync target — Findings 1 and 3 are both quiet for the same reason, and the
+   third hypothesis above would have been visible if they were not.

--- a/docs/CALDAV_SYNC_FINDINGS.md
+++ b/docs/CALDAV_SYNC_FINDINGS.md
@@ -1,0 +1,352 @@
+# CalDAV / Nextcloud to-do sync — exploratory testing findings
+
+Investigation of [#267](https://github.com/prestomation/ha-home-keeper/issues/267), run
+against a real Nextcloud 34.0.3 talking to Home Assistant's built-in `caldav`
+integration, with Home Keeper's profile to-do sync pointed at the resulting `todo.*`
+entity.
+
+**Headline: the feature already works, and it broke for the reporter for a reason
+Home Keeper owns.** No new "CalDAV support" is needed — HA's `caldav` integration
+already exposes a task list as a `todo` entity, and Home Keeper's existing profile sync
+drives it. But CalDAV lists have one property no other supported provider has, and
+Home Keeper's sync mishandles it: **an item added to a CalDAV list is not readable back
+for up to a second afterwards.** Home Keeper reads the list, does not find the item it
+just added, concludes the add failed, and adds it again. The duplicate is permanent, and
+every later edit reaches only one of the two copies.
+
+---
+
+## The environment
+
+| Piece | What was used |
+| --- | --- |
+| Home Assistant | `ghcr.io/home-assistant/home-assistant:stable`, the repo's `tests/integration` compose stack |
+| CalDAV server | `nextcloud:apache` 34.0.3, SQLite, on a shared Docker network |
+| HA integration | built-in `caldav`, pointed at `http://nextcloud/remote.php/dav` |
+| Python CalDAV lib | `caldav` 2.1.0 (vendored in the HA image) |
+| Home Keeper | this branch, one profile with `sync.entity_id = todo.chores` |
+
+Reproduction scripts are not committed — they drove HA over its REST/WebSocket API and
+Nextcloud over raw CalDAV `REPORT`/`PUT`/`DELETE`, so every assertion below is against
+the bytes on the server, not against Home Assistant's view of them.
+
+---
+
+## Setup gotcha, before any of the sync behaviour
+
+**Nextcloud's default "Personal" calendar cannot hold tasks.** It advertises
+`supported-calendar-component-set` = `VEVENT` only. HA's `caldav` todo platform creates a
+`todo.*` entity only for calendars that advertise `VTODO`
+(`SUPPORTED_COMPONENT = "VTODO"` in `caldav/todo.py`), so out of a stock Nextcloud you
+get `calendar.personal` and **no** `todo.personal`.
+
+Verified against the live server:
+
+```
+/remote.php/dav/calendars/admin/personal/   -> <comp name="VEVENT"/>
+/remote.php/dav/calendars/admin/chores/     -> <comp name="VEVENT"/> <comp name="VTODO"/> <comp name="VJOURNAL"/>
+```
+
+The `chores` collection was made with `occ dav:create-calendar`; in the UI the same thing
+happens when you add a **task list** in the Nextcloud Tasks app. Users who see no `todo`
+entity after adding the CalDAV integration are almost always looking at a VEVENT-only
+calendar. Worth a line in the README's to-do sync section.
+
+Once the list exists, the entity reports `supported_features: 119` — create, delete,
+update, due date, due datetime, description; everything Home Keeper's planner asks for
+except `MOVE_TODO_ITEM`, which it never uses.
+
+---
+
+## What works
+
+Every one of these was confirmed by reading the VTODOs back off Nextcloud.
+
+| Direction | Result |
+| --- | --- |
+| Create a task in Home Keeper | Item appears, with `DUE;VALUE=DATE`, `SUMMARY` and `DESCRIPTION` |
+| Change the due date in Home Keeper | `DUE` moves, within seconds |
+| Rename in Home Keeper | `SUMMARY` follows |
+| Change notes in Home Keeper | `DESCRIPTION` follows |
+| Complete in Home Keeper | Item flips to `STATUS:COMPLETED` |
+| Tick the item off on the server | Task completes in Home Keeper, recurrence reschedules, a **fresh** VTODO is written for the next occurrence |
+| Delete the task in Home Keeper | Its item is removed from the server |
+| A VTODO written in Nextcloud that Home Keeper never wrote | Left strictly alone — not imported, not deleted |
+
+So the reporter's tests 2, 4 and 5 are working as designed, and the sync is genuinely
+two-way. The three things they hit that are *not* fine follow.
+
+---
+
+## Finding 1 — Home Keeper mints permanent duplicate items on CalDAV lists
+
+**Severity: high. Reproduced 4 times out of 4.** This is the bug behind the reporter's
+"changing the due date never reflected into Nextcloud".
+
+### The precondition CalDAV alone has
+
+`todo.add_item` on a CalDAV list returns **before** the new item is visible to
+`todo.get_items`. HA's CalDAV entity saves to the server, then refreshes its own cache in
+a fire-and-forget background task — the comment in `caldav/todo.py` says so outright:
+
+```python
+await self.hass.async_add_executor_job(partial(self._calendar.save_todo, **item_data))
+# refreshing async otherwise it would take too much time
+self.hass.async_create_task(self.async_update_ha_state(force_refresh=True))
+```
+
+Measured directly, five times in a row, on a local container with a sub-100 ms round
+trip:
+
+```
+add 'race probe 1' returned in 84ms; get_items sees 1: >>> MISSING <<<
+    after 2s: PRESENT (server has 2)
+add 'race probe 2' returned in 61ms; get_items sees 2: >>> MISSING <<<
+    after 2s: PRESENT (server has 3)
+...
+```
+
+and for a burst, the tail of the burst is the part that stays invisible:
+
+```
+five adds took 251ms
+t+ 0s  HA sees  4  server has  5  missing from HA: ['burst 5']
+t+ 1s  HA sees  5  server has  5  missing from HA: []
+```
+
+CalDAV is the outlier among the providers Home Keeper's sync targets, and the difference
+is one `await`:
+
+| Integration | End of `async_create_todo_item` |
+| --- | --- |
+| `local_todo` | `await self.async_update_ha_state(force_refresh=True)` |
+| `todoist` | `await self.coordinator.async_refresh()` |
+| `caldav` | `self.hass.async_create_task(self.async_update_ha_state(force_refresh=True))` |
+
+So on every other target the item is readable the instant the call returns, and Home
+Keeper's assumptions hold. Against a real Nextcloud over a LAN or the internet the CalDAV
+window is far wider than the ~1 s seen here. This is arguably an upstream bug worth
+reporting against `homeassistant/components/caldav` as well — `async_create_todo_item` is
+documented as leaving the entity's state current — but Home Keeper should not depend on
+that being fixed.
+
+### What Home Keeper does with it
+
+`todo.add_item` answers with nothing, so the planner records the new item with **no
+uid** and binds one on the next pass by summary
+(`todo_list.py`, the add loop — `plan.tracked[key] = _entry(target, None, want)`).
+
+The next pass fires immediately, because writing to the list changes its state and
+`_handle_state_change` forces a pass. That pass reads a list that does not contain the
+item yet, so `resolve_tracked` returns `None`, and control reaches this branch
+(`todo_list.py`, in `plan_sync`):
+
+```python
+if item is None:
+    if want is None:
+        continue
+    sync = profile["sync"]
+    if entry.get("uid") and sync["two_way"] and sync["vanish_as_completed"]:
+        plan.complete.append(CompleteOp(key, task_id))
+        settled.add(key)
+    continue          # <- key never written to plan.tracked
+```
+
+With no uid the entry is simply dropped — deliberately, per the module docstring: *"an
+entry that never captured a uid has no proof its add ever landed, so it is re-added,
+never completed."* The second loop then finds `key not in plan.tracked` and plans a
+**second** `AddOp`. Two VTODOs, two uids, one task.
+
+The reasoning is sound for a list that answers reads honestly. It assumes "I cannot see
+it" implies "the add failed". On CalDAV it usually means "the add succeeded and the
+cache has not caught up".
+
+### Reproduction
+
+Sync a profile with 10–11 matching tasks onto a fresh CalDAV list, four times, clearing
+the server in between:
+
+```
+round 1: HK wants 11, server has 12  dupes={'Renew passport': (2, 1)}
+round 2: HK wants 11, server has 11  dupes={'Replace T&P relief valve …': (2, 1)}  missing={'Renew passport': (0, 1)}
+round 3: HK wants 10, server has 12  dupes={'Replace furnace filter': (3, 2), 'Replace T&P relief valve …': (2, 1)}
+round 4: HK wants 10, server has 12  dupes={'Replace furnace filter': (3, 2), 'Replace T&P relief valve …': (2, 1)}
+```
+
+The duplicated entries are always at the tail of the add burst, which is exactly the part
+still invisible when the follow-up pass reads.
+
+### Why the reporter saw "the due date never reflected"
+
+Once a duplicate exists, Home Keeper's bookkeeping points at exactly one of the two
+copies and never learns about the other. Planting the duplicate by hand and then changing
+the due date in Home Keeper:
+
+```
+before:  Dupe probe | DUE:20261005 | UID:c78f0766-…      <- tracked
+         Dupe probe | DUE:20261005 | UID:planted-duplicate <- orphan
+
+after:   Dupe probe | DUE:20261224 | UID:c78f0766-…      <- moved
+         Dupe probe | DUE:20261005 | UID:planted-duplicate <- frozen forever
+```
+
+Deleting the task in Home Keeper afterwards removes the tracked copy and leaves the
+orphan on the server permanently:
+
+```
+after delete:  Dupe probe | DUE:20261005 | UID:planted-duplicate
+```
+
+In the Nextcloud Tasks app the two copies are indistinguishable. A user who changes the
+due date and happens to be looking at the orphan sees exactly what was reported: a task
+that syncs on create, and then never updates again.
+
+### Fix options
+
+1. **Force the target list to refresh before the pass that would re-add.** After any
+   successful `add_item`, `await homeassistant.helpers.entity_component.async_update_entity(...)`
+   on that entity, so the next read sees a real snapshot. Turns "cannot see it" back into
+   honest evidence. Costs one extra CalDAV round trip per pass that adds anything, and
+   only on passes that add.
+2. **Give a uid-less entry a grace period in the planner.** Keep the entry in
+   `plan.tracked` the first time it resolves to nothing, with an attempt counter, and only
+   drop it (and therefore re-add) once it has been unseen across two passes. This is a
+   pure-planner change and unit-testable, which suits the mutation gate. Note a
+   genuinely-failed add is *already* retried immediately by a different path —
+   `_apply` does `settled.pop(add.key, None)` when the call raises — so the counter only
+   ever delays the case where the call succeeded, which is the case that must not re-add.
+3. **Both.** (2) is the correctness fix; (1) also shortens every other latency below.
+
+Option 2 alone closes the reported bug and touches only `todo_list.py`, already on the
+mutation allowlist.
+
+---
+
+## Finding 2 — inbound changes wait on a 15-minute poll
+
+**Severity: medium (expectation-setting), not a defect.** This is the reporter's third
+observation.
+
+`caldav/todo.py` sets `SCAN_INTERVAL = timedelta(minutes=15)`, and nothing pushes: CalDAV
+has no change notification HA subscribes to. `todo.get_items` reads the entity's cached
+`todo_items` and does not force a refresh, so **Home Keeper's own 5-minute sweep cannot
+help** — it re-reads the same cache.
+
+Measured: a VTODO ticked off directly on Nextcloud produced no reaction for 90 s, and
+then reacted within 2 s of a forced `homeassistant.update_entity`:
+
+```
+t+  5s  todo.chores=1  HK last_completed=None
+t+ 15s  todo.chores=1  HK last_completed=None
+t+ 30s  todo.chores=1  HK last_completed=None
+t+ 60s  todo.chores=1  HK last_completed=None
+t+ 90s  todo.chores=1  HK last_completed=None
+=== force HA to poll ===
++  2s   HK last_completed=2026-09-01T02:37:21-04:00  next_due=2026-12-01T02:37:21-05:00
+```
+
+The recurrence rescheduled and a fresh VTODO was written for the next occurrence — which
+is what the reporter saw, several minutes later than they expected.
+
+This is a CalDAV limitation, not a Home Keeper one, and it is the same for anything else
+reading that list. Two things could be done about it:
+
+- **Document it.** "Ticking an item off on a CalDAV server can take up to 15 minutes to
+  reach Home Keeper" belongs in the README's to-do sync section, next to the Todoist
+  recipe.
+- **Optionally shorten it.** Home Keeper's periodic sweep could call
+  `homeassistant.update_entity` on each synced list before reading it, which would bound
+  inbound latency by Home Keeper's own 5-minute tick instead of CalDAV's 15. That is a
+  network round trip per synced list per 5 minutes against somebody else's server, so it
+  should be a deliberate choice, not a silent one.
+
+---
+
+## Finding 3 — a write that fails while the server is down is only retried on the sweep
+
+**Severity: low.** Nextcloud was stopped, a new matching task was created in Home Keeper,
+and Nextcloud was restarted.
+
+While the server was down the entity did **not** go unavailable — it only polls every 15
+minutes, so HA had no idea. Home Keeper therefore read a stale-but-plausible list, planned
+the add, and the `todo.add_item` call failed. That is handled correctly: `_apply` drops
+the entry so the next pass retries, and Home Keeper itself stayed healthy throughout
+(`_call` swallows the failure, `async_sync` never raises).
+
+What is worth knowing is what wakes the retry. Nothing about the server coming back
+produces a task event or a list state change, so the retry waits for the **5-minute
+periodic sweep** — measured at 248 s after recovery, which is that sweep and not
+anything faster:
+
+```
+t+  0s  server has: ['Offline probe A']
+t+104s  still ['Offline probe A']
+t+228s  still ['Offline probe A']
+t+248s  >>> 'Offline probe B' landed <<<
+```
+
+Forcing an entity refresh does not help unless the item count changes, because it is the
+*state change* that forces a Home Keeper pass. Self-healing, but slower than it looks,
+and silent — the failure is logged at `debug` only:
+
+```python
+except Exception as err:  # never break the mutation that triggered us
+    self._logger.debug("todo.%s on %s failed: %s", service, entity_id, err)
+```
+
+For a self-hosted CalDAV server that goes down regularly, a repeated failure against a
+configured target is arguably worth the `_warn_once` treatment the missing-list and
+unsupported-feature paths already get.
+
+---
+
+## What is expected, and what Home Keeper can and cannot do
+
+Worth stating plainly, because the issue thread has two different asks tangled together.
+
+**Home Keeper syncs *its* tasks onto a list. It does not adopt a list's tasks.** The
+`todo` entity is a delivery surface. A VTODO written in Nextcloud that Home Keeper never
+created is left alone — not imported, not renamed, not deleted (confirmed: a hand-written
+`foreign-probe-1.ics` survived every subsequent pass untouched). That is the documented
+design, and it is the right one: a Home Keeper task carries recurrence, a device, an
+area, labels, consumables and completion history, none of which a VTODO can express, so
+there is nothing sensible to infer from a bare summary line.
+
+So for the original request — *"syncing tasks to/from a caldav server"* — the honest
+answer is:
+
+- **To CalDAV: yes, fully, today.** Create, rename, reschedule, re-describe, complete,
+  delete, and recurrence rescheduling all land on the server.
+- **From CalDAV: completions only.** Ticking an item off completes the Home Keeper task
+  (that is the whole two-way contract, same as Todoist). Creating a task *in* Nextcloud
+  and having it become a Home Keeper task is not a thing Home Keeper does for any
+  provider, and is a much larger feature than "CalDAV support".
+
+**CalDAV's own limits, as opposed to Home Keeper's:**
+
+- No push. 15-minute poll, both directions of visibility.
+- No uid returned on create, so the sync must bind by summary on a later pass — which is
+  what Finding 1 exploits. Two tasks with the same name on one list are only ever
+  distinguished by that binding.
+- Due dates are date-only in practice. Home Keeper deliberately writes `DUE;VALUE=DATE`
+  (`desired_by_sync` truncates `next_due` to a date, because "a to-do list works in that
+  granularity"), so a task's **time of day never reaches the server** and changing only
+  the time of day produces no CalDAV write at all. That is by design but is a plausible
+  second reading of "I changed the due date and nothing happened".
+- Nextcloud's calendars advertise their component set, and only a task list advertises
+  `VTODO`.
+- Deletes on the Nextcloud side go to a trashbin and read as a vanish, which with
+  `vanish_as_completed` on (the default) completes the Home Keeper task.
+
+---
+
+## Suggested follow-ups
+
+1. **Fix Finding 1** — the duplicate is data the user has to clean up by hand, and it
+   silently breaks every later edit. Option 2 above is the contained fix.
+2. **README**: a short CalDAV/Nextcloud paragraph in "Send tasks to your to-do lists",
+   covering the task-list-not-Personal-calendar gotcha and the 15-minute inbound delay.
+3. **Reply on #267** with the working/not-working split above, so the reporter knows the
+   feature is there and what specifically misfired.
+4. Consider warning (not just `debug`-logging) on repeated write failures against a
+   configured sync target.

--- a/docs/CALDAV_SYNC_FINDINGS.md
+++ b/docs/CALDAV_SYNC_FINDINGS.md
@@ -242,43 +242,61 @@ mutation allowlist.
 
 ---
 
-## Finding 2 — inbound changes wait on a 15-minute poll
+## Finding 2 — inbound changes wait on a poll, up to 15 minutes
 
-**Severity: medium (expectation-setting), not a defect.** This is the reporter's third
-observation.
+**Severity: medium (expectation-setting), not a defect.**
 
 `caldav/todo.py` sets `SCAN_INTERVAL = timedelta(minutes=15)`, and nothing pushes: CalDAV
 has no change notification HA subscribes to. `todo.get_items` reads the entity's cached
-`todo_items` and does not force a refresh, so **Home Keeper's own 5-minute sweep cannot
-help** — it re-reads the same cache.
+`todo_items` and does not force a refresh, so Home Keeper never sees the server sooner
+than that cache does.
 
-Measured: a VTODO ticked off directly on Nextcloud produced no reaction for 90 s, and
-then reacted within 2 s of a forced `homeassistant.update_entity`:
+There are two delays stacked here, and it is worth keeping them apart:
+
+1. **Server → HA cache.** The 15-minute poll — *unless* something forces a refresh
+   first. Every Home Keeper write to that list does: `add_item` / `update_item` /
+   `remove_item` each end with a `force_refresh` on the CalDAV entity. So a list Home
+   Keeper is actively writing to gets refreshed as a side effect, and a quiet one waits
+   the full 15 minutes.
+2. **HA cache → Home Keeper.** Either instant (the list's state changes, which forces a
+   pass) or the 5-minute periodic sweep.
+
+Both were measured. A VTODO ticked off on Nextcloud in a quiet window produced no
+reaction for 90 s, then reacted within 2 s of a forced `homeassistant.update_entity` —
+delay 1:
 
 ```
 t+  5s  todo.chores=1  HK last_completed=None
-t+ 15s  todo.chores=1  HK last_completed=None
-t+ 30s  todo.chores=1  HK last_completed=None
-t+ 60s  todo.chores=1  HK last_completed=None
+...
 t+ 90s  todo.chores=1  HK last_completed=None
 === force HA to poll ===
 +  2s   HK last_completed=2026-09-01T02:37:21-04:00  next_due=2026-12-01T02:37:21-05:00
 ```
 
-The recurrence rescheduled and a fresh VTODO was written for the next occurrence — which
-is what the reporter saw, several minutes later than they expected.
+A second run showed delay 2 in isolation, and it is the more interesting of the two. The
+tick landed 1 s before a refresh Home Keeper's own write had already triggered, so the
+cache was fresh at 02:45:54 (confirmed in the HA log — that is the last CalDAV server
+call before the reaction). Home Keeper still did not act until **02:50:53, exactly one
+5-minute sweep later**, because the item count did not move: probe A went completed and
+probe B was added in the same window, so `todo.chores` stayed at 1 and no state-change
+event fired.
 
-This is a CalDAV limitation, not a Home Keeper one, and it is the same for anything else
-reading that list. Two things could be done about it:
+That is the case `async_schedule_sweep`'s own docstring calls out — *"a list whose
+outstanding count happens to land back where it started — one item ticked off while
+another was added — produces no state change at all, so the listener alone can miss a
+tick-off"* — working exactly as designed. The sweep is the safety net, and it caught it.
+
+So the worst case is 15 min + 5 min, the common case on an active list is under 5 min,
+and neither is a defect. What follows from it:
 
 - **Document it.** "Ticking an item off on a CalDAV server can take up to 15 minutes to
   reach Home Keeper" belongs in the README's to-do sync section, next to the Todoist
   recipe.
 - **Optionally shorten it.** Home Keeper's periodic sweep could call
-  `homeassistant.update_entity` on each synced list before reading it, which would bound
-  inbound latency by Home Keeper's own 5-minute tick instead of CalDAV's 15. That is a
-  network round trip per synced list per 5 minutes against somebody else's server, so it
-  should be a deliberate choice, not a silent one.
+  `homeassistant.update_entity` on each synced list before reading it, which would
+  collapse delay 1 into delay 2 and bound the whole thing by Home Keeper's own 5-minute
+  tick. That is a network round trip per synced list per 5 minutes against somebody
+  else's server, so it should be a deliberate choice, not a silent one.
 
 ---
 
@@ -385,7 +403,8 @@ answer is:
 
 **CalDAV's own limits, as opposed to Home Keeper's:**
 
-- No push. 15-minute poll, both directions of visibility.
+- No push. HA reads the server on a 15-minute poll, shortened only by Home Keeper's own
+  writes forcing a refresh (Finding 2).
 - No uid returned on create, so the sync must bind by summary on a later pass — which is
   what Finding 1 exploits. Two tasks with the same name on one list are only ever
   distinguished by that binding.

--- a/docs/CALDAV_SYNC_FINDINGS.md
+++ b/docs/CALDAV_SYNC_FINDINGS.md
@@ -241,36 +241,40 @@ like the reported symptom.
 
 The resemblance is suggestive, not evidence.
 
-### Fix options
+### What shipped
 
-1. **Force the target list to refresh before the pass that would re-add.** After any
-   successful `add_item`, `await homeassistant.helpers.entity_component.async_update_entity(...)`
-   on that entity, so the next read sees a real snapshot. Turns "cannot see it" back into
-   honest evidence. Costs one extra CalDAV round trip per pass that adds anything, and
-   only on passes that add.
-2. **Give a uid-less entry a grace period in the planner.** Keep the entry in
-   `plan.tracked` the first time it resolves to nothing, with an attempt counter, and only
-   drop it (and therefore re-add) once it has been unseen across two passes. This is a
-   pure-planner change and unit-testable, which suits the mutation gate. Note a
-   genuinely-failed add is *already* retried immediately by a different path —
-   `_apply` does `settled.pop(add.key, None)` when the call raises — so the counter only
-   ever delays the case where the call succeeded, which is the case that must not re-add.
-3. **Both.** (2) is the correctness fix; (1) also shortens every other latency below.
+The planner now treats the `add_item` call's own outcome as the answer, and refuses to
+let a later read of a stale cache overturn it. A uid-less entry whose item cannot be
+resolved is **held** — carried forward verbatim, stamped `added_at` — instead of being
+dropped and re-added. The hold is bounded by `UNCONFIRMED_GRACE` (20 minutes), after
+which a genuinely lost add is repaired rather than leaving the task with no item for
+good.
 
-Option 2 touches only `todo_list.py`, already on the mutation allowlist, which is why it
-looks like the contained one. **It is a sketch, not a design** — these have to be settled
-before it is written, and one of them may sink it:
+Wall clock rather than a count of passes, which is the load-bearing detail: the driver
+runs up to four passes back to back with no delay, so "unseen for two passes" can elapse
+in milliseconds — entirely inside the window being waited out. 20 minutes is a *staleness
+budget* calibrated to clear CalDAV's 15-minute poll, not a formula; the mechanism itself
+depends on nothing upstream.
 
-- Where does the counter live? `plan.tracked` is rebuilt from scratch each pass, so the
-  count has to be carried on the persisted entry, which widens the bookkeeping shape.
-- What happens on the pass where the uid finally binds while the item is still invisible?
-  That combination should not arise (the uid is read *off* the resolved item), but the
-  transition needs stating rather than assuming.
-- The `claimed` and `settled` sets span the whole plan, so an entry held back rather than
-  dropped must not claim an identity it has not resolved — otherwise two profiles syncing
-  onto one list could deadlock each other out of a line.
+Two details that had to be right:
 
-Neither option is validated here. Both are directions.
+- The held entry is carried forward **verbatim**, never rebuilt from what the task now
+  wants. For a uid-less entry the summary *is* the handle, so it has to keep saying what
+  was written to the list — otherwise a task renamed mid-hold would never match its own
+  line again.
+- The stamp is **re-written** rather than `setdefault`, because a value that is
+  unparsable or in the future (a clock that jumped backwards before NTP corrected it)
+  would never age out, turning "hold, never duplicate" into "hold, never deliver".
+
+**Verified against the same Nextcloud that produced the bug:** 4 rounds of the bulk
+first sync, **0 duplicates** where every round previously produced 1–3, with the server's
+VTODO count matching the wanted-task count exactly and nothing missing.
+
+Deliberately *not* done: forcing the entity to refresh before each read
+(`async_update_entity`). It would shorten every latency here as a bonus, but it cannot
+close the race on its own — Home Assistant's own fire-and-forget refreshes can still land
+afterwards carrying an older snapshot — and it costs a round trip to somebody else's
+server on every pass that adds anything. Worth considering separately, on its own merits.
 
 ---
 

--- a/tests/unit/test_todo_list.py
+++ b/tests/unit/test_todo_list.py
@@ -99,14 +99,23 @@ def _item(summary=NAME, uid="i1", status=tm.STATUS_NEEDS_ACTION, **extra):
     }
 
 
-def _entry(entity_id=LIST, uid="i1", summary=NAME, due=DUE, last_completed=None):
+def _entry(
+    entity_id=LIST, uid="i1", summary=NAME, due=DUE, last_completed=None, added_at=None
+):
     return {
         "entity_id": entity_id,
         "uid": uid,
         "summary": summary,
         "due": due,
         "last_completed": last_completed,
+        "added_at": added_at,
     }
+
+
+def _added(minutes_ago=0, **kw):
+    """A uid-less entry stamped *minutes_ago* — an add we have not seen back yet."""
+    kw.setdefault("uid", None)
+    return _entry(added_at=(NOW - timedelta(minutes=minutes_ago)).isoformat(), **kw)
 
 
 def _tracked(entry=None, key=KEY):
@@ -114,7 +123,14 @@ def _tracked(entry=None, key=KEY):
 
 
 def _plan(
-    *, synced=None, tracked=None, desired=None, items=None, lists=None, caps=None
+    *,
+    synced=None,
+    tracked=None,
+    desired=None,
+    items=None,
+    lists=None,
+    caps=None,
+    now=NOW,
 ):
     """Run one pass. *items* is LIST's contents (None = unreadable list)."""
     if lists is None:
@@ -125,6 +141,7 @@ def _plan(
         desired=desired or {},
         items_by_entity=lists,
         capabilities=CAPS if caps is None else caps,
+        now=now,
     )
 
 
@@ -297,15 +314,7 @@ def test_a_due_task_with_no_item_yet_is_added_to_the_list():
     assert plan.add == [
         tm.AddOp(KEY, LIST, NAME, due=DUE, description="Under the sink")
     ]
-    assert plan.tracked == {
-        KEY: {
-            "entity_id": LIST,
-            "uid": None,
-            "summary": NAME,
-            "due": DUE,
-            "last_completed": None,
-        }
-    }
+    assert plan.tracked == {KEY: _added()}
     assert plan.update == [] and plan.remove == [] and plan.complete == []
 
 
@@ -335,15 +344,7 @@ def test_the_next_pass_binds_the_uid_of_the_item_it_added():
     )
     assert plan.add == [] and plan.update == [] and plan.remove == []
     assert plan.complete == []
-    assert plan.tracked == {
-        KEY: {
-            "entity_id": LIST,
-            "uid": "captured",
-            "summary": NAME,
-            "due": DUE,
-            "last_completed": None,
-        }
-    }
+    assert plan.tracked == {KEY: _entry(uid="captured")}
 
 
 def test_an_open_item_already_reading_the_same_is_adopted():
@@ -359,7 +360,7 @@ def test_a_ticked_off_lookalike_is_never_adopted():
         items=[_item(uid="old", status=tm.STATUS_COMPLETED)],
     )
     assert plan.add == [tm.AddOp(KEY, LIST, NAME, due=DUE)]
-    assert plan.tracked == {KEY: _entry(uid=None)}
+    assert plan.tracked == {KEY: _added()}
 
 
 # ── keeping a synced chore in step ──────────────────────────────────────────
@@ -396,13 +397,7 @@ def test_a_rename_a_new_date_and_new_notes_are_one_update():
     ]
     assert plan.remove == [] and plan.add == [] and plan.complete == []
     assert plan.tracked == {
-        KEY: {
-            "entity_id": LIST,
-            "uid": "i1",
-            "summary": "Change the water filter",
-            "due": "2026-07-01",
-            "last_completed": None,
-        }
+        KEY: _entry(summary="Change the water filter", due="2026-07-01")
     }
 
 
@@ -510,9 +505,7 @@ def test_a_tick_home_keeper_already_knows_about_is_not_sent_back():
     )
     assert plan.complete == [] and plan.update == [] and plan.remove == []
     assert plan.add == [tm.AddOp(KEY, LIST, NAME, due="2026-09-14")]
-    assert plan.tracked == {
-        KEY: _entry(uid=None, due="2026-09-14", last_completed=DONE_ISO)
-    }
+    assert plan.tracked == {KEY: _added(due="2026-09-14", last_completed=DONE_ISO)}
 
 
 # ── completed inside Home Keeper ──────────────────────────────────────────────
@@ -547,15 +540,7 @@ def test_completing_the_task_ticks_the_item_off_and_the_next_one_is_fresh():
     assert plan.update == [tm.UpdateOp(KEY, LIST, "i1", status=tm.STATUS_COMPLETED)]
     assert plan.add == [tm.AddOp(KEY, LIST, NAME, due="2026-09-14")]
     assert plan.remove == [] and plan.complete == []
-    assert plan.tracked == {
-        KEY: {
-            "entity_id": LIST,
-            "uid": None,
-            "summary": NAME,
-            "due": "2026-09-14",
-            "last_completed": DONE_ISO,
-        }
-    }
+    assert plan.tracked == {KEY: _added(due="2026-09-14", last_completed=DONE_ISO)}
 
 
 def test_completing_a_task_that_is_done_for_good_only_ticks_the_item_off():
@@ -591,15 +576,106 @@ def test_a_vanished_item_completes_the_task_when_the_sync_opted_in():
     assert plan.tracked == {}
 
 
-def test_a_vanished_item_we_never_confirmed_is_re_added_not_completed():
+def test_a_vanished_item_we_never_confirmed_is_never_completed():
     # No uid means no proof our add ever landed, and completing a task on the
     # strength of a write we cannot confirm is the one mistake with no undo.
+    plan = _plan(tracked=_tracked(_added()), desired=_desired([_want()]), items=[])
+    assert plan.complete == []
+
+
+def test_an_add_we_have_not_seen_back_yet_is_held_rather_than_repeated():
+    # The CalDAV shape: the add landed, but the list cannot show it yet. Adding a
+    # second one here is what minted duplicates nobody could tell apart.
+    plan = _plan(tracked=_tracked(_added()), desired=_desired([_want()]), items=[])
+    assert plan.add == [] and plan.complete == []
+    assert plan.tracked == {KEY: _added()}
+
+
+def test_an_add_still_missing_when_the_hold_runs_out_is_put_on_again():
+    # Waiting longer will not tell us what happened to it, and a chore with no
+    # line at all is worse than a second one.
+    plan = _plan(
+        tracked=_tracked(_added(minutes_ago=21)),
+        desired=_desired([_want()]),
+        items=[],
+    )
+    assert plan.add == [tm.AddOp(KEY, LIST, NAME, due=DUE)]
+    assert plan.tracked == {KEY: _added()}
+
+
+def test_an_add_is_still_held_just_short_of_the_hold_running_out():
+    plan = _plan(
+        tracked=_tracked(_added(minutes_ago=19)),
+        desired=_desired([_want()]),
+        items=[],
+    )
+    assert plan.add == []
+
+
+def test_the_hold_runs_out_strictly_after_the_grace_not_at_it():
+    # Pins the boundary itself: exactly one grace old is still held.
+    entry = _entry(uid=None, added_at=(NOW - tm.UNCONFIRMED_GRACE).isoformat())
+    assert tm._add_unconfirmed(entry, now=NOW) is False
+    assert tm._add_unconfirmed(entry, now=NOW + timedelta(seconds=1)) is True
+
+
+def test_an_unconfirmed_add_with_no_stamp_starts_its_hold_now():
+    # Bookkeeping written before the stamp existed, and the adopt path on a list
+    # that hands out no uids: hold one grace rather than duplicating on sight.
     plan = _plan(
         tracked=_tracked(_entry(uid=None)), desired=_desired([_want()]), items=[]
     )
-    assert plan.complete == []
-    assert plan.add == [tm.AddOp(KEY, LIST, NAME, due=DUE)]
-    assert plan.tracked == {KEY: _entry(uid=None)}
+    assert plan.add == []
+    assert plan.tracked == {KEY: _added()}
+
+
+def test_a_stamp_that_cannot_be_read_is_replaced_rather_than_trusted():
+    # "Hold, never duplicate" must not become "hold, never deliver": a stamp that
+    # cannot be parsed would otherwise never age out, and the chore would never
+    # reach the list at all.
+    plan = _plan(
+        tracked=_tracked(_entry(uid=None, added_at="whenever")),
+        desired=_desired([_want()]),
+        items=[],
+    )
+    assert plan.add == []
+    assert plan.tracked == {KEY: _added()}
+
+
+def test_a_stamp_from_the_future_is_replaced_rather_than_trusted():
+    # A clock that jumped backwards before NTP corrected it. Left alone, ``now``
+    # never gets past it and the hold never ends.
+    plan = _plan(
+        tracked=_tracked(_added(minutes_ago=-90)),
+        desired=_desired([_want()]),
+        items=[],
+    )
+    assert plan.add == []
+    assert plan.tracked == {KEY: _added()}
+
+
+def test_a_held_add_keeps_the_text_it_wrote_when_the_task_is_renamed():
+    # The summary is the handle for a uid-less entry, so it has to keep saying
+    # what went onto the list — not what we now want — or nothing would ever
+    # match the line we are waiting for.
+    plan = _plan(
+        tracked=_tracked(_added()),
+        desired=_desired([_want(name="Change the water filter")]),
+        items=[],
+    )
+    assert plan.add == []
+    assert plan.tracked[KEY]["summary"] == NAME
+
+
+def test_a_held_add_binds_its_uid_once_the_list_can_show_it():
+    plan = _plan(
+        tracked=_tracked(_added()),
+        desired=_desired([_want()]),
+        items=[_item(uid="landed")],
+    )
+    assert plan.add == []
+    assert plan.tracked == {KEY: _entry(uid="landed")}
+    assert plan.tracked[KEY]["added_at"] is None
 
 
 def test_a_vanished_item_is_re_added_when_the_sync_reads_deletion_as_deletion():
@@ -661,7 +737,7 @@ def test_pointing_a_sync_at_another_list_moves_the_chore():
     )
     assert plan.remove == [tm.RemoveOp(KEY, OTHER, "i1")]
     assert plan.add == [tm.AddOp(KEY, LIST, NAME, due=DUE)]
-    assert plan.tracked == {KEY: _entry(uid=None)}
+    assert plan.tracked == {KEY: _added()}
 
 
 def test_deleting_a_sync_clears_what_it_wrote():
@@ -807,6 +883,9 @@ def test_two_syncs_on_one_list_never_share_a_line():
 
 
 def test_two_tasks_reading_the_same_never_share_a_line():
+    # One line, two tasks reading the same: the first claims it, and the second is
+    # left holding an add it cannot confirm. It waits rather than putting a second
+    # line up — the one line already there may well be its own.
     plan = _plan(
         tracked={"m1:t1": _entry(uid=None), "m1:t2": _entry(uid=None)},
         desired={M1: {T1: _want(), "t2": _want(tid="t2")}},
@@ -814,7 +893,8 @@ def test_two_tasks_reading_the_same_never_share_a_line():
     )
     assert plan.tracked["m1:t1"]["uid"] == "only"
     assert plan.tracked["m1:t2"]["uid"] is None
-    assert plan.add == [tm.AddOp("m1:t2", LIST, NAME, due=DUE)]
+    assert plan.tracked["m1:t2"]["added_at"] == NOW.isoformat()
+    assert plan.add == []
 
 
 # ── which list item a tracked entry points at ─────────────────────────────────
@@ -856,6 +936,30 @@ def test_a_ticked_off_item_is_matched_when_it_is_the_only_one():
     plan = _plan(
         tracked=_tracked(_entry(uid=None)),
         desired=_desired([_want()]),
+        items=[_item(uid="old", status=tm.STATUS_COMPLETED)],
+    )
+    assert plan.complete == [tm.CompleteOp(KEY, T1)]
+
+
+def test_an_unconfirmed_add_never_reads_the_line_it_replaced_as_a_tick():
+    # A recurring chore just completed inside Home Keeper: the old line is ticked
+    # off, the fresh one is not readable yet, and matching by summary lands on the
+    # predecessor. Reading that as the household's tick would complete the task a
+    # second time and strand the new line for good — so it waits instead.
+    plan = _plan(
+        tracked=_tracked(_added(last_completed=DONE_ISO)),
+        desired=_desired([_want(last_completed=DONE_ISO)]),
+        items=[_item(uid="old", status=tm.STATUS_COMPLETED)],
+    )
+    assert plan.complete == []
+    assert plan.add == [] and plan.update == [] and plan.remove == []
+    assert plan.tracked == {KEY: _added(last_completed=DONE_ISO)}
+
+
+def test_a_tick_still_lands_once_the_unconfirmed_add_has_waited_its_grace():
+    plan = _plan(
+        tracked=_tracked(_added(minutes_ago=21, last_completed=DONE_ISO)),
+        desired=_desired([_want(last_completed=DONE_ISO)]),
         items=[_item(uid="old", status=tm.STATUS_COMPLETED)],
     )
     assert plan.complete == [tm.CompleteOp(KEY, T1)]
@@ -1075,6 +1179,7 @@ def test_every_tracked_entry_is_planned_independently_in_one_pass():
             "h": _want("h", name="Sweep the chimney"),
             "i": _want("i", name="Oil the hinges"),
             "k": _want("k", name="Test the RCD"),
+            "m": _want("m", name="Prune the hedge"),
             "z": _want("z", name="Defrost the freezer"),
         },
         "m9": {"a": _want("a", name="Rake the leaves")},
@@ -1090,8 +1195,9 @@ def test_every_tracked_entry_is_planned_independently_in_one_pass():
         "m1:d": _entry(uid="id", summary="Change the smoke alarm"),
         # Vanished, and we hold a uid: the sync reads that as done.
         "m1:e": _entry(uid="ie", summary="Bleed the radiators"),
-        # Vanished with no uid to vouch for it: put it back instead.
-        "m1:f": _entry(uid=None, summary="Wash the windows"),
+        # Vanished with no uid to vouch for it, and the hold has run out: put it
+        # back rather than leaving the chore with no line at all.
+        "m1:f": _added(minutes_ago=21, summary="Wash the windows"),
         # Vanished, and nobody wants it any more.
         "m1:g": _entry(uid="ig", summary="Polish the taps"),
         # Left on the list this sync used to point at.
@@ -1107,6 +1213,8 @@ def test_every_tracked_entry_is_planned_independently_in_one_pass():
         "m5:b": _entry(uid="i5b", summary="Flush the boiler"),
         "m5:c": _entry(uid="i5c", summary="Seal the deck"),
         "m5:d": _entry(entity_id=GHOST, uid="i5d", summary="Wax the car"),
+        # Added a moment ago and not readable back yet: held, never repeated.
+        "m1:m": _added(summary="Prune the hedge"),
         # Renamed since it was synced.
         "m9:a": _entry(entity_id=OTHER, uid="i9", summary="Rake up the leaves"),
     }
@@ -1132,6 +1240,7 @@ def test_every_tracked_entry_is_planned_independently_in_one_pass():
             ],
         },
         capabilities=CAPS,
+        now=NOW,
     )
     assert plan.remove == [
         tm.RemoveOp("m1:b", LIST, "ib"),
@@ -1155,18 +1264,19 @@ def test_every_tracked_entry_is_planned_independently_in_one_pass():
     ]
     assert plan.tracked == {
         "m1:a": _entry(uid="ia", summary="Descale the kettle"),
-        "m1:d": _entry(
-            uid=None,
+        "m1:d": _added(
             summary="Change the smoke alarm",
             due="2026-09-14",
             last_completed=DONE_ISO,
         ),
-        "m1:f": _entry(uid=None, summary="Wash the windows"),
-        "m1:h": _entry(uid=None, summary="Sweep the chimney"),
+        "m1:f": _added(summary="Wash the windows"),
+        "m1:h": _added(summary="Sweep the chimney"),
         "m1:i": _entry(entity_id=GHOST, uid="ii", summary="Oil the hinges"),
         # Adopted: a line already reading the same is never duplicated.
         "m1:k": _entry(uid="ik", summary="Test the RCD"),
-        "m1:z": _entry(uid=None, summary="Defrost the freezer"),
+        # Held: its add is unconfirmed and still inside the grace.
+        "m1:m": _added(summary="Prune the hedge"),
+        "m1:z": _added(summary="Defrost the freezer"),
         "m5:d": _entry(entity_id=GHOST, uid="i5d", summary="Wax the car"),
         "m9:a": _entry(entity_id=OTHER, uid="i9", summary="Rake the leaves"),
     }

--- a/tests/unit/test_todo_list.py
+++ b/tests/unit/test_todo_list.py
@@ -610,6 +610,28 @@ def test_an_add_is_still_held_just_short_of_the_hold_running_out():
         items=[],
     )
     assert plan.add == []
+    # The original stamp is what keeps running: re-stamping each pass would push
+    # the deadline out forever and the hold would never end.
+    assert plan.tracked == {KEY: _added(minutes_ago=19)}
+
+
+def test_a_stamp_already_in_the_past_is_the_one_the_hold_keeps_running_on():
+    entry = _added(minutes_ago=19)
+    assert tm._added_stamp(entry, now=NOW) == entry["added_at"]
+
+
+def test_a_stamp_that_cannot_be_trusted_is_replaced_with_now():
+    # Unparsable, absent, and from the future all mean the same thing: there is no
+    # deadline here, so start one rather than holding without end.
+    assert tm._added_stamp({"added_at": "whenever"}, now=NOW) == NOW.isoformat()
+    assert tm._added_stamp({"added_at": None}, now=NOW) == NOW.isoformat()
+    assert tm._added_stamp({}, now=NOW) == NOW.isoformat()
+    assert tm._added_stamp(_added(minutes_ago=-1), now=NOW) == NOW.isoformat()
+
+
+def test_a_stamp_taken_at_this_very_instant_is_kept_as_it_is():
+    entry = _added()
+    assert tm._added_stamp(entry, now=NOW) == entry["added_at"]
 
 
 def test_the_hold_runs_out_strictly_after_the_grace_not_at_it():

--- a/tests/unit/test_todo_list_sync.py
+++ b/tests/unit/test_todo_list_sync.py
@@ -267,13 +267,16 @@ def _item(
     }
 
 
-def _entry(entity_id=LIST, uid="i1", summary=NAME, due=DUE, last_completed=None):
+def _entry(
+    entity_id=LIST, uid="i1", summary=NAME, due=DUE, last_completed=None, added_at=None
+):
     return {
         "entity_id": entity_id,
         "uid": uid,
         "summary": summary,
         "due": due,
         "last_completed": last_completed,
+        "added_at": added_at,
     }
 
 
@@ -391,10 +394,13 @@ def test_a_due_task_lands_on_the_list_with_its_date_and_notes():
         {"entity_id": LIST, "item": NAME, "due_date": DUE, "description": NOTES}
     ]
     # No uid: ``todo.add_item`` answers with nothing, and the next pass binds one.
+    # It is stamped instead, so a list too slow to show the new item does not earn
+    # a second one.
     assert store.get_todo_list_items() == {
         KEY: {
             "entity_id": LIST,
             "uid": None,
+            "added_at": NOW.isoformat(),
             "summary": NAME,
             "due": DUE,
             "last_completed": None,


### PR DESCRIPTION
Related to #267 — but deliberately **not** `Fixes #267`. The reporter's symptom was never reproduced; this fixes a different, real bug found while investigating theirs. A false reference would make `notify-issues` close their issue on release.

## What changed

Exploratory testing against a **real Nextcloud 34.0.3** (HA 2026.8.3, built-in `caldav`) turned up two bugs on one precondition, both now fixed. Findings are written up in `docs/CALDAV_SYNC_FINDINGS.md`.

### The precondition

`todo.add_item` answers with nothing, so a fresh entry carries no uid and is matched by summary on a later pass. HA's CalDAV entity refreshes its cached items in a **fire-and-forget** task, where `local_todo` and `todoist` both `await` theirs:

```python
# caldav/todo.py
await self.hass.async_add_executor_job(partial(self._calendar.save_todo, **item_data))
# refreshing async otherwise it would take too much time
self.hass.async_create_task(self.async_update_ha_state(force_refresh=True))
```

Measured locally, `todo.get_items` did not show the item on **any** of five consecutive adds.

### Bug A — permanent duplicate (reproduced 4/4)

The next pass failed to resolve the item and, having no uid, read that as a failed add and added it again. The bookkeeping only ever points at one copy, so later edits moved one and deleting the task orphaned the other.

### Bug B — phantom completion (found in review, verified in source)

`resolve_tracked` falls back to the first summary match **even when it is ticked off** — which, after a recurring task completes, is the predecessor Home Keeper ticked off itself. `completed_since` is a strict `>`, so the pass read that as the household's tick and planned a second completion, skipping an occurrence and stranding the new item. Strictly worse than A.

### The fix

Both come from one unsound step: letting a read of a stale cache overturn what the write already established. An unconfirmed entry is now **held** — carried forward verbatim, since for a uid-less entry the summary is its only handle — and stamped `added_at`, until `UNCONFIRMED_GRACE` (20 min) expires and a genuinely lost add is repaired rather than leaving the task with no item. The same stamp gates the ticked-item arm.

Two decisions worth review:

- **Wall clock, not a pass count.** The driver runs four passes back to back with no delay, so "unseen for two passes" can elapse in milliseconds — inside the window being waited out.
- **20 minutes is a staleness budget**, calibrated to clear CalDAV's 15-minute `SCAN_INTERVAL`, not a formula. The mechanism depends on nothing upstream; only the number does.
- The stamp is **rewritten** rather than kept, because a value that is unparsable or in the future (a clock that jumped back before NTP corrected it) would never age out — turning "hold, never duplicate" into "hold, never deliver".

### Also in here

- **README**: says plainly that a to-do item you add on the list yourself never becomes a Home Keeper task, what does travel inbound, and the two CalDAV gotchas (the 15-minute poll; Nextcloud's default *Personal* calendar holds only events so it never appears as a to-do list).
- **New workflow rule** in `AGENTS.md` + `.amazonq/rules/`: user-facing text is drafted by a Sonnet 4.5 subagent, then reviewed. Dogfooded for the README and CHANGELOG here — I tightened both drafts for vale `ai-tells` risks.
- **Version bump to `0.20.0b1`** — required, not optional: `v0.19.0` is already tagged, so `check-changelog-release-gap.py` rejects editing that section and `release.yml` would skip a tag it already cut.

## Verification

- `pytest tests/unit` — **1591 passed**
- `ruff check` / `ruff format --check` — clean
- **Mutation gate — 97.29%** (395/406 mutants killed, threshold 80%), scoped to the four changed functions
- `mypy --strict` on `todo_list.py` — clean (the full mypy job needs HA, whose Python floor this container is below; CI covers it)
- **Against the real Nextcloud that produced the bug:**
  - Bug A: **0 duplicates across 4 rounds**, where every round previously produced 1–3. Server VTODO count matched the wanted-task count exactly, nothing missing.
  - Bug B: a completed recurring task recorded **exactly one** completion, with its next occurrence written and intact.

## Checklist

- [x] Tests run locally (`pytest tests/unit`, mutation gate, ruff) — plus a real CalDAV run
- [x] `CHANGELOG.md` updated — `## [0.20.0b1]`, no `(Fixes #N)` by design (see top)
- [x] Panel UI changed → n/a, no UI change
- [x] New user-facing UI surface → n/a
- [x] New user-facing feature → n/a; bug fix, so no `preview-release` label