### PR TITLE
Advance a fixed schedule past the occurrence it was showing, and hold its local hour

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,25 @@
 {
   "outputStyle": "Concise",
+  "permissions": {
+    "allow": [
+      "mcp__Claude_Code_Remote__archive_session",
+      "mcp__Claude_Code_Remote__create_trigger",
+      "mcp__Claude_Code_Remote__delete_trigger",
+      "mcp__Claude_Code_Remote__list_triggers",
+      "mcp__Claude_Code_Remote__send_later",
+      "mcp__Claude_Code_Remote__subscribe_pr_activity",
+      "mcp__Claude_Code_Remote__unsubscribe_pr_activity",
+      "mcp__claude-code-remote__archive_session",
+      "mcp__claude-code-remote__create_trigger",
+      "mcp__claude-code-remote__delete_trigger",
+      "mcp__claude-code-remote__list_triggers",
+      "mcp__claude-code-remote__send_later",
+      "mcp__claude-code-remote__subscribe_pr_activity",
+      "mcp__claude-code-remote__unsubscribe_pr_activity",
+      "mcp__github__subscribe_pr_activity",
+      "mcp__github__unsubscribe_pr_activity"
+    ]
+  },
   "hooks": {
     "SessionStart": [
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to Home Keeper are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
 
+## [0.24.0b1]
+
+### Fixed
+
+- **Fixed schedules.** A task on a fixed schedule now moves to its next occurrence when
+  you mark it done. A task due later in the same day used to stay due today.
+  (Fixes #331)
+- **Daylight saving time.** A fixed schedule now keeps its time of day when the clocks
+  change. A task set for 10am used to move to 9am each autumn.
+
 ## [0.23.0] - 2026-09-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -87,8 +87,10 @@ A task has a name, notes, an optional attached device, and a recurrence:
   completion. An example is a fridge filter every 1 month after the last
   completion. Each completion resets the interval. A missed task stays overdue and
   does not roll forward.
-- Fixed, shown as **Repeats on a fixed schedule** in the form, is an anchored calendar schedule
-  that is independent of completions. An example is medicine every day at 8am.
+- Fixed, shown as **Repeats on a fixed schedule** in the form, is an anchored calendar schedule.
+  An example is medicine every day at 8am. A completion moves the task to the next
+  occurrence on the schedule. The dates that follow do not move, and they keep the same
+  time of day when the clocks change.
 - One-off, shown as **Just once** in the form, runs one time. See
   [One-off tasks](#one-off-do-once-tasks) below.
 - Triggered is monitored and condition-driven, with no schedule. See below.

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor", "number"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.23.0"
+PANEL_VERSION = "0.24.0b1"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -21,5 +21,5 @@
   "requirements": [
     "Babel>=2.12"
   ],
-  "version": "0.23.0"
+  "version": "0.24.0b1"
 }

--- a/custom_components/home_keeper/recurrence.py
+++ b/custom_components/home_keeper/recurrence.py
@@ -245,6 +245,31 @@ def _fast_forward(
     return add_months(occ, jump * interval)
 
 
+def _regrid(anchor: datetime, probe: datetime) -> datetime:
+    """*anchor* re-homed into *probe*'s timezone, so stepping keeps local wall time.
+
+    A schedule promises a wall clock: "every day at 10:00" means 10:00 on the kitchen
+    clock, on both sides of a daylight-saving transition. :func:`_step` delivers that
+    — but only while the anchor carries a real zone, because ``dt + timedelta`` holds
+    the *tzinfo it is given*. A fixed UTC offset is a tzinfo too, and holding one of
+    those across a transition is what makes a 10:00 task read 09:00 every autumn.
+
+    Storage is what strips the zone. An ISO string carries an offset and not a zone
+    identity, so ``ZoneInfo("America/Los_Angeles")`` is written as ``-07:00`` and
+    reloads as ``timezone(timedelta(hours=-7))``. Every anchor therefore comes back
+    from the store offset-only, no matter how it was written — which is why writing it
+    differently cannot fix this and re-homing on the way in has to.
+
+    *probe* is the caller's clock (``after`` here, ``start`` in
+    :func:`expand_fixed_occurrences`), which in this integration is always derived
+    from ``dt_util.now()`` and so carries Home Assistant's configured zone. Re-homing
+    keeps the instant and swaps the tzinfo, so an anchor stored as ``17:00+00:00``,
+    ``10:00-07:00`` or naive-turned-``10:00-07:00`` all resolve to the same 10:00
+    local and all hold it through the transition.
+    """
+    return anchor.astimezone(probe.tzinfo)
+
+
 def next_fixed_occurrence(
     anchor: datetime,
     freq: str,
@@ -254,12 +279,13 @@ def next_fixed_occurrence(
 ) -> datetime:
     """Smallest occurrence strictly greater than *after* for a fixed schedule.
 
-    Occurrences start at *anchor* and repeat every *interval* of *freq*,
-    preserving the anchor's time-of-day. If *after* precedes the anchor, the
-    anchor itself is returned.
+    Occurrences start at *anchor* and repeat every *interval* of *freq*, preserving
+    the anchor's time-of-day **as read in *after*'s timezone** (see :func:`_regrid`).
+    If *after* precedes the anchor, the anchor itself is returned.
     """
     if interval < 1:
         raise ValueError(f"interval must be >= 1, got {interval}")
+    anchor = _regrid(anchor, after)
     if anchor > after:
         return anchor
     occ = _fast_forward(anchor, freq, interval, after)
@@ -286,10 +312,14 @@ def expand_fixed_occurrences(
 ) -> list[datetime]:
     """All fixed occurrences within the half-open range ``[start, end)``.
 
+    Occurrences read at the anchor's time-of-day in *start*'s timezone, the same rule
+    :func:`next_fixed_occurrence` follows (see :func:`_regrid`).
+
     Bounded by ``MAX_EXPAND_ITERATIONS`` to guard against runaway loops.
     """
     if start >= end:
         return []
+    anchor = _regrid(anchor, start)
     occurrences: list[datetime] = []
     # Find the first occurrence at or after *start* — fast-forward close first so a
     # far-past anchor doesn't exhaust the iteration cap before reaching the window.
@@ -376,6 +406,48 @@ def _record_entry(history: Iterable[dict], entry: dict) -> list[dict]:
     return entries
 
 
+def _advance_fixed_schedule(task: dict, *, now: datetime) -> str:
+    """The ``next_due`` a fixed task moves to once its occurrence is dealt with.
+
+    Shared by :func:`apply_completion` and :func:`skip_occurrence`, because completing
+    an occurrence and skipping it move the schedule in exactly the same way — only the
+    log each one writes is different.
+
+    The schedule advances past ``max(now, next_due)``, and both halves earn their keep:
+
+    * **Past ``next_due``**, because the occurrence the task is *showing* is the one
+      the user just dealt with. Advancing past ``now`` alone hands that occurrence
+      straight back whenever the task is completed before its time of day: a task
+      anchored at 10:00 and marked done at 09:00 stayed due at 10:00 today, so the
+      completion read as though it had done nothing (#331). An anchor late in the
+      evening was unusable that way for nearly the whole day.
+    * **Past ``now``**, because an overdue task must not crawl the grid one missed
+      occurrence per press. A daily task last due a fortnight ago lands on the next
+      occurrence after today, collapsing the fortnight into a single step.
+
+    A task with no ``next_due`` has no occurrence on the board, so *now* is the whole
+    answer. ``models.build_task`` reaches this state on purpose: a ``last_completed``
+    seed is recorded as a completion *before* the schedule is ever computed.
+
+    This is deliberately not what :func:`compute_next_due` does. That function derives
+    a due date from a task's own state with no memory of where the schedule already
+    stood, which is what makes it the right tool for *rewinding* one (see
+    :func:`remove_completion`) and the wrong tool for advancing it.
+    """
+    anchor = _parse(task["anchor"])
+    assert anchor is not None
+    current = _parse(task.get("next_due"))
+    # ``current`` comes off a stored ISO string, so it carries a bare offset; re-home
+    # it before ``max`` so the winner always hands ``next_fixed_occurrence`` a probe in
+    # Home Assistant's zone (see ``_regrid``). Comparison itself is instant-based and
+    # would be correct either way — it is the *tzinfo of the winner* that matters.
+    after = max(now, current.astimezone(now.tzinfo)) if current is not None else now
+    return _clamp_season(
+        next_fixed_occurrence(anchor, task["freq"], int(task["interval"]), after=after),
+        task,
+    ).isoformat()
+
+
 def apply_completion(
     task: dict,
     completed_at: datetime,
@@ -396,8 +468,9 @@ def apply_completion(
     Records the completion in history (capped) and recomputes ``next_due``:
 
     * floating  -> measured from ``completed_at`` (the clock resets)
-    * fixed     -> the next scheduled occurrence after ``now`` (schedule-driven;
-      completion only marks the occurrence done)
+    * fixed     -> the next scheduled occurrence after the one the task was showing
+      (schedule-driven; the completion marks that occurrence done rather than
+      restarting a clock — see :func:`_advance_fixed_schedule`)
     * triggered -> ``next_due = None`` (dormant): completing a condition-driven
       task *clears* the condition rather than rescheduling it, so it leaves every
       time surface until the owner re-arms it. History is still recorded, so the
@@ -426,14 +499,7 @@ def apply_completion(
             task,
         ).isoformat()
     elif rec_type == REC_FIXED:
-        anchor = _parse(task["anchor"])
-        assert anchor is not None
-        task["next_due"] = _clamp_season(
-            next_fixed_occurrence(
-                anchor, task["freq"], int(task["interval"]), after=now
-            ),
-            task,
-        ).isoformat()
+        task["next_due"] = _advance_fixed_schedule(task, now=now)
     elif rec_type in (REC_TRIGGERED, REC_ONE_OFF, REC_SENSOR):
         # A one-off is permanently complete; a triggered task clears its condition; a
         # sensor task's crossing has been actioned (and its meter reset by the store,
@@ -467,9 +533,10 @@ def skip_occurrence(task: dict, *, now: datetime, metadata: dict | None = None) 
 
     * floating  -> ``now + interval·unit`` (a fresh interval from now; the next
       completion still measures from *its* ``completed_at``).
-    * fixed     -> the next scheduled occurrence strictly after ``max(now, next_due)``.
-      An upcoming task advances exactly one occurrence; an overdue task jumps to the
-      next occurrence after *now*, collapsing any already-missed occurrences rather than
+    * fixed     -> the next scheduled occurrence strictly after ``max(now, next_due)``,
+      exactly as a completion advances it (:func:`_advance_fixed_schedule`). An
+      upcoming task advances exactly one occurrence; an overdue task jumps to the next
+      occurrence after *now*, collapsing any already-missed occurrences rather than
       taking one skip per missed period.
     * one-off / triggered / sensor -> dormant (``next_due = None``): there is no "next"
       occurrence to advance to, so skipping clears it from every time surface (a
@@ -487,16 +554,7 @@ def skip_occurrence(task: dict, *, now: datetime, metadata: dict | None = None) 
             add_interval(now, int(task["interval"]), task["unit"]), task
         ).isoformat()
     elif rec_type == REC_FIXED:
-        anchor = _parse(task["anchor"])
-        assert anchor is not None
-        current = _parse(task.get("next_due"))
-        after = max(now, current) if current is not None else now
-        task["next_due"] = _clamp_season(
-            next_fixed_occurrence(
-                anchor, task["freq"], int(task["interval"]), after=after
-            ),
-            task,
-        ).isoformat()
+        task["next_due"] = _advance_fixed_schedule(task, now=now)
     elif rec_type in (REC_TRIGGERED, REC_ONE_OFF, REC_SENSOR):
         task["next_due"] = None
     else:
@@ -620,6 +678,13 @@ def move_completion(task: dict, old_ts: str, new_ts: str, *, now: datetime) -> d
     replaces it (the same same-instant dedup ``apply_completion`` does); the moved
     entry's metadata wins and the entry it collided with is discarded.
 
+    Triggered/sensor tasks' ``next_due`` is left untouched, and so is a **fixed**
+    task's: its due date is schedule state that completing or skipping already moved
+    on (:func:`_advance_fixed_schedule`), not a value derived from the log, so
+    recomputing it from the anchor here would rewind the task onto an occurrence it
+    has already dealt with. Only :func:`remove_completion` rewinds, because an undo is
+    meant to.
+
     Both the removal and the re-insertion happen *before* ``last_completed``/
     ``next_due`` are re-derived — re-deriving in between (as if this were
     ``remove_completion`` followed by a separate insert) would misfire for a one-off
@@ -665,7 +730,7 @@ def move_completion(task: dict, old_ts: str, new_ts: str, *, now: datetime) -> d
         # (see above), so a one-off always stays dormant post-move — it only
         # re-arms via remove_completion, which can genuinely empty history.
         task["next_due"] = None
-    elif rec_type not in (REC_TRIGGERED, REC_SENSOR):
+    elif rec_type not in (REC_TRIGGERED, REC_SENSOR, REC_FIXED):
         task["next_due"] = compute_next_due(task, now=now).isoformat()
     return task
 

--- a/custom_components/home_keeper/transfer.py
+++ b/custom_components/home_keeper/transfer.py
@@ -44,6 +44,7 @@ from .const import (
     COMPLETION_ENTRY_FIELDS,
     MAX_IMPORT_BYTES,
     MAX_IMPORT_RECORDS,
+    REC_FIXED,
     SKIP_ENTRY_FIELDS,
     TASK_SOURCE_BUY,
     TASK_SOURCE_DECLARATIVE_COMPANION,
@@ -664,8 +665,12 @@ def apply_history(
     it was serviced seven years ago and, past 500 entries, would keep the oldest half
     of the log instead of the newest.
 
-    Completions replay through the live recurrence math, so the final one computes
-    ``next_due`` exactly as it would have. Skips are *logged* in place
+    Completions replay through the live recurrence math, so a floating task's final one
+    computes ``next_due`` exactly as it would have. A **fixed** task's schedule is
+    restated from its anchor afterwards instead: a live completion advances it past the
+    occurrence it was showing, which replayed once per entry would put an imported task
+    as many occurrences into the future as it carries history. Skips are *logged* in
+    place
     (``recurrence.record_skip``) without moving the due date: a skip from 2019 says an
     occurrence was passed over then, and running its schedule math against today's
     clock would invent a date nobody ever saw.
@@ -698,6 +703,15 @@ def apply_history(
             recurrence.apply_completion(task, when, now=now, metadata=metadata)
         else:
             recurrence.record_skip(task, when, metadata=metadata)
+    if history and task.get("recurrence_type") == REC_FIXED:
+        # A completion moves a fixed task one occurrence on — it clears the occurrence
+        # the task is showing. Right for a press today, wrong for a replay: a decade of
+        # imported history would walk the schedule a decade into the future, one step
+        # per entry. ``EXCLUDED_TASK_KEYS`` already says ``next_due`` is derived rather
+        # than carried, so restate it from the anchor once the fold is done. Guarded on
+        # *history* so an import carrying none cannot snap a stored (e.g. snoozed) due
+        # date back onto the grid.
+        task["next_due"] = recurrence.compute_next_due(task, now=now).isoformat()
     return len(history), len(skips)
 
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -14,11 +14,15 @@ an explicit `now`):
 | Type | Semantics | `next_due` after completion |
 |------|-----------|-----------------------------|
 | **floating** | measured from last completion (`interval` × days/weeks/months) | `completed_at + interval` (the clock resets) |
-| **fixed** | anchored calendar schedule (`FREQ` DAILY/WEEKLY/MONTHLY × `interval` from an `anchor` datetime) | the next scheduled occurrence after `now` (schedule-driven, not completion-driven) |
+| **fixed** | anchored calendar schedule (`FREQ` DAILY/WEEKLY/MONTHLY × `interval` from an `anchor` datetime) | the next scheduled occurrence after the one the task was showing (schedule-driven, not completion-driven) |
 | **triggered** | condition-driven rather than scheduled. An owning integration arms it (`trigger_task`, or by creating it) when a condition becomes true and clears it (`complete_task`) when it resolves. `next_due` is its state: a timestamp = armed/due-now, `None` = dormant (invisible to to-do/calendar/overdue). | `None` (dormant). Completing *clears* the condition rather than rescheduling, while still recording the completion so cadence accumulates |
 
 Month arithmetic clamps to month length (Jan 31 + 1mo → Feb 28/29). A missed
-floating task stays overdue rather than rolling forward on its own. The `triggered`
+floating task stays overdue rather than rolling forward on its own. A fixed schedule
+keeps its anchor's local time of day across a daylight-saving transition. A stored
+anchor is offset-only, because an ISO string has an offset but no zone identity. The
+engine re-homes the anchor into Home Assistant's configured zone before it steps the
+grid. The `triggered`
 type is the first-class home for condition-driven sources (Battery Notes batteries,
 leak sensors, filter pressure). See [INTEGRATING.md](INTEGRATING.md) §7 and
 [BATTERY_NOTES_PLAN.md](BATTERY_NOTES_PLAN.md).

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -536,3 +536,78 @@ def test_renaming_task_updates_device_entity_name(ha):
         )
     finally:
         call_service(ha, "home_keeper", "delete_task", {"task_id": task_id})
+
+
+def test_completing_a_fixed_task_before_its_time_of_day_moves_it_on(ha):
+    """Regression (#331): the end-to-end shape the reporter saw.
+
+    Anchored an hour ahead, so the completion lands *before* the occurrence the task
+    is showing — the window in which the due date used to come back unchanged while
+    the completion was still logged.
+    """
+    from datetime import datetime, timedelta
+
+    anchor = datetime.now().astimezone() + timedelta(hours=1)
+    name = "Test fixed completion probe"
+    call_service(
+        ha,
+        "home_keeper",
+        "add_task",
+        {
+            "name": name,
+            "recurrence_type": "fixed",
+            "interval": 1,
+            "freq": "DAILY",
+            "anchor": anchor.isoformat(),
+        },
+    )
+    task_id = next(t["id"] for t in _list_tasks(ha) if t["name"] == name)
+    try:
+        before = next(t for t in _list_tasks(ha) if t["id"] == task_id)["next_due"]
+        call_service(ha, "home_keeper", "complete_task", {"task_id": task_id})
+        after = next(t for t in _list_tasks(ha) if t["id"] == task_id)
+        assert after["next_due"] != before, "next_due did not move (#331)"
+        assert datetime.fromisoformat(after["next_due"]) == datetime.fromisoformat(
+            before
+        ) + timedelta(days=1)
+        assert len(after["completions"]) == 1
+    finally:
+        call_service(ha, "home_keeper", "delete_task", {"task_id": task_id})
+
+
+def test_a_utc_anchor_schedules_at_the_local_hour_it_names(ha):
+    """A UTC-spelled anchor — what the panel sends — must resolve to the local hour the
+    user chose, not to the UTC one.
+
+    The DST half of this is only provable against a clock the test cannot move, so the
+    travelling-across-a-transition case lives in
+    ``tests/unit/test_recurrence_fixed.py`` and property R5c. What this pins is the
+    wiring: that the value leaving the service reads at the intended wall clock once it
+    has been through storage and back.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    anchor = datetime.now().astimezone() + timedelta(hours=1)
+    name = "Test fixed utc anchor probe"
+    call_service(
+        ha,
+        "home_keeper",
+        "add_task",
+        {
+            "name": name,
+            "recurrence_type": "fixed",
+            "interval": 1,
+            "freq": "DAILY",
+            # Same instant, spelled in UTC — what the panel sends today.
+            "anchor": anchor.astimezone(UTC).isoformat(),
+        },
+    )
+    task_id = next(t["id"] for t in _list_tasks(ha) if t["name"] == name)
+    try:
+        task = next(t for t in _list_tasks(ha) if t["id"] == task_id)
+        due = datetime.fromisoformat(task["next_due"]).astimezone()
+        assert (due.hour, due.minute) == (anchor.hour, anchor.minute), (
+            f"anchored {anchor.isoformat()} but next_due reads {due.isoformat()}"
+        )
+    finally:
+        call_service(ha, "home_keeper", "delete_task", {"task_id": task_id})

--- a/tests/unit/test_calendar.py
+++ b/tests/unit/test_calendar.py
@@ -306,3 +306,25 @@ def test_the_season_search_stops_at_its_iteration_bound(monkeypatch):
     assert _entity({"t_fixed": task}).event is None
     # One call to find the first occurrence, then one per bounded step.
     assert steps == 6
+
+
+def test_collect_events_keeps_the_local_hour_across_a_dst_transition():
+    """The calendar projects the anchor grid itself, so it drifts wherever the engine
+    does. A stored anchor is offset-only (an ISO string has no zone identity), and
+    Home Assistant hands ``async_get_events`` a window already through
+    ``dt_util.as_local`` — so the window is what tells the grid which zone to hold.
+    Without that, a 09:00 task would list at 08:00 for half the year and disagree with
+    its own to-do entity.
+    """
+    from zoneinfo import ZoneInfo
+
+    zone = ZoneInfo("America/New_York")
+    stored = datetime(2026, 6, 1, 9, tzinfo=zone).isoformat()
+    entity = _entity({"t_fixed": _fixed_task(datetime.fromisoformat(stored))})
+
+    # A window on the far side of the autumn transition, in the zone HA would pass.
+    start = datetime(2026, 11, 5, 0, tzinfo=zone)
+    end = datetime(2026, 11, 7, 0, tzinfo=zone)
+    hours = {e.start.astimezone(zone).hour for e in entity._collect_events(start, end)}
+
+    assert hours == {9}, f"occurrences drifted off 09:00 local: {sorted(hours)}"

--- a/tests/unit/test_move_completion.py
+++ b/tests/unit/test_move_completion.py
@@ -240,3 +240,33 @@ def test_move_completion_one_off_with_other_completions_stays_dormant():
     )
     assert out["next_due"] is None
     assert out["last_completed"] == second.isoformat()
+
+
+def test_move_completion_fixed_keeps_an_advanced_due_date():
+    # A fixed task's next_due is schedule state that completing or skipping already
+    # moved on — not a value derived from the log. Re-timestamping an entry must not
+    # recompute it from the anchor: that rewinds the task onto the occurrence it has
+    # just dealt with and puts it back on today's list (#331).
+    now = dt(2026, 9, 8, 9)
+    anchor = dt(2026, 9, 8, 10)
+    advanced = dt(2026, 9, 9, 10)
+    logged = dt(2026, 9, 8, 9)
+    task = {
+        "recurrence_type": "fixed",
+        "interval": 1,
+        "freq": "DAILY",
+        "anchor": anchor.isoformat(),
+        "last_completed": logged.isoformat(),
+        "next_due": advanced.isoformat(),
+        "completions": [{"ts": logged.isoformat()}],
+    }
+    out = r.move_completion(
+        task, logged.isoformat(), dt(2026, 9, 8, 8).isoformat(), now=now
+    )
+    assert out["next_due"] == advanced.isoformat()
+    assert out["last_completed"] == dt(2026, 9, 8, 8).isoformat()
+    # The recomputed answer is today's occurrence — the one already completed. This is
+    # what makes the assertion above a gate rather than a coincidence, unlike
+    # ``test_move_completion_fixed_stays_schedule_driven``, whose fixture has the two
+    # agreeing.
+    assert r.compute_next_due(out, now=now).isoformat() == anchor.isoformat()

--- a/tests/unit/test_recurrence_fixed.py
+++ b/tests/unit/test_recurrence_fixed.py
@@ -176,3 +176,140 @@ def test_remove_completion_keeps_fixed_schedule():
     assert task["last_completed"] is None
     # Fixed schedule is independent of completions: next occurrence after now.
     assert task["next_due"] == datetime(2026, 6, 14, 8, tzinfo=tz).isoformat()
+
+
+def test_completing_before_the_time_of_day_moves_to_the_next_occurrence():
+    # Regression (#331): a DAILY task anchored at 10:00 and marked done at 09:00 used
+    # to stay due at 10:00 *today*. The schedule advanced past ``now``, which is still
+    # before the occurrence the task was showing, so it landed straight back on that
+    # occurrence and the completion read as though it had done nothing. An anchor late
+    # in the evening was unusable this way for nearly the whole day.
+    anchor = dt(2026, 9, 8, 10)
+    now = dt(2026, 9, 8, 9)
+    task = {
+        "recurrence_type": "fixed",
+        "interval": 1,
+        "freq": "DAILY",
+        "anchor": anchor.isoformat(),
+        "next_due": anchor.isoformat(),
+        "completions": [],
+    }
+    r.apply_completion(task, now, now=now)
+    assert task["next_due"] == dt(2026, 9, 9, 10).isoformat()
+    assert task["last_completed"] == now.isoformat()
+
+
+def test_completing_an_overdue_fixed_task_collapses_the_missed_occurrences():
+    # The other half of ``max(now, next_due)``: a long-overdue task lands on the next
+    # occurrence after *now* rather than crawling the grid one missed occurrence per
+    # completion. The completion twin of
+    # ``test_skip_fixed_overdue_advances_to_next_future_occurrence``.
+    task = {
+        "recurrence_type": "fixed",
+        "interval": 1,
+        "freq": "DAILY",
+        "anchor": dt(2026, 1, 1, 8).isoformat(),
+        "next_due": dt(2026, 6, 10, 8).isoformat(),  # several days overdue
+        "completions": [],
+    }
+    now = dt(2026, 6, 13, 9)
+    r.apply_completion(task, now, now=now)
+    assert task["next_due"] == dt(2026, 6, 14, 8).isoformat()
+
+
+def test_completing_an_upcoming_fixed_task_advances_exactly_one_occurrence():
+    # An occurrence still ahead of ``now`` advances by exactly one step, never more.
+    # This is what pins ``max`` rather than ``min``: taking the smaller operand here
+    # would hand back the occurrence the task is already showing.
+    anchor = dt(2026, 6, 18, 8)
+    task = {
+        "recurrence_type": "fixed",
+        "interval": 1,
+        "freq": "WEEKLY",
+        "anchor": anchor.isoformat(),
+        "next_due": anchor.isoformat(),
+        "completions": [],
+    }
+    now = dt(2026, 6, 13, 9)
+    r.apply_completion(task, now, now=now)
+    assert task["next_due"] == dt(2026, 6, 25, 8).isoformat()
+
+
+def test_completing_a_fixed_task_with_no_due_date_advances_from_now():
+    # ``models.build_task`` records a ``last_completed`` seed *before* it computes the
+    # schedule, so the task reaching ``apply_completion`` carries no ``next_due`` at
+    # all. There is no occurrence on the board to clear, so *now* is the whole answer.
+    task = {
+        "recurrence_type": "fixed",
+        "interval": 1,
+        "freq": "DAILY",
+        "anchor": dt(2026, 1, 1, 8).isoformat(),
+        "completions": [],
+    }
+    now = dt(2026, 6, 13, 9)
+    r.apply_completion(task, now, now=now)
+    assert task["next_due"] == dt(2026, 6, 14, 8).isoformat()
+
+
+def test_undoing_a_completion_puts_the_cleared_occurrence_back():
+    # The asymmetry with ``move_completion``: an undo is *meant* to rewind, so
+    # ``remove_completion`` recomputes from the anchor and today's occurrence returns
+    # to every time surface.
+    anchor = dt(2026, 9, 8, 10)
+    now = dt(2026, 9, 8, 9)
+    task = {
+        "recurrence_type": "fixed",
+        "interval": 1,
+        "freq": "DAILY",
+        "anchor": anchor.isoformat(),
+        "next_due": anchor.isoformat(),
+        "completions": [],
+    }
+    r.apply_completion(task, now, now=now)
+    assert task["next_due"] == dt(2026, 9, 9, 10).isoformat()
+    r.remove_completion(task, now.isoformat(), now=now)
+    assert task["next_due"] == anchor.isoformat()
+    assert task["last_completed"] is None
+
+
+def test_a_schedule_keeps_its_local_hour_across_dst_after_a_storage_round_trip():
+    # Regression: an ISO string carries an *offset*, not a zone identity, so whatever
+    # tzinfo the anchor had when it was written, it reloads as a fixed offset —
+    # ``fromisoformat("...-07:00").tzinfo`` is ``timezone(timedelta(hours=-7))``, not
+    # ``ZoneInfo``. ``_step`` then holds that offset's wall clock, and a 10:00 task
+    # reads 09:00 once the zone leaves DST.
+    #
+    # ``test_r5a`` proves ``_step`` keeps local wall time, but only for a live
+    # ``ZoneInfo`` anchor — the shape storage can never hand back. This pins the shape
+    # production actually produces.
+    from zoneinfo import ZoneInfo
+
+    zone = ZoneInfo("America/Los_Angeles")
+    stored = datetime(2026, 9, 8, 10, tzinfo=zone).isoformat()
+    anchor = datetime.fromisoformat(stored)  # the reload, offset-only
+
+    after_dst_ends = datetime(2026, 11, 5, 9, tzinfo=zone)
+    nxt = r.next_fixed_occurrence(anchor, "DAILY", 1, after=after_dst_ends)
+
+    local = nxt.astimezone(zone)
+    assert (local.hour, local.minute) == (10, 0), (
+        f"stored {stored} reloaded as {anchor.tzinfo!r} and drifted to "
+        f"{local.isoformat()}"
+    )
+
+
+def test_a_utc_anchor_still_schedules_at_the_hour_the_user_chose():
+    # The shape every panel-created task already carries: the browser converted the
+    # user's 10:00 to UTC before sending it. Read back in the user's zone it is still
+    # their 10:00, and it has to stay their 10:00 after the clock changes.
+    from zoneinfo import ZoneInfo
+
+    zone = ZoneInfo("America/Los_Angeles")
+    anchor = datetime.fromisoformat("2026-09-08T17:00:00+00:00")  # 10:00 PDT
+
+    for probe, label in (
+        (datetime(2026, 9, 8, 9, tzinfo=zone), "same day, before the occurrence"),
+        (datetime(2026, 11, 5, 9, tzinfo=zone), "after DST ends"),
+    ):
+        nxt = r.next_fixed_occurrence(anchor, "DAILY", 1, after=probe).astimezone(zone)
+        assert (nxt.hour, nxt.minute) == (10, 0), f"{label}: got {nxt.isoformat()}"

--- a/tests/unit/test_recurrence_properties.py
+++ b/tests/unit/test_recurrence_properties.py
@@ -22,6 +22,7 @@ import itertools
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
+import hk_models as models
 import hk_recurrence as r
 import property_strategies as ps
 import pytest
@@ -315,3 +316,73 @@ def test_r7_a_floating_schedule_always_moves_forward(
     """
     due = r.compute_floating_next_due(last_completed, interval, unit, now=now)
     assert due > last_completed
+
+
+@given(
+    anchor=ps.zoned_datetimes(),
+    freq=st.sampled_from(["DAILY", "WEEKLY", "MONTHLY"]),
+    interval=st.integers(1, 12),
+)
+def test_r5c_a_schedule_survives_the_round_trip_through_storage(anchor, freq, interval):
+    """R5c. R5a still holds once the anchor has been through the store.
+
+    R5a proves `_step` keeps local wall time — for a live `ZoneInfo` anchor. Nothing
+    in the store is one. An ISO string carries an *offset* and not a zone identity, so
+    a `ZoneInfo("America/Los_Angeles")` anchor is written `-07:00` and reloads as
+    `timezone(timedelta(hours=-7))`, and holding *that* across a transition is what
+    made a 10:00 task read 09:00 every autumn.
+
+    So this is R5a over the shape production actually produces: serialize, reload,
+    and only then expand. It is the property the original pair missed by testing the
+    engine with an input the engine never receives.
+
+    Kills the `_regrid` call in `expand_fixed_occurrences` and, through the shared
+    helper, in `next_fixed_occurrence`.
+    """
+    reloaded = datetime.fromisoformat(anchor.isoformat())
+    end = anchor + timedelta(days=400)
+    for occurrence in r.expand_fixed_occurrences(reloaded, freq, interval, anchor, end):
+        local = occurrence.astimezone(anchor.tzinfo)
+        assert (local.hour, local.minute) == (anchor.hour, anchor.minute), (
+            f"anchor={anchor.isoformat()} freq={freq} interval={interval}: "
+            f"{occurrence.isoformat()} reads at a different clock time"
+        )
+
+
+@given(
+    anchor=ps.aware_datetimes(min_year=2020, max_year=2030),
+    freq=st.sampled_from(["DAILY", "WEEKLY", "MONTHLY"]),
+    interval=st.integers(1, 12),
+    now=ps.aware_datetimes(min_year=2024, max_year=2030),
+    logged_seconds_ago=st.integers(0, 3 * 86_400),
+)
+def test_r7_completing_a_fixed_task_always_clears_the_occurrence_it_showed(
+    anchor, freq, interval, now, logged_seconds_ago
+):
+    """R7. A completed fixed task never keeps the due date it was showing.
+
+    What #331 reported is exactly "next_due came back unchanged", and whether it bites
+    depends on where `now` falls between two occurrences — the one thing a literal
+    example fixes and a generator does not. The timestamp the completion carries is
+    drawn independently and never appears in the assertion, which also pins that a
+    fixed schedule ignores *when* the work was logged.
+
+    Kills the `max(now, current)` -> `min(...)` mutant in `_advance_fixed_schedule`
+    (min returns `now`, whose next occurrence is the one already on the board) and the
+    `is not None` -> `is None` mutant (`max(datetime, None)` raises).
+    """
+    task = models.build_task(
+        {
+            "name": "p",
+            "recurrence_type": "fixed",
+            "freq": freq,
+            "interval": interval,
+            "anchor": anchor.isoformat(),
+        },
+        now=now,
+    )
+    before = datetime.fromisoformat(task["next_due"])
+    r.apply_completion(task, now - timedelta(seconds=logged_seconds_ago), now=now)
+    after = datetime.fromisoformat(task["next_due"])
+    assert after > before, f"{freq}/{interval} anchored {anchor}: stayed at {before}"
+    assert after > now

--- a/tests/unit/test_recurrence_season.py
+++ b/tests/unit/test_recurrence_season.py
@@ -530,3 +530,37 @@ class TestMultiWindowSeason:
         }
         r.skip_occurrence(task, now=dt(2026, 10, 1))
         assert task["next_due"] == dt(2027, 4, 1).isoformat()
+
+
+def test_a_season_regrid_holds_the_local_hour_across_dst():
+    """The season re-grid runs its own ``next_fixed_occurrence``, so it needs a probe
+    in the same zone as the schedule or the clamped date reads at the stored offset's
+    wall clock instead of the local one.
+
+    It gets one by construction rather than by being told: ``_clamp_season`` is only
+    ever handed a ``next_due`` that came *out* of the grid, so the season start it
+    derives inherits that zone. This pins that chain — a reviewer flagged it as safe
+    but subtle, and nothing else asserts on it.
+    """
+    from datetime import datetime
+    from zoneinfo import ZoneInfo
+
+    zone = ZoneInfo("America/New_York")
+    # Stored the way every anchor is: serialized, so offset-only on reload.
+    stored = datetime(2026, 6, 1, 9, tzinfo=zone).isoformat()
+    task = {
+        "recurrence_type": "fixed",
+        "interval": 1,
+        "freq": "DAILY",
+        "anchor": stored,
+        # A winter-only season, so a summer "now" has to clamp forward across the
+        # autumn transition to reach it.
+        "active_season": [{"start": "12-01", "end": "02-28"}],
+    }
+    now = datetime(2026, 6, 13, 10, tzinfo=zone)
+    due = datetime.fromisoformat(r.compute_next_due(task, now=now).isoformat())
+    local = due.astimezone(zone)
+    assert (local.hour, local.minute) == (9, 0), (
+        f"season-clamped occurrence drifted to {local.isoformat()}"
+    )
+    assert (local.month, local.day) == (12, 1)

--- a/tests/unit/test_release_issues.py
+++ b/tests/unit/test_release_issues.py
@@ -540,6 +540,7 @@ _KNOWN_ISSUES = frozenset(
         305,
         308,
         313,
+        331,
     }
 )
 

--- a/tests/unit/test_transfer.py
+++ b/tests/unit/test_transfer.py
@@ -1800,3 +1800,50 @@ def test_an_exported_document_round_trips_a_name_that_looks_like_a_boolean():
     plan = _plan(text)
     assert plan.ok, _errors(plan)
     assert plan.records[0].payload["name"] == "no"
+
+
+def test_replaying_history_does_not_walk_a_fixed_schedule_forward():
+    # A completion moves a fixed task one occurrence on, which is right for a press
+    # today and wrong for a replay: three imported completions would otherwise land the
+    # task three days into the future. ``next_due`` is excluded from the document
+    # because it is derived, so the import restates it from the anchor.
+    doc = _doc(
+        tasks=[
+            {
+                "name": "Bin day",
+                "recurrence_type": "fixed",
+                "freq": "DAILY",
+                "interval": 1,
+                # Later in the day than NOW, so the schedule is the shape that drifts.
+                "anchor": "2026-06-13T18:00:00-04:00",
+                "history": [
+                    {"completed_at": "2026-06-10T18:00:00-04:00"},
+                    {"completed_at": "2026-06-11T18:00:00-04:00"},
+                    {"completed_at": "2026-06-12T18:00:00-04:00"},
+                ],
+            }
+        ]
+    )
+    task = _plan(doc).records[0].payload
+    assert task["next_due"] == "2026-06-13T18:00:00-04:00"
+    assert len(task["completions"]) == 3
+
+
+def test_an_import_with_no_history_leaves_a_fixed_task_where_it_was():
+    # Only a replayed completion can drag the schedule. With none in the document the
+    # stored due date stands, so a snoozed task stays snoozed through an import.
+    stored = _task(
+        name="Bin day",
+        recurrence_type="fixed",
+        freq="DAILY",
+        interval=1,
+        anchor="2026-06-13T18:00:00-04:00",
+    )
+    stored["next_due"] = "2026-06-20T18:00:00-04:00"  # snoozed a week out
+    plan = _plan(
+        _doc(tasks=[{"name": "Bin day", "notes": "Green bin"}]),
+        tasks={stored["id"]: stored},
+    )
+    (record,) = plan.records
+    assert record.action == "update"
+    assert record.payload["next_due"] == "2026-06-20T18:00:00-04:00"


### PR DESCRIPTION
Fixes #331

## What changed

Two defects in fixed (anchored) recurrence. The second was found while investigating the first and is independent of it.

### A. Completing a fixed task did not move it (#331)

`apply_completion` advanced with `next_fixed_occurrence(after=now)`. That returns the smallest occurrence **strictly after** `now`, so completing a task earlier in the day than its own time of day handed back the occurrence it was already sitting on — the completion was logged, `last_completed` was stamped, and the due date never moved.

| anchor time | completed at | old `next_due` |
|---|---|---|
| 10:00 | 09:00 | **today 10:00** — unchanged |
| 10:00 | 11:00 | tomorrow 10:00 — correct |
| 23:00 | any daytime hour | **today 23:00** — unchanged all day |

The reporter has tasks at 10:00 and at 23:00, which matches "for most tasks", and filed at 13:31 UTC — mid-morning in any US zone, inside the failing window.

`skip_occurrence` already had the right rule and documented it; `apply_completion` never got the line. Both now share `_advance_fixed_schedule`, which advances past `max(now, next_due)`. Both halves matter: past `next_due` is what stops a completion handing back the occurrence on the board, past `now` is what stops an overdue task crawling one missed occurrence per press.

This matches what users expect elsewhere. Todoist guarantees a completion never leaves you on a date you have reached ("If your task was scheduled for yesterday, and you complete it today, the task will not move to today"). TickTick's "Repeat from due date" computes the next occurrence from the due date rather than from now — the same rule.

`compute_next_due` and `remove_completion` deliberately keep `after=now`: an undo *should* rewind.

### Two paths that only become wrong once `next_due` can sit ahead of the grid

Both are caused by the fix above, so they are fixed here rather than left as follow-ups.

- **`move_completion`** recomputed from the anchor, which would drag a task back onto the occurrence it had just completed — the same symptom on a different button. A fixed task now keeps its due date when a log entry is re-timed, alongside triggered and sensor tasks.
- **`transfer.apply_history`** replays every historical completion, so a year of imported history would have walked the schedule a year forward, one step per entry. Measured before the fix: three replayed completions moved `next_due` three days out. It now restates the schedule from the anchor once the fold is done, guarded on the document actually carrying history so a no-history import cannot snap a snoozed task.

### B. A fixed schedule slipped an hour at every DST transition

An ISO string has an offset and no zone identity, so an anchor comes back from storage as a bare offset no matter how it was written, and `_step` then holds *that* offset's wall clock:

```
datetime(2026,9,8,10, tzinfo=ZoneInfo("America/Los_Angeles")).isoformat()
  -> "2026-09-08T10:00:00-07:00"
datetime.fromisoformat(that).tzinfo
  -> datetime.timezone(timedelta(hours=-7))     # zone identity gone
```

Probing a DAILY task the user set to 10:00 America/Los_Angeles, after DST ends:

| stored anchor | before | after |
|---|---|---|
| `17:00+00:00` (what the panel sends) | 2026-11-06 **09:00** | 2026-11-05 10:00 |
| `10:00-07:00` (written in HA's zone) | 2026-11-06 **09:00** | 2026-11-05 10:00 |
| `10:00` (naive — the documented service shape) | 2026-11-05 10:00 | 2026-11-05 10:00 |

Row 2 is why normalizing the anchor on save cannot fix this: serialization erases the zone either way. The engine now re-homes the anchor into the caller's zone before stepping, which is Home Assistant's configured zone at every call site (`dt_util.now()`, and `dt_util.as_local` on both of HA's calendar entry points). That also heals every anchor already in the store — no migration, nothing rewritten on disk.

The arithmetic is unchanged. `_step` was always correct; it just never received an anchor carrying a real zone.

## Testing

`test_r5a` already proved `_step` keeps local wall time — but only for a live `ZoneInfo` anchor, the shape storage can never hand back, which is why it stayed green while the product drifted. **R5c** is that property over the shape production actually produces: serialize, reload, then expand. **R7** covers A's domain claim (a completed fixed task never keeps the due date it was showing).

Each property was checked by mutating the line it claims to kill and watching it go red:

| mutant | killed by |
|---|---|
| `max(now, current)` → `min(...)` | R7 |
| `current is not None` → `is None` | R7 |
| `_regrid` dropped from `expand_fixed_occurrences` | R5c |
| `_regrid` dropped from `next_fixed_occurrence` | `test_a_utc_anchor_still_schedules_at_the_hour_the_user_chose` |

Also added: four example tests around the `max(now, next_due)` boundary, an undo test pinning the deliberate asymmetry with `move_completion`, a `move_completion` test that gates the change rather than coinciding with it (the existing one passes either way — its fixture has both values agreeing), two `transfer` tests, a calendar test across a transition, and two integration tests (nothing in `tests/integration/` completed a fixed task before).

Run locally, all green:

- `bash ci/test-python-unit.sh` — 2274 passed
- `pytest tests/unit -m property` — 16 passed
- `bash ci/test-mutation-python.sh` — **89.92%** (339/377), threshold 80%
- integration tier — 202 passed against the Docker HA container
- `ruff`, and `vale` compared as a hit *set* against `origin/main` — no new hits
- `mypy` — the 2 errors present are identical on `origin/main` (this `.venv` resolved an older HA below the Python floor); no new ones

## Deferred

The panel converts the typed wall clock through the **browser's** zone in both directions (`forms.ts:130-144`), so a user whose browser differs from HA's zone sets a schedule at the wrong hour — and the form renders it back through the same browser zone, so it reads as correct. That is a separate, narrower bug and is not fixed here. It needs `hass.config.time_zone` (the `Hass` interface declares only `config?: { currency?: string }`), `hass` threaded through `taskFormData`/`buildTaskPayload`, and replacing `frontend/test/forms-helpers.test.js:112-154`, which builds its expectations with the same browser-local `Date` constructor it tests and so would pass against both the buggy and fixed code.

Worth folding into that PR: the display layer reads `next_due` in browser-local (`formatDate`/`formatDateTime` pass HA's `lang` but no `timeZone`, and `dueLabel`'s day bucketing uses browser-local midnight). Note #250 was this same class of bug one field over.

## One-way doors

**None.** No service field, event payload, storage key, entity attribute or document format changes shape. The re-homing is read-side, so nothing on disk is rewritten and reverting the code fully reverts the behaviour.

One judgement worth a reviewer's eye: an automation author who passed an anchor with an explicit UTC offset *intending* a UTC-pinned schedule now gets a local-wall-clock one. `services.yaml` documents the shape as naive ("sets time-of-day", with a naive example), `docs/INTEGRATING.md` says "naive is OK", and the published JSON schema declares only `{"type": "string"}` with no format — but it is a real, if unlikely, behaviour change.

A second, deliberate consequence: a fixed schedule now follows HA's *current* zone. Change the configured timezone and "8 AM" means 8 AM where you live now.

## Checklist

- [x] Tests run locally (`pytest tests/unit -v`, `bash ci/test-frontend.sh`)
- [x] `CHANGELOG.md` updated — user-facing changes only, with `(Fixes #N)` for each issue this fixes
- [x] Panel UI changed → n/a, nothing under `frontend/src/` changes and the rendered panel is identical
- [x] New user-facing UI surface → n/a
- [x] New user-facing feature → n/a (bug fix), but version bumped to `0.24.0b1` anyway: `0.23.0` is already tagged so `check-changelog-release-gap` would reject editing it, and `main` still owed the post-stable bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdrQRsagyEAxZ88Mo9cLCf

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdrQRsagyEAxZ88Mo9cLCf)_