### PR TITLE
ci: one typing requirements file, so the nightly mypy lane cannot drift

### DIFF
--- a/.amazonq/rules/testing-and-workflow.md
+++ b/.amazonq/rules/testing-and-workflow.md
@@ -167,6 +167,14 @@
   running fails instead. The gate runs the generator as a *subprocess*, because
   `tests/conftest.py` installs stub parent packages so the pure core loads without Home
   Assistant and promises nothing imports the real package in-process.
+- **A check no pull request runs needs its inputs shared with one that does.**
+  `ha-beta.yml` is a nightly and gates nothing, so its mypy lane first runs on `main`,
+  after the merge. Its dependency list was a second copy of `lint.yml`'s, and #309
+  added `types-PyYAML` to the copy a PR executes. The nightly went red for
+  `Library stubs not installed for "yaml"` and filed #320 against a Home Assistant
+  that was fine. Both lanes and `ci/setup-ci-deps.sh` now install from
+  `requirements-typing.txt`, which is the only place a mypy dependency is named. Name
+  a new stub package there.
 - **A missing test dependency fails the run; it never skips it quietly.** Every
   package `requirements-test.txt` names is imported plainly — `import hypothesis`,
   `import yaml` — so a missing one raises at collection and the run goes red.

--- a/.github/workflows/ha-beta.yml
+++ b/.github/workflows/ha-beta.yml
@@ -176,7 +176,7 @@ jobs:
       # The cheapest early warning there is: upstream deprecations and signature
       # changes surface as type errors well before they surface as broken behaviour.
       - name: Install pre-release Home Assistant
-        run: pip install --pre mypy homeassistant Babel
+        run: pip install --pre -r requirements-typing.txt
 
       # Not `continue-on-error`: for *this* job the version under test is the whole
       # point, so a stale resolve is a real failure rather than a lost diagnostic.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,12 +31,11 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.14"
-      # Install Home Assistant so its own types resolve — strict typing against the
-      # real HA API is the Platinum quality-scale gate (quality_scale.yaml). Also
-      # install the integration's own runtime requirements (manifest.json) so their
-      # imports resolve too.
+      # requirements-typing.txt is the one list of what a mypy lane installs, and
+      # says why each entry is there. The nightly lane in ha-beta.yml reads the same
+      # file, because a list copied into a workflow no PR runs drifts unnoticed.
       - name: Install mypy + Home Assistant + integration requirements
-        run: pip install mypy homeassistant Babel types-PyYAML
+        run: pip install -r requirements-typing.txt
       - name: Report and verify the Home Assistant version being checked
         run: python ci/check-ha-version.py
       - name: Mypy (strict typing)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -648,9 +648,15 @@ the Home Assistant unit lane then test an older API than CI does.
   (`manifest.json` `quality_scale`; per-rule ledger in
   `custom_components/home_keeper/quality_scale.yaml`). `lint.yml` runs `mypy` against
   the integration with Home Assistant installed — keep it error-free, and run it
-  locally (`pip install mypy homeassistant && mypy custom_components/home_keeper`)
+  locally (`pip install -r requirements-typing.txt && mypy custom_components/home_keeper`)
   before pushing. User-facing exceptions must be localized (translation keys under
   `strings.json` → `exceptions`); see `.amazonq/rules/`.
+- **`requirements-typing.txt` is the only place a mypy dependency is named.**
+  `lint.yml`, `ha-beta.yml` and `ci/setup-ci-deps.sh` all install from it. A new
+  third-party import needs its stub package added there, or mypy fails with
+  `Library stubs not installed`. Adding it to one workflow is what broke the nightly
+  in #320: `ha-beta.yml` runs on a schedule, so no PR executes its mypy lane, and a
+  list that drifts there stays green through review and goes red on `main`.
 
 ## CI
 
@@ -666,7 +672,9 @@ the Home Assistant unit lane then test an older API than CI does.
 - `e2e.yml` — Docker + Playwright; uploads the Playwright report on failure.
 - `ha-beta.yml` — **nightly early warning**, gates nothing. Runs integration, e2e and
   the upgrade suite against `HA_TAG=beta`, plus mypy against a pre-release HA, and
-  files/updates a single `ha-beta-regression` issue on failure.
+  files/updates a single `ha-beta-regression` issue on failure. **No PR runs it**, so
+  every input it needs comes from a file a PR lane reads too — see
+  `requirements-typing.txt` above.
 - `pytest_coverage.yml` + `post_coverage_to_pr.yml` — coverage comment on PRs.
 - `release.yml` — PR-merge-driven release (see RELEASE.md). Its `notify-issues` job
   tells every issue the version fixes which release carries the fix, and closes them

--- a/ci/setup-ci-deps.sh
+++ b/ci/setup-ci-deps.sh
@@ -139,6 +139,9 @@ if [ "$SKIP_PYTHON" = 1 ]; then log "SKIP    the Python packages (SKIP_PYTHON=1)
 VENV_PY=""
 vpyhas() { [ -x "$VENV/bin/python" ] && "$VENV/bin/python" -c "import $1" >/dev/null 2>&1; }
 vhas()   { [ -x "$VENV/bin/$1" ]; }
+# A stub package has no importable module of its own, so ask the metadata instead.
+vdisthas() { [ -x "$VENV/bin/python" ] && "$VENV/bin/python" -c \
+  "import importlib.metadata as m; m.version('$1')" >/dev/null 2>&1; }
 vpip() {
   if have uv; then
     uv pip install --quiet --python "$VENV/bin/python" "$@"
@@ -204,21 +207,22 @@ else
 fi
 
 if [ -x "$VENV/bin/python" ]; then
-  # lint.yml: ruff check, ruff format --check, then mypy with Home Assistant.
-  for tool in ruff mypy; do
-    if [ "$FORCE" = 0 ] && vhas "$tool"; then skip "$tool"; else
-      log "Installing $tool..."
-      vpip "$tool" && ok "$tool" || fail "$tool"
-    fi
-  done
+  # lint.yml: ruff check, then ruff format --check.
+  if [ "$FORCE" = 0 ] && vhas ruff; then skip "ruff"; else
+    log "Installing ruff..."
+    vpip ruff && ok "ruff" || fail "ruff"
+  fi
 
-  # mypy in lint.yml types against Home Assistant itself. The fixtures package
-  # above normally brings it, so this only fills a gap.
-  if [ "$FORCE" = 0 ] && vpyhas homeassistant; then
-    skip "homeassistant"
+  # lint.yml: mypy with Home Assistant. Both mypy lanes read requirements-typing.txt,
+  # so the local run checks what CI checks -- stub packages included. Installing a
+  # bare mypy here left `mypy custom_components/home_keeper` reporting the missing
+  # yaml stubs, which reads as a broken machine rather than a real error.
+  if [ "$FORCE" = 0 ] && vhas mypy && vpyhas homeassistant && vdisthas types-PyYAML; then
+    skip "requirements-typing.txt"
   else
-    log "Installing homeassistant..."
-    vpip homeassistant && ok "homeassistant" || fail "homeassistant"
+    log "Installing requirements-typing.txt..."
+    vpip -r requirements-typing.txt && ok "requirements-typing.txt" \
+      || fail "requirements-typing.txt"
   fi
 
   # mutation.yml pins this version of mutmut. Keep the pin.

--- a/requirements-typing.txt
+++ b/requirements-typing.txt
@@ -1,0 +1,15 @@
+# What every mypy lane installs. lint.yml (the gate on each PR), ha-beta.yml (the
+# nightly against a pre-release Home Assistant) and ci/setup-ci-deps.sh (the local
+# .venv) all read this file. Name a new dependency here, never in one workflow: the
+# nightly lane runs on a schedule, so a list that drifts there stays green through
+# every PR and goes red on main. That is how #320 shipped.
+#
+# A third-party import that ships no types needs its stub package in this file.
+mypy
+# Home Assistant itself, so its own types resolve. Strict typing against the real
+# Home Assistant API is the Platinum quality-scale gate (quality_scale.yaml).
+homeassistant
+# The integration's own runtime requirements (manifest.json), so their imports resolve.
+Babel
+# transfer.py imports yaml inside _yaml_pair().
+types-PyYAML

--- a/requirements-typing.txt
+++ b/requirements-typing.txt
@@ -4,12 +4,15 @@
 # nightly lane runs on a schedule, so a list that drifts there stays green through
 # every PR and goes red on main. That is how #320 shipped.
 #
-# A third-party import that ships no types needs its stub package in this file.
+# Entries come in two kinds. A package the integration imports goes in so its own
+# types resolve, which works when the package ships them (a py.typed marker). One
+# that ships none needs its stub distribution instead, named `types-<package>`, or
+# mypy stops on `Library stubs not installed`.
 mypy
-# Home Assistant itself, so its own types resolve. Strict typing against the real
-# Home Assistant API is the Platinum quality-scale gate (quality_scale.yaml).
+# Home Assistant itself. Strict typing against the real Home Assistant API is the
+# Platinum quality-scale gate (quality_scale.yaml).
 homeassistant
-# The integration's own runtime requirements (manifest.json), so their imports resolve.
+# A runtime requirement in manifest.json. It ships its own types.
 Babel
-# transfer.py imports yaml inside _yaml_pair().
+# The stub kind: PyYAML ships none, and transfer.py imports yaml in _yaml_pair().
 types-PyYAML


### PR DESCRIPTION
Fixes #320

## What changed

The nightly `ha-beta` run has failed since 2026-09-10 on a missing stub package, not on a Home Assistant change:

```
custom_components/home_keeper/transfer.py:432: error: Library stubs not installed for "yaml"  [import-untyped]
Found 1 error in 1 file (checked 56 source files)
```

**Why no PR caught it.** #309 added `transfer.py`, which imports `yaml` inside `_yaml_pair()`, and added `types-PyYAML` to `lint.yml` — the mypy lane that gates PRs. It did not add it to the second, hand-copied list in `ha-beta.yml`. That lane runs on `schedule` + `workflow_dispatch` only and gates nothing, so **no pull request ever executes it**: the drift stayed invisible through review and went red on `main` the next morning, filing #320 against a Home Assistant that is fine. The local path gave no warning either — `ci/setup-ci-deps.sh` installed a bare `mypy`, so a local run printed the same error and read as a broken machine.

So the fix is the class, not the package:

- **New `requirements-typing.txt`** — the one list of what a mypy lane installs, with a reason beside each entry.
- **`lint.yml`** and **`ha-beta.yml`** install from it (`--pre` still applies in the nightly).
- **`ci/setup-ci-deps.sh`** installs it into `.venv`, so a local `mypy custom_components/home_keeper` checks what CI checks. The skip check gained a `vdisthas` helper, because a stub package has no importable module of its own.
- **`AGENTS.md`** and **`.amazonq/rules/testing-and-workflow.md`** record the rule: a check no pull request runs needs its inputs shared with one that does.

No `CHANGELOG.md` entry, version bump, beta cut or `preview-release` label: this is a developer-only CI change, which `AGENTS.md` exempts from all four. No UI change and no source change, so no screenshots, no walkthrough edit, and nothing for the mutation gate to score.

## One-way doors

None. CI configuration and developer documentation only — no service field, event payload, storage shape or entity attribute is touched.

## Verification

Locally, against the repo `.venv`:

```
$ .venv/bin/mypy custom_components/home_keeper/transfer.py
transfer.py:432: error: Library stubs not installed for "yaml"   # reproduced

$ .venv/bin/python -m pip install types-PyYAML
$ .venv/bin/mypy custom_components/home_keeper/transfer.py
# the yaml error is gone
```

The two errors that remain in that local run (`LOVELACE_DATA`, `transfer_runner.py:71`) come from the Home Assistant 2024.12.5 that pip resolved for this machine's interpreter — the #199 symptom `ci/check-ha-version.py` reports — not from this change. CI's lane pins Python at Home Assistant's floor.

Both workflow files parse, `bash -n ci/setup-ci-deps.sh` is clean, and the new skip check was exercised both ways (present → skip, absent → install).

Real proof is a `workflow_dispatch` run of `ha-beta.yml` from this branch, confirming `mypy against pre-release HA` passes. The scheduled nightly on `main` after merge closes the loop on #320.

## Checklist

- [x] Tests run locally — no Python or TypeScript source changed; mypy reproduced and verified as above
- [x] `CHANGELOG.md` updated — n/a, developer-only change
- [x] Panel UI changed → n/a
- [x] New user-facing UI surface → n/a
- [x] New user-facing feature → n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxPriZWcbj2s2KnsPGmcFp

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxPriZWcbj2s2KnsPGmcFp)_