### PR TITLE
docs: credit outside contributors in the changelog

### DIFF
--- a/.amazonq/rules/testing-and-workflow.md
+++ b/.amazonq/rules/testing-and-workflow.md
@@ -21,11 +21,13 @@
   counting the bold lead as the first, not three per paragraph.
 - **Credit an outside contributor in the bullet for their change.** End the bullet
   with `(Thanks @user!)`, after `(Fixes #N)` if the bullet has one. The credit does
-  not count against the three-sentence budget. Every change that came from a PR by
-  someone outside the project gets one, in the same change that writes the bullet.
-  `summarize()` in `ci/release-issues.py` quotes only the bold lead, so the credit
-  stays in the CHANGELOG. It does not reach the issue comment, and it does not
-  notify the contributor on each release.
+  not count against the three-sentence budget. An outside contributor is anyone
+  without write access to the repository when the PR opens. Their change gets a
+  credit in the same PR that writes the bullet. If a maintainer and a contributor
+  share the work, the contributor gets the credit. `summarize()` in
+  `ci/release-issues.py` quotes only the bold lead. The credit stays in the
+  CHANGELOG. It does not reach the issue comment, and it does not notify the
+  contributor on each release.
 - Post screenshots to the PR for any change that adds/changes/fixes UI (capture
   via `tests/e2e/screenshots.capture.ts`, commit under `docs/images/`, embed via
   a `raw.githubusercontent.com/.../<commit-sha>/docs/images/<file>.png` URL).

--- a/.amazonq/rules/testing-and-workflow.md
+++ b/.amazonq/rules/testing-and-workflow.md
@@ -19,6 +19,13 @@
   `docs/`, or the PR; the changelog says what changed and stops. One bullet per change,
   never a second paragraph. Three sentences is the budget for the **whole bullet**,
   counting the bold lead as the first, not three per paragraph.
+- **Credit an outside contributor in the bullet for their change.** End the bullet
+  with `(Thanks @user!)`, after `(Fixes #N)` if the bullet has one. The credit does
+  not count against the three-sentence budget. Every change that came from a PR by
+  someone outside the project gets one, in the same change that writes the bullet.
+  `summarize()` in `ci/release-issues.py` quotes only the bold lead, so the credit
+  stays in the CHANGELOG. It does not reach the issue comment, and it does not
+  notify the contributor on each release.
 - Post screenshots to the PR for any change that adds/changes/fixes UI (capture
   via `tests/e2e/screenshots.capture.ts`, commit under `docs/images/`, embed via
   a `raw.githubusercontent.com/.../<commit-sha>/docs/images/<file>.png` URL).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,9 +44,11 @@
   section forgot.
 - **Credit an outside contributor in the bullet for their change.** End the bullet
   with `(Thanks @user!)`, after `(Fixes #N)` if the bullet has one. The credit does
-  not count against the three-sentence budget. Every change that came from a PR by
-  someone outside the project gets one, in the same change that writes the bullet.
-  `ci/release-issues.py` quotes only the bold lead, so the credit stays in the
+  not count against the three-sentence budget. An outside contributor is anyone
+  without write access to the repository when the PR opens. Their change gets a
+  credit in the same PR that writes the bullet. If a maintainer and a contributor
+  share the work, the contributor gets the credit. `summarize()` in
+  `ci/release-issues.py` quotes only the bold lead. The credit stays in the
   CHANGELOG. It does not reach the issue comment, and it does not notify the
   contributor on each release.
 - **Keep linking issues from a PR with `Fixes #N`.** Closing-on-merge is turned off

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,13 @@
   because `(#N)` is also the squash-merge PR number and the two can't be told apart.
   The job posts a CI warning naming any issue a shipped commit referenced that the
   section forgot.
+- **Credit an outside contributor in the bullet for their change.** End the bullet
+  with `(Thanks @user!)`, after `(Fixes #N)` if the bullet has one. The credit does
+  not count against the three-sentence budget. Every change that came from a PR by
+  someone outside the project gets one, in the same change that writes the bullet.
+  `ci/release-issues.py` quotes only the bold lead, so the credit stays in the
+  CHANGELOG. It does not reach the issue comment, and it does not notify the
+  contributor on each release.
 - **Keep linking issues from a PR with `Fixes #N`.** Closing-on-merge is turned off
   for this repository, so the keyword links the PR to the issue — that's what fills in
   the issue's **Development** panel and its linked-pull-request relationship — without


### PR DESCRIPTION
Docs only. Adds a changelog rule: a change that came from an outside contributor's PR
gets `(Thanks @user!)` at the end of its bullet, after `(Fixes #N)`.

Written into both `AGENTS.md` and `.amazonq/rules/testing-and-workflow.md`, per the
"conventions live in `.amazonq/rules/` — keep them current" gate.

## The two details the rule pins down

- **It does not count against the three-sentence budget.** A credit is a tag like
  `(Fixes #N)`, not a sentence of the entry.
- **It stays in the CHANGELOG.** `summarize()` in `ci/release-issues.py` quotes only a
  bullet's bold lead into the issue comment `notify-issues` posts, so the credit never
  reaches that comment and never pings the contributor on each release. Verified
  against the parser:

  ```
  bullet:  **Optional Home Assistant labels.** … (Fixes #21) (Thanks @bonzenpaule!)
  issues:  [{'number': 21, 'summary': 'Optional Home Assistant labels.'}]
  ```

The matching change in the Battery Notes glue is
[ha-home-keeper-battery-notes#22](https://github.com/prestomation/ha-home-keeper-battery-notes/pull/22),
which adds a changelog-conventions section to its `RELEASE.md` (it had none) and applies
the credit to the bullet for the contributor PR in flight there.

No code changed, so no test or version bump. `AGENTS.md` and `.amazonq/rules/` are
outside vale's configured scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BgrUw9GJch8LgWpsT94xKV

---
_Generated by [Claude Code](https://claude.ai/code/session_01BgrUw9GJch8LgWpsT94xKV)_