### PR TITLE
release: 0.23.0, and link the docs from every feature bullet

### DIFF
--- a/.amazonq/rules/testing-and-workflow.md
+++ b/.amazonq/rules/testing-and-workflow.md
@@ -42,9 +42,11 @@
   user-guide page is `.../docs/guide/<slug>`, where the slug is the section's
   `USER_SECTIONS` entry in `website/scripts/doc-map.mjs`; a deeper anchor adds the
   heading slug. `### Fixed` and `### Changed` bullets may link the same way and do not
-  have to. A link to a page the release itself adds is a 404 until the release
-  publishes, which is correct: `docs-deploy.yml` deploys on stable release
-  publication, so page and link go live together.
+  have to. A link to a page the release itself adds resolves only when a **stable**
+  ships — `deploy-docs` in `release.yml` is gated on `prerelease == 'false'`, so a beta
+  never republishes the site and the bullet's link 404s for beta testers until then.
+  Write it in the feature PR regardless; that is the cost of pinning the site to the
+  latest stable. Nothing validates these URLs, so check the shape against a live page.
 - **Credit an outside contributor in the bullet for their change.** End the bullet
   with `(Thanks @user!)`, after `(Fixes #N)` if the bullet has one. The credit does
   not count against the three-sentence budget. An outside contributor is anyone

--- a/.amazonq/rules/testing-and-workflow.md
+++ b/.amazonq/rules/testing-and-workflow.md
@@ -33,6 +33,18 @@
   buttons the feature hides, what it rewrites internally, which surfaces it touches,
   which fields it added. That is `README.md` material. When trimming a big feature
   loses something real, split it into 2 bullets rather than growing 1.
+- **A feature bullet's bold lead links its documentation.** Every `### Added` bullet
+  writes the lead as a Markdown link to the page documenting the feature, e.g.
+  `**[Import and export](https://prestomation.github.io/ha-home-keeper/docs/guide/import-export).**`.
+  It costs nothing against the three-sentence budget, and `summarize()` quotes the
+  lead into the issue reporter's comment, so the reporter gets the docs link too. Use
+  the absolute site URL — the bullet is read on GitHub and in a release body. A
+  user-guide page is `.../docs/guide/<slug>`, where the slug is the section's
+  `USER_SECTIONS` entry in `website/scripts/doc-map.mjs`; a deeper anchor adds the
+  heading slug. `### Fixed` and `### Changed` bullets may link the same way and do not
+  have to. A link to a page the release itself adds is a 404 until the release
+  publishes, which is correct: `docs-deploy.yml` deploys on stable release
+  publication, so page and link go live together.
 - **Credit an outside contributor in the bullet for their change.** End the bullet
   with `(Thanks @user!)`, after `(Fixes #N)` if the bullet has one. The credit does
   not count against the three-sentence budget. An outside contributor is anyone

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,10 +80,16 @@
   — and a deeper anchor is that page plus the heading slug. Link the nearest page that
   says what the feature does, not the repository README and not a `docs/*_PLAN.md`.
   A `### Fixed` or `### Changed` bullet may link the same way when a page covers it,
-  and does not have to. **A link to a page that a release adds is a 404 until that
-  release publishes**, which is correct: `docs-deploy.yml` deploys the site on stable
-  release publication, so the page and the link go live together. Check the shape of
-  an existing URL rather than the new one.
+  and does not have to. **A link to a page the release itself adds resolves only when a
+  _stable_ ships**, because `deploy-docs` in `release.yml` is gated on
+  `prerelease == 'false'` and a beta never republishes the site. Write the link in the
+  feature PR anyway, since that is when the author knows which page documents the
+  feature and the stable cut rolls the bullet up unchanged — but the bullet ships first
+  in a `## [X.Y.ZbN]` section whose link 404s for beta testers until the stable
+  publishes. That is the cost of pinning the site to the latest stable, not an
+  oversight. Prefer an existing page when one already covers the feature, and check the
+  shape of a URL that is already live, because nothing validates these links and a typo
+  404s forever.
 - **Credit an outside contributor in the bullet for their change.** End the bullet
   with `(Thanks @user!)`, after `(Fixes #N)` if the bullet has one. The credit does
   not count against the three-sentence budget. An outside contributor is anyone

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,22 @@
   because `(#N)` is also the squash-merge PR number and the two can't be told apart.
   The job posts a CI warning naming any issue a shipped commit referenced that the
   section forgot.
+- **A feature bullet's bold lead links its documentation.** Every `### Added` bullet
+  writes the lead as a Markdown link to the page that documents the feature, e.g.
+  `**[Import and export](https://prestomation.github.io/ha-home-keeper/docs/guide/import-export).**`.
+  A link costs nothing against the three-sentence budget, and `summarize()` in
+  `ci/release-issues.py` quotes the bold lead into the issue reporter's comment, so
+  the reporter gets a working link to the docs as well. Use the absolute site URL,
+  because the bullet is read on GitHub and in a release body, never only in the
+  repository. A user-guide page is `https://prestomation.github.io/ha-home-keeper/docs/guide/<slug>`
+  — the slug is the section's `USER_SECTIONS` entry in `website/scripts/doc-map.mjs`
+  — and a deeper anchor is that page plus the heading slug. Link the nearest page that
+  says what the feature does, not the repository README and not a `docs/*_PLAN.md`.
+  A `### Fixed` or `### Changed` bullet may link the same way when a page covers it,
+  and does not have to. **A link to a page that a release adds is a 404 until that
+  release publishes**, which is correct: `docs-deploy.yml` deploys the site on stable
+  release publication, so the page and the link go live together. Check the shape of
+  an existing URL rather than the new one.
 - **Credit an outside contributor in the bullet for their change.** End the bullet
   with `(Thanks @user!)`, after `(Fixes #N)` if the bullet has one. The credit does
   not count against the three-sentence budget. An outside contributor is anyone

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ All notable changes to Home Keeper are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
 
+## [0.23.0] - 2026-09-11
+
+### Added
+
+- **[Import and export](https://prestomation.github.io/ha-home-keeper/docs/guide/import-export).**
+  Settings has a new *Import and export* card that saves every task and appliance to
+  one YAML file, and reads one back. Move to a new Home Assistant, or bring years of
+  history in from another system. (Fixes #308)
+- **[Published document schema](https://prestomation.github.io/ha-home-keeper/docs/guide/import-export#the-file).**
+  The import and export format has a JSON Schema on the documentation site. Every
+  export names it, so an editor checks the file and completes the field names as you
+  write.
+- **[External IDs](https://prestomation.github.io/ha-home-keeper/docs/guide/import-export#how-a-record-finds-its-match).**
+  Give a task or an appliance an `external_id` of your choice. An import matches on
+  it, so running a migration script twice updates your records instead of copying
+  them.
+
+### Fixed
+
+- **Notification triggers.** A notification now states which tasks its profile
+  selects. The 2 automatic switches are grouped as Triggers, which set the moment a
+  notification is sent rather than its contents. (Fixes #313)
+- **Fully managed tasks.** A task whose companion sets every field no longer shows
+  Edit. The page names the companion instead.
+
 ## [0.23.0b2]
 
 ### Fixed

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -53,16 +53,25 @@ documents the feature:
   budget.
 - **Use the absolute site URL.** The bullet is read on GitHub and in the release body,
   not only in the repository, so a relative path does not resolve.
-- **Finding the URL.** A User Guide page is
+- **Finding a User Guide URL.** The page is
   `https://prestomation.github.io/ha-home-keeper/docs/guide/<slug>`, where `<slug>` is
   the README section's `USER_SECTIONS` entry in `website/scripts/doc-map.mjs`. A
-  deeper anchor is that page plus the heading slug. A Developer Guide page is
-  `https://prestomation.github.io/ha-home-keeper/developer/<name>`, from `DOC_ROUTES`
-  in the same file.
-- **A new page 404s until the release ships, and that is correct.**
-  `docs-deploy.yml` publishes the site when a stable GitHub Release is published, so
-  the page and the bullet that links it go live in the same step. Check the shape of
-  the URL against a page that already exists rather than the new one.
+  deeper anchor is that page plus the heading slug.
+- **Finding a Developer Guide URL.** The route is that file's `DOC_ROUTES` value in
+  `website/scripts/doc-map.mjs` (`docs/INTEGRATING.md` → `/developer/integrating`),
+  appended to `https://prestomation.github.io/ha-home-keeper`. The generated API
+  reference is `GENERATED_DEV_PAGES` instead, which carries its `route` directly.
+- **A link to a page the release itself adds resolves only when a _stable_ ships.**
+  `deploy-docs` in `release.yml` is gated on `prerelease == 'false'`, so a beta never
+  republishes the site. Write the link in the feature PR anyway — that is the moment
+  the author knows which page documents the feature, and the stable cut then rolls the
+  bullet up unchanged — but know what it costs: the bullet ships in a `## [X.Y.ZbN]`
+  section whose link 404s for every beta tester until the stable publishes. That is the
+  price of pinning the site to the latest stable so nobody reads docs for an unreleased
+  feature, and it is a deliberate trade, not an oversight. Prefer an existing page when
+  one already covers the feature.
+- **Nothing validates these URLs.** A typo 404s forever, and no gate catches it. Check
+  the shape against a page that is already live before you commit the bullet.
 - `### Fixed` and `### Changed` bullets may link the same way when a page covers the
   change. They do not have to.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -36,6 +36,36 @@ the GitHub release automatically. No manual `git tag` step.
 3. **HACS picks it up** via `hacs.json` (`zip_release: true`, `filename:
    home_keeper.zip`).
 
+### Link the docs from every feature bullet
+
+An `### Added` bullet writes its bold lead as a Markdown link to the page that
+documents the feature:
+
+```markdown
+- **[Import and export](https://prestomation.github.io/ha-home-keeper/docs/guide/import-export).**
+  Settings has a new *Import and export* card that saves every task and appliance to
+  one YAML file, and reads one back.
+```
+
+- **Why the lead.** `summarize()` in `ci/release-issues.py` quotes only the bold lead
+  into the comment the issue reporter gets, so a linked lead carries the docs link
+  into that comment too. A link also costs nothing against the three-sentence bullet
+  budget.
+- **Use the absolute site URL.** The bullet is read on GitHub and in the release body,
+  not only in the repository, so a relative path does not resolve.
+- **Finding the URL.** A User Guide page is
+  `https://prestomation.github.io/ha-home-keeper/docs/guide/<slug>`, where `<slug>` is
+  the README section's `USER_SECTIONS` entry in `website/scripts/doc-map.mjs`. A
+  deeper anchor is that page plus the heading slug. A Developer Guide page is
+  `https://prestomation.github.io/ha-home-keeper/developer/<name>`, from `DOC_ROUTES`
+  in the same file.
+- **A new page 404s until the release ships, and that is correct.**
+  `docs-deploy.yml` publishes the site when a stable GitHub Release is published, so
+  the page and the bullet that links it go live in the same step. Check the shape of
+  the URL against a page that already exists rather than the new one.
+- `### Fixed` and `### Changed` bullets may link the same way when a page covers the
+  change. They do not have to.
+
 ## Issue notifications
 
 An issue closes when its fix **ships**, not when its PR merges. A merged PR is not in

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor", "number"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.23.0b2"
+PANEL_VERSION = "0.23.0"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -21,5 +21,5 @@
   "requirements": [
     "Babel>=2.12"
   ],
-  "version": "0.23.0b2"
+  "version": "0.23.0"
 }


### PR DESCRIPTION
## What changed

Cuts the stable **0.23.0** from the `0.23.0b2` line, and adds the release rule that
every feature bullet links its documentation.

**The release.** `manifest.json` and `const.py` (`PANEL_VERSION`) go to `0.23.0`, with
a matching `## [0.23.0] - 2026-09-11` section. The section is written for someone
upgrading from **0.22.0**, so the import/export work the two betas introduced is
`### Added` rather than beta-to-beta framing. Both issues that a commit since `v0.22.0`
referenced carry a `(Fixes #N)`, so `notify-issues` comments on each and closes it:
**#308** (import and export) and **#313** (notification triggers). The other three
commits in the range — #315, #316, #328 — are developer-only and correctly get no
bullet.

**The new rule.** An `### Added` bullet writes its bold lead as a Markdown link to the
page that documents the feature:

```markdown
- **[Import and export](https://prestomation.github.io/ha-home-keeper/docs/guide/import-export).**
  Settings has a new *Import and export* card that saves every task and appliance to
  one YAML file, and reads one back.
```

The lead is the right place for it. `summarize()` in `ci/release-issues.py` quotes
**only** the bold lead into the comment the issue reporter gets, so a linked lead
carries the docs link into that comment as well, and a link costs nothing against the
three-sentence bullet budget. The rule is recorded in `RELEASE.md` (the long form, with
how to derive a URL from `website/scripts/doc-map.mjs`), `AGENTS.md`, and
`.amazonq/rules/testing-and-workflow.md`.

`### Fixed` and `### Changed` bullets may link the same way and do not have to; the two
fixes in this release stay plain, because one is covered by a developer page and the
other by a page that did not change.

**The three new links return 404 until this release publishes, and that is correct.**
`docs-deploy.yml` deploys the site when a stable GitHub Release is published, so the
`import-export` guide page and the bullets that link it go live in the same step. The
URL shape is verified against pages that exist today (`/docs/guide/notifications` and
`/docs/guide/settings` both return 200).

## One-way doors

None. No service input, event payload, storage shape, or entity attribute changes. The
changelog link convention is prose, reversible at any time.

## Verification

- `python ci/release-issues.py --version 0.23.0 --json` resolves exactly `#308` and
  `#313`, and `--notes` renders the section intact. The `#308` summary comes back as
  the linked lead, so the issue comment will carry a working docs link.
- `python ci/check-changelog-release-gap.py` passes (the version is bumped).
- `pytest tests/unit` — 2260 passed, 1 skipped, 1 xfailed.
- `npx vitest run tests/frontend/doc-anchors.test.js tests/frontend/changed-pages.test.js`
  — 29 passed.
- `vale CHANGELOG.md` — no hits on any added line. The remaining hits are the
  pre-existing backlog below line 400, which the diff-scoped CI job does not read.

## Checklist

- [x] Tests run locally (`pytest tests/unit -v`)
- [x] `CHANGELOG.md` updated — `(Fixes #308)` and `(Fixes #313)` both present
- [ ] Panel UI changed → n/a, no panel source is touched
- [ ] New user-facing UI surface → n/a, no new surface
- [ ] New user-facing feature → n/a, this is the stable cut of features already in
      beta, so no `preview-release` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JTTLgTDntPbszPCcPBDRH2

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTTLgTDntPbszPCcPBDRH2)_