### PR TITLE
release: 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,52 +6,31 @@ All notable changes to Home Keeper are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
 
-## [0.22.0b5]
+## [0.22.0] - 2026-09-08
 
-### Changed
+### Added
 
+- **Task and appliance search.** The task list and the appliance list have a search
+  box. It matches the name plus other details, such as an appliance's model or the
+  companion that supplied a task. (Fixes #297)
+- **Notification icons and colors.** In *Settings → Notifications* a notification
+  can use any Material Design icon, which Android shows in the status bar. iPhone
+  shows it on the notification, over an accent color you pick. (Fixes #293)
+- **Usage intervals.** A metered task's history shows the usage between
+  completions, and a summary above the list gives the average and the range. The
+  next-due sensor reports the same figures as attributes. (Fixes #305)
+- **Appliance-first device chips.** A task's device chip opens its appliance
+  instead of the Home Assistant device page. The appliance list and an appliance's
+  own page still link straight to the device.
+- **Aligned list rows.** Task rows and appliance rows use fixed columns. A row's
+  chips and its overdue pill begin at the same place down the whole list.
 - **Profile deletion guard.** Home Keeper asks you to confirm before it deletes a
   profile. A profile that a notification uses cannot be deleted at all.
 
 ### Fixed
 
-- **Phone companion rows.** A companion row on a phone puts its buttons on a line of
-  their own. Edit and Delete no longer go past the edge of the screen.
-
-## [0.22.0b4]
-
-### Added
-
-- **Usage intervals.** A metered task's history shows the usage between completions,
-  and a summary above the list gives the average and the range. The next-due sensor
-  reports the same figures as attributes. (Fixes #305)
-
-## [0.22.0b3]
-
-### Added
-
-- **Give a notification its own icon and color.** In *Settings → Notifications* a
-  notification can use any Material Design icon, which Android shows in the status bar.
-  iPhone shows it on the notification, over an accent color you pick. (Fixes #293)
-
-## [0.22.0b2]
-
-### Added
-
-- **The task list and the appliance list now have a search box.** It matches the name
-  plus other details, such as the model of an appliance or the companion that supplied
-  a task. Home Keeper does not store the text, so every panel load starts with the
-  whole list. (Fixes #297)
-
-## [0.22.0b1]
-
-### Changed
-
-- **Appliance-first device chips.** A task's device chip opens its appliance instead
-  of the Home Assistant device page. The appliance list and an appliance's own page
-  still link straight to the device.
-- **Aligned list rows.** Task rows and appliance rows now use fixed columns. A row's
-  chips and its overdue pill begin at the same place down the whole list.
+- **Phone companion rows.** A companion row on a phone puts its buttons on a line
+  of their own. Edit and Delete no longer go past the edge of the screen.
 
 ## [0.21.0] - 2026-09-06
 

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor", "number"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.22.0b5"
+PANEL_VERSION = "0.22.0"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -21,5 +21,5 @@
   "requirements": [
     "Babel>=2.12"
   ],
-  "version": "0.22.0b5"
+  "version": "0.22.0"
 }


### PR DESCRIPTION
Fixes #

## What changed

Cuts the stable `0.22.0` release, rolling up the `0.22.0b1`–`0.22.0b5` betas:

- `custom_components/home_keeper/manifest.json` — `version` bumped `0.22.0b5` → `0.22.0`
- `custom_components/home_keeper/const.py` — `PANEL_VERSION` bumped to match
- `CHANGELOG.md` — the 5 beta sections collapsed into one `## [0.22.0] - 2026-09-08`
  section, written for someone upgrading from `0.21.0` (the previous stable), with
  everything introduced since then under `### Added` and the phone-companion-row fix
  under `### Fixed`. Drafted by a Sonnet subagent per house style, then reviewed by me.

On merge, `release.yml` tags `v0.22.0`, builds `home_keeper.zip`, and publishes the
GitHub release. Its `notify-issues` job will close #297, #293, and #305 (the issues
this stable release ships fixes for) and quote their changelog bullets.

No code changes — version/changelog only, so no screenshots, no walkthrough update,
and no beta bump apply here.

## Checklist

- [x] Tests run locally — no code changed, nothing to run
- [x] `CHANGELOG.md` updated — stable section rolled up from the betas, with
      `(Fixes #N)` preserved for #297, #293, #305
- [ ] Panel UI changed → N/A, no UI change
- [ ] New user-facing UI surface → N/A
- [ ] New user-facing feature → N/A (this bumps *to* stable, not to a new beta)

## One-way doors

None — this PR only bumps version strings and rewrites changelog prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmpBB9xHZFHQvw8yqraGXd

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmpBB9xHZFHQvw8yqraGXd)_