### PR TITLE
release: 0.21.0

### DIFF
--- a/.amazonq/rules/testing-and-workflow.md
+++ b/.amazonq/rules/testing-and-workflow.md
@@ -25,7 +25,14 @@
   `Home Keeper can now…`, `A user can now…`, `The panel now…` or `Give a task…` is
   narrating — cut it back to the noun and let the second sentence say what a user
   notices. `summarize()` in `ci/release-issues.py` quotes only the bold lead into the
-  issue reporter's comment, so it has to stand alone as a headline.
+  issue reporter's comment, so it has to stand alone as a headline. Write the lead as a
+  heading and drop the articles and prepositions: `**Seasonal tasks.**`, not `**Seasons
+  on a task.**`. ("Do not omit articles" governs sentences; a lead is a heading.)
+- **The bullet says what a user gets, not how the feature works.** A headline plus at
+  most 2 short sentences of what a user notices. Do not narrate the mechanism — which
+  buttons the feature hides, what it rewrites internally, which surfaces it touches,
+  which fields it added. That is `README.md` material. When trimming a big feature
+  loses something real, split it into 2 bullets rather than growing 1.
 - **Credit an outside contributor in the bullet for their change.** End the bullet
   with `(Thanks @user!)`, after `(Fixes #N)` if the bullet has one. The credit does
   not count against the three-sentence budget. An outside contributor is anyone

--- a/.amazonq/rules/testing-and-workflow.md
+++ b/.amazonq/rules/testing-and-workflow.md
@@ -19,6 +19,13 @@
   `docs/`, or the PR; the changelog says what changed and stops. One bullet per change,
   never a second paragraph. Three sentences is the budget for the **whole bullet**,
   counting the bold lead as the first, not three per paragraph.
+- **The bold lead is a label, not a sentence.** It names the thing that changed in a
+  short noun phrase and stops: `**Declarative companions.**`, `**Snooze and skip.**`,
+  `**Seasons on a task.**`. Aim for 2–5 words; 8 is the hard ceiling. A lead opening
+  `Home Keeper can now…`, `A user can now…`, `The panel now…` or `Give a task…` is
+  narrating — cut it back to the noun and let the second sentence say what a user
+  notices. `summarize()` in `ci/release-issues.py` quotes only the bold lead into the
+  issue reporter's comment, so it has to stand alone as a headline.
 - **Credit an outside contributor in the bullet for their change.** End the bullet
   with `(Thanks @user!)`, after `(Fixes #N)` if the bullet has one. The credit does
   not count against the three-sentence budget. An outside contributor is anyone

--- a/.amazonq/rules/writing-style.md
+++ b/.amazonq/rules/writing-style.md
@@ -156,6 +156,10 @@ can be a noun or a verb as listed, and it can appear in a heading.
 ## Special budgets that still apply
 
 - **CHANGELOG bullets** stay at 3 sentences or fewer. See `testing-and-workflow.md`.
+- **A CHANGELOG bullet's bold lead** is a label, not a sentence. Write a noun phrase
+  of 2 to 5 words. Do not write more than 8 words. Write "**Declarative
+  companions.**", not "**Home Keeper can now open a task for every entity that
+  matches a recipe.**". The sentence after the lead says what a user notices.
 - **`services.yaml` descriptions** stay at 1 or 2 sentences. The first sentence says
   what the service does. The second says a constraint, if there is one.
 - **UI labels** in `locales/en.json` and `strings.json` are 1 to 4 words. A tooltip

--- a/.amazonq/rules/writing-style.md
+++ b/.amazonq/rules/writing-style.md
@@ -160,6 +160,13 @@ can be a noun or a verb as listed, and it can appear in a heading.
   of 2 to 5 words. Do not write more than 8 words. Write "**Declarative
   companions.**", not "**Home Keeper can now open a task for every entity that
   matches a recipe.**". The sentence after the lead says what a user notices.
+- **A bold lead is a heading, so it does not take articles or prepositions.** Write
+  "**Seasonal tasks.**", not "**Seasons on a task.**". The rule "Do not omit
+  articles" applies to a sentence. It does not apply to a heading.
+- **A CHANGELOG bullet says what a user gets. It does not say how the feature
+  works.** Write the lead and 1 or 2 short sentences. Do not write which buttons the
+  feature hides, what it rewrites, or which fields it adds. Put that in `README.md`.
+  If a short bullet loses necessary information, write 2 bullets.
 - **`services.yaml` descriptions** stay at 1 or 2 sentences. The first sentence says
   what the service does. The second says a constraint, if there is one.
 - **UI labels** in `locales/en.json` and `strings.json` are 1 to 4 words. A tooltip

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,22 @@
   It also matters downstream: `summarize()` in `ci/release-issues.py` quotes **only the
   bold lead** into the comment an issue reporter gets, so the lead has to work as a
   standalone headline.
+  - **Write the lead as a heading, so drop the articles and prepositions.**
+    `**Seasonal tasks.**`, not `**Seasons on a task.**`. `**Declarative companion
+    presets.**`, not `**Presets for a declarative companion.**`. The "do not omit
+    articles" rule in `writing-style.md` governs *sentences*; a bold lead is a heading,
+    and headings are noun phrases. If a lead still has "a", "the", "of", "on", or "for"
+    in it, try again.
+- **The bullet says what a user gets, not how the feature works.** One bullet is a
+  headline plus at most 2 short sentences of what a user notices. Do not narrate the
+  mechanism: which buttons the feature hides or shows, what it rewrites internally,
+  which surfaces it touches, or which fields it added. `**Declarative companions.**
+  Define a pattern over existing entities to create tasks automatically.` is the whole
+  bullet — that the recipe's task shows Edit recipe rather than Edit and Duplicate,
+  and that Home Keeper rewrites the task on each run, are `README.md` facts. When a
+  feature is big enough that trimming it loses something real, **split it into 2
+  bullets** rather than growing one: declarative companions and their shipped presets
+  are 2 entries, not 1 entry with a clause.
 - **A stable release's `## [X.Y.Z]` notes describe what changed since the last
   _stable_ release — not since its betas.** When cutting `X.Y.Z` from an `X.Y.ZbN`
   line, write the section for someone upgrading from the previous stable version and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,16 @@
   bullet**, counting the bold lead as the first — not three per paragraph, and not three
   on top of the lead. `(Fixes #N)` must land in the bullet's **first**
   paragraph, because `ci/release-issues.py` quotes the bullet it first appears in.
+- **The bold lead is a label, not a sentence.** It names the thing that changed in a
+  short noun phrase and stops: `**Declarative companions.**`, `**Snooze and skip.**`,
+  `**Seasons on a task.**`. Aim for 2–5 words; 8 is the hard ceiling. A lead that opens
+  `Home Keeper can now…`, `A user can now…`, `The panel now…`, or `Give a task…` is
+  narrating, not labelling — cut it back to the noun and let the *second* sentence say
+  what a user notices. This is the single easiest bullet to get wrong, because a
+  narrative lead reads fine in isolation and only looks bloated next to its neighbours.
+  It also matters downstream: `summarize()` in `ci/release-issues.py` quotes **only the
+  bold lead** into the comment an issue reporter gets, so the lead has to work as a
+  standalone headline.
 - **A stable release's `## [X.Y.Z]` notes describe what changed since the last
   _stable_ release — not since its betas.** When cutting `X.Y.Z` from an `X.Y.ZbN`
   line, write the section for someone upgrading from the previous stable version and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,50 @@ All notable changes to Home Keeper are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
 
+## [0.21.0] - 2026-09-06
+
+### Added
+
+- **Declarative companions.** Define a pattern over existing entities to create tasks
+  automatically. Home Keeper previews the matches before it opens them. (Fixes #231)
+
+- **Declarative companion presets.** Home Keeper ships pre-built companions for common
+  integrations. Each preset also shows how to build one. (Fixes #230)
+
+- **Availability sensor tasks.** A sensor task can arm when its entity goes
+  unavailable or unknown.
+
+- **Snooze and skip.** Snooze and Skip sit next to Done in the panel and on the card.
+  A skip records a note and a person in the task history. (Fixes #268)
+
+- **Skip and snooze settings.** Settings can turn off either option. 3 new services
+  edit a recorded skip.
+
+- **Seasonal tasks.** A task that repeats on a clock can run only in the months you
+  select. (Fixes #242)
+
+- **Inline part editing.** Edit and add parts directly in the Parts tab. The stock
+  chip is now a stepper.
+
+### Changed
+
+- **Test button notifications.** Test now always sends a notification. It shows a due
+  task, or says "All caught up".
+
+- **Distant task notifications.** A task that is not due soon now says how far off it
+  is. The text used to read "Due soon" for every such task.
+
+- **Compact lists and task sub-tabs.** Task and appliance rows use less space. A
+  task's page splits into 3 sub-tabs.
+
+### Fixed
+
+- **Stale panel data.** The panel kept the old view after Home Keeper reloaded. It now
+  waits and reads again.
+
+- **Stock and Reorder-at focus.** Typing the first digit into an empty box rebuilt the
+  form and closed the keyboard. (Fixes #296)
+
 ## [0.21.0b6]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
 - **Declarative companions.** Define a pattern over existing entities to create tasks
   automatically. Home Keeper previews the matches before it opens them. (Fixes #231)
 
-- **Declarative companion presets.** Home Keeper ships pre-built companions for common
-  integrations. Each preset also shows how to build one. (Fixes #230)
+- **Declarative companion presets.** Home Keeper includes pre-built companions for
+  common integrations. Each preset also shows how to build one. (Fixes #230)
 
 - **Availability sensor tasks.** A sensor task can arm when its entity goes
   unavailable or unknown.

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor", "number"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.21.0b6"
+PANEL_VERSION = "0.21.0"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -21,5 +21,5 @@
   "requirements": [
     "Babel>=2.12"
   ],
-  "version": "0.21.0b6"
+  "version": "0.21.0"
 }


### PR DESCRIPTION
## What changed

Cuts stable **0.21.0** from the `0.21.0b1` … `0.21.0b6` beta line, plus the CHANGELOG style rules the drafting of it exposed.

**Release commit (`405e2e4`)**
- `CHANGELOG.md` — a `## [0.21.0] - 2026-09-06` section written for someone upgrading from **0.20.0**, not from a beta.
- `manifest.json` + `const.py` (`PANEL_VERSION`) → `0.21.0`.

Rollup decisions:

- The four `0.21.0b6` **Fixed** bullets repaired bugs in the declarative-companion and availability work that only landed in `b3`. A 0.20.0 user never saw those broken, so the corrected behaviour is folded into the feature entries rather than listed as fixes. Same treatment for `b3`'s hold fix and `b4`'s meter-skip and `origin` fixes.
- Declarative companions and their shipped presets are **2 entries**, not 1. That also moves `(Fixes #230)` onto the presets bullet, which is what that report actually asked for (a Device Pulse companion), so the release comment quotes the right line at the reporter.
- `b2`'s Test-button and notification-wording items are **Changed**, not Added — both surfaces already existed in 0.20.0.

**Docs commits (`54cff24`, `daf966e`)**

Three CHANGELOG style rules, recorded in all three places an agent reads them (`AGENTS.md`, `.amazonq/rules/testing-and-workflow.md`, `.amazonq/rules/writing-style.md`):

- The bold lead is a **label, not a sentence** — a noun phrase, 2–5 words, 8 hard ceiling. The first draft opened bullets with `**Home Keeper can now open a task for every entity that matches a recipe.**`.
- A lead is a **heading**, so it takes no articles or prepositions (`**Seasonal tasks.**`, not `**Seasons on a task.**`). The existing "Do not omit articles" rule governs sentences and was being misapplied to leads.
- A bullet says **what a user gets, not how the feature works**. Which buttons a feature hides, what it rewrites internally, which fields it added — that is README material. When trimming a big feature loses something real, split it into 2 bullets rather than growing 1.

### Issues this release ships

`ci/release-issues.py --version 0.21.0 --json` resolves **#231, #230, #268, #242, #296**, and `--missing` returns `[]` — no shipped commit references an issue the section forgot. `notify-issues` comments on each and closes it as stable.

## Checklist

- [x] Tests run locally — 1935 unit tests pass, 2 skipped (`pytest tests/unit`)
- [x] `CHANGELOG.md` updated, with `(Fixes #N)` for each issue in the bullet's first paragraph
- [x] Panel UI changed → n/a, no UI change in this PR
- [x] New user-facing UI surface → n/a, the surfaces shipped over the betas
- [x] Version bumped — `manifest.json` + `const.py` → `0.21.0` (a stable, so no `preview-release` label)

## One-way doors

**The version number `0.21.0` itself.** Publishing the tag is irreversible: HACS offers it to every user, and `notify-issues` closes #231, #230, #268, #242 and #296 with a comment naming it. The PEP 440 ordering also means no further `0.21.0bN` can ship after this — the next beta line must be `0.22.0b1`, which is the follow-up bump due on `main` right after this merges.

No service, event, storage, or attribute contract changes here; those shipped over the betas and are unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XAoBy9CfhEP9xjzirwnJaU