### PR TITLE
fix: sensor holds, and the six defects a review of the feature turned up

### DIFF
--- a/.amazonq/rules/architecture-and-code.md
+++ b/.amazonq/rules/architecture-and-code.md
@@ -196,6 +196,43 @@ command for admins; Home Keeper follows that rather than inventing a weaker line
   unrelated reload. Which tasks even have an edge to skip is the pure
   `sensor_tasks.holds_edge_state` — a `usage` meter is still anchored, because its
   baseline is a persisted reading and not an edge.
+- **A hold measures unbroken truth, and carried edge state belongs to one condition.**
+  Two rules the watcher and the pure evaluators share, both learned from #336:
+  - An **indeterminate reading** — missing / `unavailable` / `unknown`, and `missing`
+    for the availability mode — decides nothing *and* ends a pending hold
+    (`sensor_tasks._evaluate_indeterminate`). Carrying the crossing through a blackout
+    banked time the condition was not true, so a device that dropped off the network
+    armed its task the moment it came back in the trigger state. A task with no pending
+    crossing keeps its carried `condition_met`, which is what still stops a dropout
+    from re-arming a task the user dealt with, or clearing a `clear_on_recover` one.
+    The watcher therefore **routes a missing reading through the evaluator** rather than
+    skipping the task: skipping left the crossing and its hold timer in place.
+  - The carried edge is stamped with `sensor_tasks.condition_fingerprint(task)` — the
+    entity, attribute, mode and condition, and deliberately not the hold or
+    `clear_on_recover`. When the fingerprint changes the state is retired, so editing a
+    task (or the recipe that owns it) reads the entity against the new condition and
+    arms on a standing match instead of waiting for it to recur.
+- **The reconciler owns every key on a materialized task's `sensor` block except the
+  meter anchor.** `sensor.baseline` is written by the watcher, not by any recipe, so
+  `declarative_companions.merge_sensor_binding` carries a stored one forward and the
+  recipe's own `baseline` only seeds a task that has none. Rewriting the block
+  wholesale reset a `usage` recipe's meter on every registry event, which no user could
+  see and which no target could survive. A stored baseline is carried only while both
+  bindings stay in `usage` mode — it is a usage-only field, so it would fail validation
+  in any other.
+- **A disabled recipe pauses its tasks; it does not delete them.**
+  `declarative_companions.pause_spec_tasks` switches each task off and marks its
+  provenance `paused`; the enabled pass clears the marker and switches the task back on
+  with a `"resumed"` op, which the store reports as a freshly-made id so the watcher
+  arms it on a condition that became true while the recipe was off. Deleting them threw
+  away the completions recorded on each one, and a task switched off **by hand** carries
+  no marker, so that choice survives the recipe coming back.
+- **Every registry event goes through the reconcile debouncer.** Home Assistant fires
+  one entity-registry event per entity, and a pass walks every spec over every entity,
+  renders Jinja per match and writes the store, so an integration loading 50 entities
+  once cost 50 full passes. `DeclarativeCompanionSync._reconcile_debouncer`
+  (`immediate=True`, `RECONCILE_DEBOUNCE_SECONDS`) keeps the first pass prompt and folds
+  the rest of a burst into one trailing pass; it is shut down with the listeners.
 - **A declarative companion's notes are re-rendered when the task arms.** The reconcile
   pass renders name/notes from live state, but it runs on *registry* changes, so a
   template that quotes the reading (`{{ state }} h left`) froze at whatever the entity

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,7 +9,12 @@ on:
 jobs:
   integration:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # The tier runs a real Home Assistant container and several tests that wait out
+    # a hold or a coordinator tick, so it takes ~9.5 minutes at main HEAD. A 10
+    # minute cap cancelled a run whose 216 tests had all passed, and a cancelled run
+    # reads as a red check. 20 gives the tier room to grow before the cap is the
+    # thing that fails a PR again.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Home Keeper are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
 
+## [0.24.0b5]
+
+### Fixed
+
+- **Sensor hold time.** A hold now counts only the time an entity reported the
+  trigger condition. An entity that stopped reporting part way through kept its
+  hold running, so the task opened as soon as the entity came back. (Fixes #336)
+
 ## [0.24.0b4]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,28 @@ versioning, with PEP 440 pre-release suffixes (`bN`/`aN`/`rcN`) for betas.
 
 ## [0.24.0b5]
 
+### Changed
+
+- **Meter task validation.** A meter task now refuses a hold time and an auto-clear
+  switch. A meter has no condition to hold, so Home Keeper used to drop both without
+  a word.
+
 ### Fixed
 
 - **Sensor hold time.** A hold now counts only the time an entity reported the
   trigger condition. An entity that stopped reporting part way through kept its
   hold running, so the task opened as soon as the entity came back. (Fixes #336)
+- **Recipe meter progress.** A recipe that meters a sensor now keeps the reading it
+  counts from. Home Keeper reset that reading on each change to the entity list, so
+  the task could never reach its target.
+- **Disabled recipes.** A recipe you switch off now keeps its tasks and everything
+  recorded on them. The tasks stop until you switch the recipe on again.
+- **Edited conditions.** A sensor task now opens when you change its condition to one
+  the entity already meets. It used to wait for the condition to go away and come
+  back.
+- **Recipe updates.** Home Keeper now runs one pass for each group of entity changes.
+  An integration that added many entities at once made it repeat the same work for
+  each one.
 
 ## [0.24.0b4]
 

--- a/custom_components/home_keeper/const.py
+++ b/custom_components/home_keeper/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["todo", "calendar", "button", "sensor", "binary_sensor", "number"]
 # Frontend panel.
 # PANEL_VERSION is the single source of truth that release.yml validates against
 # manifest.json's "version" (mirrors Pawsistant's CARD_VERSION check).
-PANEL_VERSION = "0.24.0b4"
+PANEL_VERSION = "0.24.0b5"
 PANEL_URL_PATH = "home-keeper"  # sidebar route -> /home-keeper
 PANEL_STATIC_URL = "/home_keeper_panel"  # static path that serves the JS bundle
 PANEL_JS_FILENAME = "home-keeper-panel.js"

--- a/custom_components/home_keeper/declarative_companion_sync.py
+++ b/custom_components/home_keeper/declarative_companion_sync.py
@@ -10,8 +10,12 @@ device/area edits) and on the store's own spec-changed dispatcher signal.
 
 Mirrors the shape of ``problem_sync.ProblemSensorSync``: single initial pass on
 setup, listeners registered via ``entry.async_on_unload`` so teardown is
-automatic, entity-set changes trigger a debounced entry reload (needed because
+automatic, entity-set changes trigger a coalesced entry reload (needed because
 each managed task owns per-task device-page entities).
+
+Every registry event goes through ``_reconcile_debouncer``, so a burst — one event
+per entity when an integration loads — costs one prompt pass and one trailing pass
+rather than one full pass per event.
 """
 
 from __future__ import annotations
@@ -30,6 +34,7 @@ from homeassistant.helpers import (
 from homeassistant.helpers import (
     entity_registry as er,
 )
+from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.template import Template, TemplateError
 
@@ -43,6 +48,11 @@ if TYPE_CHECKING:
     from .coordinator import HomeKeeperCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
+# How long the reconciler waits for a burst of registry events to finish before it
+# runs the trailing pass. Long enough to fold one integration's entity load into a
+# single pass, short enough that a rename shows on the task within a breath.
+RECONCILE_DEBOUNCE_SECONDS = 5.0
 
 
 def _project_entry(entry: er.RegistryEntry) -> dict[str, Any]:
@@ -84,6 +94,19 @@ class DeclarativeCompanionSync:
         self._unsub_area_registry: CALLBACK_TYPE | None = None
         self._unsub_specs: CALLBACK_TYPE | None = None
         self._reload_scheduled = False
+        # One reconcile per burst of registry events. Home Assistant fires an entity
+        # registry event per entity, so an integration loading 50 of them used to run
+        # 50 full passes — each one walking every spec over every entity, rendering
+        # Jinja per match and writing the store. ``immediate`` keeps the first pass
+        # prompt (a recipe saved in the panel must show its tasks at once) and folds
+        # the rest of the burst into one trailing pass.
+        self._reconcile_debouncer = Debouncer(
+            hass,
+            _LOGGER,
+            cooldown=RECONCILE_DEBOUNCE_SECONDS,
+            immediate=True,
+            function=self._async_reconcile_and_maybe_reload,
+        )
 
     # ── lifecycle ────────────────────────────────────────────────────────────
     async def async_initial_reconcile(self) -> None:
@@ -136,6 +159,9 @@ class DeclarativeCompanionSync:
             self._handle_specs_changed,
         )
         self._entry.async_on_unload(self._unsub_specs)
+        # A pass still pending when the entry unloads would run against the objects
+        # the reload replaced, so the debouncer is shut down with the listeners.
+        self._entry.async_on_unload(self._reconcile_debouncer.async_shutdown)
 
     # ── snapshot builders ────────────────────────────────────────────────────
     def _registry_snapshot(self) -> dict[str, Any]:
@@ -255,8 +281,9 @@ class DeclarativeCompanionSync:
         Complexity: the snapshot is built once per pass, then each spec walks
         every entity to apply its filters (O(N specs x M entities)). For the
         expected load (~10 specs, ~500 entities) that's ~5,000 predicate
-        evaluations per pass, which the dispatcher already debounces to at most
-        one pass per burst of registry events. If users report slowness with
+        evaluations per pass, plus a Jinja render per match and a store write.
+        ``_reconcile_debouncer`` is what keeps a burst of registry events to 2 of
+        those passes rather than one per event. If users report slowness with
         many specs, index the snapshot by domain/platform/device_class once and
         filter the pre-indexed subset per spec.
         """
@@ -266,17 +293,13 @@ class DeclarativeCompanionSync:
         specs = self._coordinator.store.get_declarative_companions()
         for spec in list(specs.values()):
             if not spec.get("enabled", True):
-                # A disabled spec's managed tasks are dropped (reconcile with empty
-                # matches), so toggling enabled off cleans up without deleting the spec.
-                store = self._coordinator.store
-                changed, made = await store.reconcile_declarative_companion_tasks(
-                    spec,
-                    {},
-                    {},
-                    config_entry_id=self._entry.entry_id,
+                # A disabled spec's managed tasks are switched off rather than
+                # removed, so a recipe can be turned off for a week without losing
+                # the completions recorded on the tasks it made. Re-enabling the
+                # recipe brings them back (see ``pause_spec_tasks``).
+                await self._coordinator.store.pause_declarative_companion_tasks(
+                    spec["id"]
                 )
-                entity_set_changed = entity_set_changed or changed
-                created.extend(made)
                 continue
             try:
                 matches = declarative_companions.expand_spec(spec, snapshot)
@@ -368,13 +391,13 @@ class DeclarativeCompanionSync:
 
     @callback
     def _trigger_reconcile(self) -> None:
-        """Schedule a reconcile pass (shared by every registry-event wrapper)."""
-        self._hass.async_create_task(self._async_reconcile_and_maybe_reload())
+        """Ask the debouncer for a pass (shared by every registry-event wrapper)."""
+        self._hass.async_create_task(self._reconcile_debouncer.async_call())
 
     @callback
     def _handle_specs_changed(self) -> None:
         """Store fired ``SIGNAL_DECLARATIVE_SPECS_CHANGED`` after a spec CRUD."""
-        self._hass.async_create_task(self._async_reconcile_and_maybe_reload())
+        self._hass.async_create_task(self._reconcile_debouncer.async_call())
 
     async def _async_reconcile_and_maybe_reload(self) -> None:
         entity_set_changed, created = await self._reconcile_all()

--- a/custom_components/home_keeper/declarative_companions.py
+++ b/custom_components/home_keeper/declarative_companions.py
@@ -48,6 +48,7 @@ from .const import (
     MAX_DECLARATIVE_SPEC_DESCRIPTION_LEN,
     MAX_DECLARATIVE_SPEC_NAME_LEN,
     REC_SENSOR,
+    SENSOR_MODE_USAGE,
     TASK_SOURCE_DECLARATIVE_COMPANION,
 )
 from .models import TaskValidationError
@@ -170,8 +171,14 @@ def _normalize_task_template(data: Any) -> dict[str, Any]:
 
     Jinja source strings are validated for length and non-emptiness (``name_template``
     only) — actual template compilation happens on the HA-bound side where a
-    ``hass`` object is in scope. ``category``/``priority``/``labels`` pass through
-    with light shape checks and are stamped verbatim onto the materialized task.
+    ``hass`` object is in scope. ``labels`` passes through with a light shape check
+    and is stamped onto the materialized task.
+
+    The v1 shape also accepted ``category`` and ``priority``, and nothing ever read
+    them: :func:`_build_task` stamps ``labels`` alone, and a Home Keeper task has no
+    category or priority field to stamp them onto. They are dropped here rather than
+    refused, because a spec written when the service still advertised them would
+    otherwise fail validation on load and be dropped whole.
     """
     if data is None:
         data = {}
@@ -190,18 +197,6 @@ def _normalize_task_template(data: Any) -> dict[str, Any]:
         MAX_DECLARATIVE_NOTES_TEMPLATE_LEN,
     )
     result["notes_template"] = notes_template
-    category = _clean_str(data.get("category"), "task_template.category", 100)
-    if category:
-        result["category"] = category
-    priority = data.get("priority")
-    if priority is not None:
-        try:
-            priority_int = int(priority)
-        except (TypeError, ValueError) as err:
-            raise DeclarativeCompanionValidationError(
-                "task_template.priority must be an integer"
-            ) from err
-        result["priority"] = priority_int
     labels_raw = data.get("labels")
     if labels_raw in (None, "", []):
         result["labels"] = []
@@ -462,6 +457,37 @@ def task_key(task: dict[str, Any]) -> tuple[str, str] | None:
     return (spec_id, ent_reg_id)
 
 
+def merge_sensor_binding(existing: Any, fresh: dict[str, Any]) -> dict[str, Any]:
+    """The recipe's binding, keeping the meter anchor the watcher owns.
+
+    Every key on a materialized task's ``sensor`` block belongs to the recipe and is
+    rewritten from it on each pass — except ``baseline``, which no recipe writes. The
+    sensor watcher stamps it from the first live reading and moves it forward on each
+    completion, so it is the record of how far the meter has run.
+
+    Rewriting the block wholesale dropped it, and a reconcile pass runs on **any**
+    entity, device or area registry event, so a ``usage`` recipe restarted its meter
+    at the current reading whenever anything in Home Assistant changed. A task set to
+    "every 300 hours" could never reach 300.
+
+    A stored baseline therefore wins over the recipe's, which is only a seed for a
+    task that has none yet. The carry needs both sides in ``usage`` mode: ``baseline``
+    is a usage-only field (see ``models.USAGE_ONLY_SENSOR_FIELDS``), so carrying it
+    into a recipe switched to ``threshold`` would make the binding fail validation.
+    """
+    if not isinstance(existing, dict):
+        return fresh
+    if (
+        existing.get("mode") != SENSOR_MODE_USAGE
+        or fresh.get("mode") != SENSOR_MODE_USAGE
+    ):
+        return fresh
+    baseline = existing.get("baseline")
+    if baseline is None:
+        return fresh
+    return {**fresh, "baseline": baseline}
+
+
 def _build_task(
     spec: dict[str, Any],
     match: dict[str, Any],
@@ -531,8 +557,11 @@ def reconcile_declarative_tasks(
     * ``new_tasks`` — a fresh task map (non-declarative tasks and tasks from other
       specs are carried through untouched).
     * ``ops`` — ordered ``(kind, task)`` events the store must fire:
-      ``"created"`` / ``"deleted"`` / ``"updated"``. Arm/clear transitions are not
-      handled here — the sensor watcher owns those on the materialized tasks.
+      ``"created"`` / ``"deleted"`` / ``"updated"`` / ``"resumed"``. A ``"resumed"``
+      task is an ordinary update that also counts as freshly made, because the recipe
+      that had paused it is on again (see :func:`pause_spec_tasks`). Arm/clear
+      transitions are not handled here — the sensor watcher owns those on the
+      materialized tasks.
     * ``changed`` — whether ``new_tasks`` differs from ``tasks`` (persist if true).
 
     Handles four cases per match: new (create), still-there (drift-update
@@ -583,6 +612,9 @@ def reconcile_declarative_tasks(
         # renames / device rehoming / spec-name edits flow through.
         entry = match["entity"]
         managed_by = build_managed_by(spec, config_entry_id, lang=lang)
+        # Whether this task is off because the recipe was off. Rewriting ``source``
+        # below drops the marker, which is how it clears.
+        was_paused = bool((declarative_source(task) or {}).get("paused"))
         new_source = {
             TASK_SOURCE_DECLARATIVE_COMPANION: {
                 "spec_id": spec["id"],
@@ -596,17 +628,71 @@ def reconcile_declarative_tasks(
             ("notes", rendered_notes),
             ("device_id", entry.get("device_id")),
             ("area_id", entry.get("area_id")),
-            ("sensor", match["sensor"]),
+            ("sensor", merge_sensor_binding(task.get("sensor"), match["sensor"])),
             ("managed_by", managed_by),
             ("source", new_source),
         ):
             if task.get(field) != value:
                 task[field] = value
                 task_changed = True
+        # A task this recipe paused (see :func:`pause_spec_tasks`) runs again, unless
+        # the person switched this one task off themselves — that choice has no
+        # ``paused`` marker, and it is theirs to undo.
+        resumed = False
+        if was_paused and not task.get("enabled", True):
+            task["enabled"] = True
+            task_changed = True
+            resumed = True
         if task_changed:
-            ops.append(("updated", task))
+            # ``resumed`` is an update the caller must also treat as a task made just
+            # now: the watcher has to arm it on a condition that is true while the
+            # recipe was off, exactly as it would for a task the pass created.
+            ops.append(("resumed" if resumed else "updated", task))
             changed = True
 
+    return result, ops, changed
+
+
+def pause_spec_tasks(
+    spec_id: str, tasks: dict[str, dict[str, Any]]
+) -> tuple[dict[str, dict[str, Any]], list[tuple[str, dict[str, Any]]], bool]:
+    """Switch off every task of *spec_id* instead of removing it.
+
+    What a disabled recipe does to the tasks it made. Deleting them was tidy and it
+    threw away the completions on each one, so switching a recipe off for a week and
+    back on lost the history of the work it had tracked. A disabled task is already
+    ignored by the sensor watcher and by every due-date surface, which is the whole
+    of what "off" has to mean.
+
+    The ``paused`` marker on the task's own provenance block records who switched it
+    off, so re-enabling the recipe brings back the tasks it paused and leaves alone
+    any task the person switched off by hand. It travels with ``source`` in an export
+    like the rest of the provenance.
+
+    Same ``(new_tasks, ops, changed)`` shape as
+    :func:`reconcile_declarative_tasks`; the ops are always ``"updated"``.
+    """
+    result = dict(tasks)
+    ops: list[tuple[str, dict[str, Any]]] = []
+    changed = False
+    for task in result.values():
+        key = task_key(task)
+        if key is None or key[0] != spec_id:
+            continue
+        source = declarative_source(task)
+        if source is None:  # pragma: no cover - task_key already proved it is there
+            continue
+        if not task.get("enabled", True) and source.get("paused"):
+            continue
+        if task.get("enabled", True):
+            task["enabled"] = False
+            source["paused"] = True
+        else:
+            # Switched off by hand before the recipe was: leave the marker off so
+            # re-enabling the recipe does not switch it back on.
+            continue
+        ops.append(("updated", task))
+        changed = True
     return result, ops, changed
 
 

--- a/custom_components/home_keeper/declarative_companions.py
+++ b/custom_components/home_keeper/declarative_companions.py
@@ -679,18 +679,14 @@ def pause_spec_tasks(
         key = task_key(task)
         if key is None or key[0] != spec_id:
             continue
-        source = declarative_source(task)
-        if source is None:  # pragma: no cover - task_key already proved it is there
+        if not task.get("enabled", True):
+            # Already off: either this recipe paused it on an earlier pass, or the
+            # person switched this one task off. The first needs nothing, and the
+            # second must not get a marker — that choice is theirs to undo.
             continue
-        if not task.get("enabled", True) and source.get("paused"):
-            continue
-        if task.get("enabled", True):
-            task["enabled"] = False
-            source["paused"] = True
-        else:
-            # Switched off by hand before the recipe was: leave the marker off so
-            # re-enabling the recipe does not switch it back on.
-            continue
+        task["enabled"] = False
+        # ``task_key`` above already proved the provenance block is a mapping.
+        task["source"][TASK_SOURCE_DECLARATIVE_COMPANION]["paused"] = True
         ops.append(("updated", task))
         changed = True
     return result, ops, changed

--- a/custom_components/home_keeper/manifest.json
+++ b/custom_components/home_keeper/manifest.json
@@ -21,5 +21,5 @@
   "requirements": [
     "Babel>=2.12"
   ],
-  "version": "0.24.0b4"
+  "version": "0.24.0b5"
 }

--- a/custom_components/home_keeper/models.py
+++ b/custom_components/home_keeper/models.py
@@ -47,6 +47,8 @@ from .const import (
 # (``threshold``, ``state``) reject them rather than storing a setting that never
 # applies.
 USAGE_ONLY_SENSOR_FIELDS = ("also_every", "combinator", "unit", "target", "baseline")
+# The mirror of the tuple above: the fields only an edge-driven mode reads.
+EDGE_ONLY_SENSOR_FIELDS = ("for_seconds", "clear_on_recover")
 
 
 class TaskValidationError(ValueError):
@@ -296,6 +298,16 @@ def normalize_sensor(
         result["attribute"] = attribute
 
     if mode == SENSOR_MODE_USAGE:
+        # A meter has no condition to hold or to recover from, so these 2 do nothing
+        # here. Dropping them quietly let a caller save "for 10 minutes" onto a usage
+        # task and believe it applied, which is what :func:`_reject_fields` exists to
+        # stop. Only a truthy value is refused: a form that always sends
+        # ``for_seconds: 0`` or ``clear_on_recover: false`` is saying nothing.
+        for name in EDGE_ONLY_SENSOR_FIELDS:
+            if data.get(name):
+                raise TaskValidationError(
+                    f"sensor.{name} is not valid for a usage-mode sensor task"
+                )
         target_raw = data.get("target")
         if target_raw is None or target_raw == "":
             raise TaskValidationError("sensor.target must be a number")

--- a/custom_components/home_keeper/sensor_tasks.py
+++ b/custom_components/home_keeper/sensor_tasks.py
@@ -407,6 +407,32 @@ def evaluate_usage(
     return {"action": None, "reset_candidate": reset_candidate}
 
 
+def condition_fingerprint(task: dict[str, Any]) -> tuple[Any, ...]:
+    """What the carried edge state of *task* was measured against.
+
+    The caller holds "was the condition true last tick" and "when did it cross" in
+    memory, and both are answers about **one** condition. Edit the task — or edit the
+    recipe that owns it — and the answers describe a question nobody is asking any
+    more: a task moved from "below 20%" to "below 50%" carried a ``condition_met``
+    that had been decided against the old limit, so a battery already at 30% stayed
+    dormant until it rose above 50% and fell back through it.
+
+    So the caller compares this fingerprint with the one it recorded and starts the
+    edge afresh when they differ. The entity and the condition are in it. The hold and
+    ``clear_on_recover`` are not: neither decides whether the condition is true, and
+    a longer hold applies to the crossing already running without discarding it.
+    """
+    cfg = sensor_config(task) or {}
+    return (
+        cfg.get("entity_id"),
+        cfg.get("attribute"),
+        cfg.get("mode"),
+        cfg.get("comparison"),
+        cfg.get("value"),
+        cfg.get("state"),
+    )
+
+
 def hold_due_at(
     task: dict[str, Any], *, crossed_at: datetime | None, now: datetime
 ) -> datetime | None:

--- a/custom_components/home_keeper/sensor_tasks.py
+++ b/custom_components/home_keeper/sensor_tasks.py
@@ -38,6 +38,10 @@ Every edge decision also reports **when its pending hold completes**
 (:func:`hold_due_at`). A hold ends in its own time, so the watcher books one
 re-evaluation for that moment. It does not wait for a state change, which a quiet — or
 absent — entity never sends.
+
+A hold measures **unbroken** truth. A reading that says nothing — a missing,
+``unavailable`` or ``unknown`` entity — decides nothing and ends a pending hold, so
+the next true reading starts the clock again (:func:`_evaluate_indeterminate`).
 """
 
 from __future__ import annotations
@@ -417,15 +421,52 @@ def hold_due_at(
 
     A hold that is already due returns ``None``. A timer cannot help there: the same
     evaluation arms the task if it can, so only new information about the entity moves
-    a task that stayed dormant. This is what keeps an indeterminate reading (see
-    :func:`evaluate_state` and :func:`evaluate_availability`) from booking the same
-    past moment again and again.
+    a task that stayed dormant.
     """
     cfg = sensor_config(task)
     if cfg is None or crossed_at is None or task.get("next_due") is not None:
         return None
     due = crossed_at + timedelta(seconds=int(cfg.get("for_seconds") or 0))
     return due if due > now else None
+
+
+def _evaluate_indeterminate(
+    *, condition_met_prev: bool, crossed_at: datetime | None
+) -> dict[str, Any]:
+    """The decision for a reading that says nothing: decide nothing, break the hold.
+
+    An indeterminate reading is a missing / ``unavailable`` / ``unknown`` entity for
+    the ``state`` and ``threshold`` modes, and an entity that is not in the state
+    machine yet for ``availability``. It is neither a match nor a recovery, so the
+    action is always ``None``: a Zigbee dropout must not arm a task, and it must not
+    complete a ``clear_on_recover`` one either.
+
+    It does end a **pending hold**. A hold says the condition must be true for
+    ``for_seconds`` without a break, and time with no reading is not time the
+    condition was true. Carrying the crossing through the gap banked that time: a
+    device that dropped off the network for an hour armed its task the moment it came
+    back in the trigger state, whatever the hold said (#336). So an unconsumed
+    crossing is dropped, and ``condition_met`` goes with it, because a carried
+    ``True`` with no crossing cannot start the fresh hold the next true reading needs.
+
+    A task with no pending crossing keeps its carried ``condition_met``: the condition
+    was already met without a crossing (baselined at startup) or the crossing was
+    consumed by an arm, and there the "no reading is not a recovery" rule is the whole
+    decision. That is what stops a dropout from re-arming a task the user dealt with.
+    """
+    if crossed_at is not None:
+        return {
+            "action": None,
+            "condition_met": False,
+            "crossed_at": None,
+            "hold_due_at": None,
+        }
+    return {
+        "action": None,
+        "condition_met": condition_met_prev,
+        "crossed_at": None,
+        "hold_due_at": None,
+    }
 
 
 def _evaluate_edge(
@@ -495,7 +536,7 @@ def _evaluate_edge(
 def evaluate_threshold(
     task: dict[str, Any],
     *,
-    reading: float,
+    reading: float | None,
     condition_met_prev: bool,
     crossed_at: datetime | None,
     now: datetime,
@@ -504,9 +545,18 @@ def evaluate_threshold(
 
     The condition is the binding's numeric ``comparison`` against ``value``; see
     :func:`_evaluate_edge` for the edge/hold semantics and the returned shape.
+
+    ``reading`` is ``None`` when the bound entity is missing, ``unavailable``,
+    ``unknown`` or not a number. Like the ``None`` state in :func:`evaluate_state`,
+    that decides nothing — the task never arms on bad data — and it breaks a pending
+    hold (see :func:`_evaluate_indeterminate`).
     """
     cfg = sensor_config(task)
     assert cfg is not None
+    if reading is None:
+        return _evaluate_indeterminate(
+            condition_met_prev=condition_met_prev, crossed_at=crossed_at
+        )
     return _evaluate_edge(
         task,
         cfg,
@@ -534,18 +584,15 @@ def evaluate_state(
     ``state`` is ``None`` when the bound entity is missing, ``unavailable`` or
     ``unknown``. That is **not** a recovery: treating a Zigbee dropout as "the
     condition went away" would silently complete every ``clear_on_recover`` task the
-    first time its device fell off the mesh. A ``None`` state therefore holds the
-    carried edge state exactly as it was and decides nothing.
+    first time its device fell off the mesh. A ``None`` state therefore decides
+    nothing, and it ends a pending hold — see :func:`_evaluate_indeterminate`.
     """
     cfg = sensor_config(task)
     assert cfg is not None
     if state is None:
-        return {
-            "action": None,
-            "condition_met": condition_met_prev,
-            "crossed_at": crossed_at,
-            "hold_due_at": hold_due_at(task, crossed_at=crossed_at, now=now),
-        }
+        return _evaluate_indeterminate(
+            condition_met_prev=condition_met_prev, crossed_at=crossed_at
+        )
     return _evaluate_edge(
         task,
         cfg,
@@ -581,19 +628,16 @@ def evaluate_availability(
     ignore. See :func:`_evaluate_edge` for the returned shape.
 
     ``status == "missing"`` is indeterminate (the entity is not yet loaded — e.g.
-    early in HA startup) and holds the carried edge state exactly as it was, so a
-    boot-time gap can never fabricate a spurious arm or clear. Mirrors the
-    ``problem_sync`` "indeterminate does not fabricate" invariant.
+    early in HA startup), so it fabricates neither an arm nor a clear and it ends a
+    pending hold. Mirrors the ``problem_sync`` "indeterminate does not fabricate"
+    invariant. See :func:`_evaluate_indeterminate`.
     """
     cfg = sensor_config(task)
     assert cfg is not None
     if status == AVAILABILITY_MISSING:
-        return {
-            "action": None,
-            "condition_met": condition_met_prev,
-            "crossed_at": crossed_at,
-            "hold_due_at": hold_due_at(task, crossed_at=crossed_at, now=now),
-        }
+        return _evaluate_indeterminate(
+            condition_met_prev=condition_met_prev, crossed_at=crossed_at
+        )
     return _evaluate_edge(
         task,
         cfg,

--- a/custom_components/home_keeper/sensor_watcher.py
+++ b/custom_components/home_keeper/sensor_watcher.py
@@ -194,7 +194,10 @@ class SensorTaskWatcher:
         self._unsub_state: CALLBACK_TYPE | None = None
         self._tracked: tuple[str, ...] = ()
         # In-memory threshold edge state, keyed by task id:
-        #   {"condition_met": bool, "crossed_at": datetime | None}
+        #   {"condition_met": bool, "crossed_at": datetime | None, "condition": tuple}
+        # ``condition`` is the binding the other 2 were decided against (see
+        # ``sensor_tasks.condition_fingerprint``); an edit to the task or to the
+        # recipe that owns it retires them.
         self._edge: dict[str, dict[str, Any]] = {}
         # One pending "the hold is up" timer per task id, keyed the same way. A
         # ``for_seconds`` hold ends in its own time, and the bound entity sends no
@@ -255,12 +258,19 @@ class SensorTaskWatcher:
                 # evaluation arms on a condition that is already true. A usage meter
                 # has no edge, so it is still anchored below.
                 continue
+            # Recorded with the state, so an edit between now and the first
+            # evaluation retires it (see :meth:`_carried_edge`).
+            condition = sensor_tasks.condition_fingerprint(task)
             if mode == SENSOR_MODE_THRESHOLD:
                 reading = read_sensor_value(self._hass, cfg)
                 met = reading is not None and sensor_tasks.compare(
                     reading, cfg["comparison"], float(cfg["value"])
                 )
-                self._edge[tid] = {"condition_met": met, "crossed_at": None}
+                self._edge[tid] = {
+                    "condition_met": met,
+                    "crossed_at": None,
+                    "condition": condition,
+                }
             elif mode == SENSOR_MODE_STATE:
                 # Record an already-matching sensor as met-without-a-crossing, so a
                 # vacuum still reporting "water tank low" across a restart doesn't
@@ -269,6 +279,7 @@ class SensorTaskWatcher:
                     "condition_met": read_sensor_state(self._hass, cfg)
                     == cfg.get("state"),
                     "crossed_at": None,
+                    "condition": condition,
                 }
             elif mode == SENSOR_MODE_AVAILABILITY:
                 # Record an already-unavailable entity as met-without-a-crossing:
@@ -280,6 +291,7 @@ class SensorTaskWatcher:
                 self._edge[tid] = {
                     "condition_met": status == sensor_tasks.AVAILABILITY_UNAVAILABLE,
                     "crossed_at": None,
+                    "condition": condition,
                 }
             else:
                 reading = read_sensor_value(self._hass, cfg)
@@ -455,16 +467,38 @@ class SensorTaskWatcher:
             return True
         return False
 
+    def _carried_edge(
+        self, tid: str, task: dict[str, Any]
+    ) -> tuple[bool, datetime | None]:
+        """The carried ``(condition_met, crossed_at)`` for *task*, if it still applies.
+
+        Edge state answers a question about one condition, so an edit to the task —
+        or to the recipe that owns it — retires it: the fingerprint recorded with the
+        state no longer matches the binding being evaluated, and the pass starts from
+        "nothing seen yet". A standing condition then reads as a fresh crossing and
+        arms after its hold, which is what a person editing a task expects. The
+        pending hold goes with the state it belonged to.
+        """
+        edge = self._edge.get(tid)
+        if edge is None:
+            return False, None
+        if edge.get("condition") != sensor_tasks.condition_fingerprint(task):
+            self._cancel_hold_timer(tid)
+            return False, None
+        return bool(edge.get("condition_met")), edge.get("crossed_at")
+
     async def _evaluate_threshold(
         self, tid: str, task: dict[str, Any], *, reading: float | None, now: Any
     ) -> bool:
+        condition_met_prev, crossed_at = self._carried_edge(tid, task)
         return await self._apply_edge(
             tid,
+            task,
             sensor_tasks.evaluate_threshold(
                 task,
                 reading=reading,
-                condition_met_prev=bool(self._edge.get(tid, {}).get("condition_met")),
-                crossed_at=self._edge.get(tid, {}).get("crossed_at"),
+                condition_met_prev=condition_met_prev,
+                crossed_at=crossed_at,
                 now=now,
             ),
         )
@@ -472,13 +506,15 @@ class SensorTaskWatcher:
     async def _evaluate_state(
         self, tid: str, task: dict[str, Any], *, state: str | None, now: Any
     ) -> bool:
+        condition_met_prev, crossed_at = self._carried_edge(tid, task)
         return await self._apply_edge(
             tid,
+            task,
             sensor_tasks.evaluate_state(
                 task,
                 state=state,
-                condition_met_prev=bool(self._edge.get(tid, {}).get("condition_met")),
-                crossed_at=self._edge.get(tid, {}).get("crossed_at"),
+                condition_met_prev=condition_met_prev,
+                crossed_at=crossed_at,
                 now=now,
             ),
         )
@@ -486,13 +522,15 @@ class SensorTaskWatcher:
     async def _evaluate_availability(
         self, tid: str, task: dict[str, Any], *, status: str, now: Any
     ) -> bool:
+        condition_met_prev, crossed_at = self._carried_edge(tid, task)
         return await self._apply_edge(
             tid,
+            task,
             sensor_tasks.evaluate_availability(
                 task,
                 status=status,
-                condition_met_prev=bool(self._edge.get(tid, {}).get("condition_met")),
-                crossed_at=self._edge.get(tid, {}).get("crossed_at"),
+                condition_met_prev=condition_met_prev,
+                crossed_at=crossed_at,
                 now=now,
             ),
         )
@@ -523,7 +561,9 @@ class SensorTaskWatcher:
                 _LOGGER.exception("Could not refresh the notes of task %s", tid)
         await self._coordinator.store.trigger_task(tid)
 
-    async def _apply_edge(self, tid: str, decision: dict[str, Any]) -> bool:
+    async def _apply_edge(
+        self, tid: str, task: dict[str, Any], decision: dict[str, Any]
+    ) -> bool:
         """Carry an edge decision's state forward and apply its action.
 
         Returns whether the task's due-state changed. A ``clear_on_recover`` clear
@@ -538,6 +578,7 @@ class SensorTaskWatcher:
         self._edge[tid] = {
             "condition_met": decision["condition_met"],
             "crossed_at": decision["crossed_at"],
+            "condition": sensor_tasks.condition_fingerprint(task),
         }
         self._schedule_hold(tid, decision["hold_due_at"])
         action = decision["action"]

--- a/custom_components/home_keeper/sensor_watcher.py
+++ b/custom_components/home_keeper/sensor_watcher.py
@@ -416,8 +416,11 @@ class SensorTaskWatcher:
                 if await self._evaluate_usage(tid, task, reading=reading, now=now):
                     changed_any = True
             else:
-                if reading is None:
-                    continue  # unavailable / non-numeric — never arm on bad data
+                # A missing reading is handled inside the evaluator, like the state
+                # mode's missing state: it never arms on bad data, and it ends a
+                # pending hold. Skipping it here left the crossing and its timer in
+                # place, so the seconds an entity spent unreadable counted toward the
+                # hold (#336).
                 if await self._evaluate_threshold(tid, task, reading=reading, now=now):
                     changed_any = True
         # Drop edge state for tasks that no longer exist so it can't leak. A task that
@@ -453,7 +456,7 @@ class SensorTaskWatcher:
         return False
 
     async def _evaluate_threshold(
-        self, tid: str, task: dict[str, Any], *, reading: float, now: Any
+        self, tid: str, task: dict[str, Any], *, reading: float | None, now: Any
     ) -> bool:
         return await self._apply_edge(
             tid,

--- a/custom_components/home_keeper/services.yaml
+++ b/custom_components/home_keeper/services.yaml
@@ -1471,7 +1471,7 @@ add_declarative_companion:
     name, description, enabled, preset_id, selection ({target_integration,
     domain, device_class, entity_regex, area_ids, label_ids, exclude_*}), trigger
     (same shape as sensor task binding, plus the new availability mode), and
-    task_template ({name_template, notes_template, category, priority, labels}).
+    task_template ({name_template, notes_template, labels}).
     Admin-only.
 
 update_declarative_companion:

--- a/custom_components/home_keeper/store.py
+++ b/custom_components/home_keeper/store.py
@@ -1589,6 +1589,29 @@ class HomeKeeperStore:
         async_dispatcher_send(self._hass, SIGNAL_DECLARATIVE_SPECS_CHANGED)
         return entity_set_changed
 
+    async def pause_declarative_companion_tasks(self, spec_id: str) -> bool:
+        """Switch off the tasks of a disabled recipe, keeping them and their history.
+
+        The disabled half of :meth:`reconcile_declarative_companion_tasks`. Delegates
+        the decision to :func:`declarative_companions.pause_spec_tasks` and fires the
+        same ``home_keeper_task_updated`` event per changed task. Returns whether
+        anything changed; the entity set never does, because no task is created or
+        removed, so the caller needs no reload.
+        """
+        new_tasks, ops, changed = declarative_companions.pause_spec_tasks(
+            spec_id, self._tasks
+        )
+        if not changed:
+            return False
+        self._tasks = new_tasks
+        await self._save()
+        for _kind, task in ops:
+            self._hass.bus.async_fire(
+                EVENT_TASK_UPDATED,
+                events.task_event_data(task, extra={"changed_fields": ["enabled"]}),
+            )
+        return True
+
     async def reconcile_declarative_companion_tasks(
         self,
         spec: dict[str, Any],
@@ -1642,6 +1665,18 @@ class HomeKeeperStore:
             elif kind == "deleted":
                 self._hass.bus.async_fire(
                     EVENT_TASK_DELETED, events.task_event_data(task)
+                )
+                if _task_owns_entities(task):
+                    entity_set_changed = True
+            elif kind == "resumed":
+                # The recipe that had paused this task is on again. It is an update
+                # to everything that reads tasks, and a task made just now to the
+                # sensor watcher, which must arm it on a condition that became true
+                # while the recipe was off.
+                created_ids.append(task["id"])
+                self._hass.bus.async_fire(
+                    EVENT_TASK_UPDATED,
+                    events.task_event_data(task, extra={"changed_fields": ["enabled"]}),
                 )
                 if _task_owns_entities(task):
                     entity_set_changed = True

--- a/docs/guide/tasks/sensor-tasks.md
+++ b/docs/guide/tasks/sensor-tasks.md
@@ -43,6 +43,9 @@ A hold counts only the time the entity reported the condition. If the entity sto
 reporting, the hold stops. It starts again when the entity reports the condition
 again.
 
+If you change the condition of a task, Home Keeper reads the entity against the new
+condition. A task opens when the entity already meets the new condition.
+
 An armed sensor task behaves like any other task. It is on the to-do list and the
 calendar. It sets the device's overdue sensor and fires the
 `home_keeper_task_overdue` event.

--- a/docs/guide/tasks/sensor-tasks.md
+++ b/docs/guide/tasks/sensor-tasks.md
@@ -39,6 +39,10 @@ On the task form, select **Based on a sensor** and select the sensor and a mode:
   before the task arms. An optional attribute is treated as unavailable when it
   is missing. This mode clears the task by default when the entity recovers.
 
+A hold counts only the time the entity reported the condition. If the entity stops
+reporting, the hold stops. It starts again when the entity reports the condition
+again.
+
 An armed sensor task behaves like any other task. It is on the to-do list and the
 calendar. It sets the device's overdue sensor and fires the
 `home_keeper_task_overdue` event.

--- a/docs/guide/views/settings.md
+++ b/docs/guide/views/settings.md
@@ -85,6 +85,10 @@ warning shows above 50 matches. A recipe cannot match more than 500 entities. Se
 
 ![The page of a task a recipe made, with an Edit recipe button and no Done button while the task is monitored](../../images/21e-panel-declarative-task-detail.png)
 
+A recipe you switch off keeps the tasks it made. The tasks stop until you switch the
+recipe on again. Their history stays with them. Delete the recipe to remove its
+tasks.
+
 Each recipe gets a row under **Settings → Companions** with an Edit button and a
 Delete button. On a phone the row stacks, and the buttons take a line of their own.
 

--- a/tests/e2e/walkthrough.config.ts
+++ b/tests/e2e/walkthrough.config.ts
@@ -19,9 +19,22 @@ export default captureConfig('walkthrough.capture.ts', {
   // CI-specific slowness if a green run ever reports a length the container cannot
   // reproduce.
   //
-  // 240s is that measurement plus ~40%, and the base config gives CI `retries: 2`,
+  // 240s was that measurement plus ~40%, and the base config gives CI `retries: 2`,
   // so the tour has three independent attempts at it. Move the number against a
   // fresh measurement, not a hunch.
+  //
+  // Fresh measurements, September 2026, on a tour that has grown several surfaces
+  // since: **204s on CI** (green), **234s on CI** on the very next push of the same
+  // branch, and **210s in the dev container**. The 234s run then failed — it spent
+  // its last seconds inside a 40s wait at the closing step — and its first retry hit
+  // 240s outright. The tour is unchanged between those 2 CI runs and so is the
+  // panel, so the spread is the runner, and 240s had stopped being a margin: 204s
+  // leaves 15%, and one slower runner is over the line.
+  //
+  // 360s is the highest of those figures plus ~54%. Read the next timeout the same
+  // way round — the margin first — but a *lengthening* tour is the other half of
+  // this: at 3 attempts, 6 minutes each, the job's own 30-minute cap is the next
+  // thing that gives.
   //
   // **This cap is the only thing that bounds a hung tour.** `actionTimeout` below
   // does not: it applies to Playwright *actions* (click, fill), and the tour is
@@ -29,7 +42,7 @@ export default captureConfig('walkthrough.capture.ts', {
   // `actionTimeout` buys is that one bad selector fails in 20s instead of eating the
   // whole budget and reporting the timeout in the wrong place. Both matter; they are
   // not the same guard.
-  timeout: 240_000,
+  timeout: 360_000,
   use: {
     // The base config leaves actionTimeout unset (0 = no per-action cap), so a
     // click on a momentarily-unstable element would hang for the whole test budget.

--- a/tests/integration/ha_config/.storage/home_keeper
+++ b/tests/integration/ha_config/.storage/home_keeper
@@ -61,7 +61,7 @@
         "recurrence_type": "floating",
         "interval": 12,
         "unit": "months",
-        "device_id": "01c353cbab7c7bac40d0701fc14e4e40",
+        "device_id": "b5c13a793fe3ac02f5c809a733e87e0d",
         "area_id": null,
         "enabled": true,
         "created": "2022-05-10T10:00:00-04:00",
@@ -449,7 +449,7 @@
         "name": "Replace T&P relief valve (Garage water heater)",
         "notes": "",
         "recurrence_type": "floating",
-        "device_id": "01c353cbab7c7bac40d0701fc14e4e40",
+        "device_id": "b5c13a793fe3ac02f5c809a733e87e0d",
         "area_id": null,
         "enabled": true,
         "completion_detail": "none",
@@ -640,7 +640,7 @@
         "name": "Wear rain jacket",
         "notes": "",
         "recurrence_type": "use",
-        "device_id": "3ad6cde8b08bec396cdc3cd3f3b81f4d",
+        "device_id": "7e1959d36f1295e876483782f8d3b44d",
         "area_id": null,
         "enabled": true,
         "completion_detail": "none",
@@ -674,45 +674,13 @@
         "name": "Renew DWR coating (Rain jacket)",
         "notes": "",
         "recurrence_type": "triggered",
-        "device_id": "3ad6cde8b08bec396cdc3cd3f3b81f4d",
+        "device_id": "7e1959d36f1295e876483782f8d3b44d",
         "area_id": null,
         "enabled": true,
         "completion_detail": "none",
         "completion_required_fields": [],
         "active_season": null,
         "next_due": null
-      },
-      "bdc97efa-a60d-4ccb-847c-924340af197b": {
-        "id": "bdc97efa-a60d-4ccb-847c-924340af197b",
-        "created": "2026-09-12T10:15:06.558253-04:00",
-        "last_completed": null,
-        "completions": [],
-        "skips": [],
-        "source": null,
-        "managed_by": null,
-        "external_id": "",
-        "labels": [],
-        "card_links": [],
-        "task_chips": [],
-        "tag_id": null,
-        "require_tag_scan": false,
-        "name": "Sensor watcher test",
-        "notes": "",
-        "recurrence_type": "sensor",
-        "device_id": null,
-        "area_id": null,
-        "enabled": true,
-        "completion_detail": "none",
-        "completion_required_fields": [],
-        "active_season": null,
-        "sensor": {
-          "entity_id": "input_number.hk_demo_meter",
-          "mode": "threshold",
-          "comparison": ">",
-          "value": 50.0,
-          "for_seconds": 15
-        },
-        "next_due": "2026-09-12T10:15:29.953594-04:00"
       }
     },
     "assets": {
@@ -720,7 +688,7 @@
         "id": "e8d76383-4067-415c-975f-2ee73f475fa1",
         "kind": "virtual",
         "name": "Garage water heater",
-        "device_id": "01c353cbab7c7bac40d0701fc14e4e40",
+        "device_id": "b5c13a793fe3ac02f5c809a733e87e0d",
         "identifiers": [
           [
             "home_keeper",
@@ -815,29 +783,6 @@
               }
             ],
             "archived_at": "2025-06-15T10:00:00-04:00"
-          },
-          {
-            "task_id": "72fafed5-81e4-4723-bc53-7fb8767badd5",
-            "task_name": "Usage interval attributes test",
-            "part_id": null,
-            "completions": [
-              {
-                "ts": "2026-08-13T14:27:39.198825+00:00",
-                "reading": 1200.0,
-                "meter_start": 1000.0
-              },
-              {
-                "ts": "2026-08-20T14:27:39.198825+00:00",
-                "reading": 1500.0,
-                "meter_start": 1200.0
-              },
-              {
-                "ts": "2026-08-27T14:27:39.198825+00:00",
-                "reading": 1900.0,
-                "meter_start": 1500.0
-              }
-            ],
-            "archived_at": "2026-09-12T10:27:49.255290-04:00"
           }
         ],
         "metadata": [
@@ -912,7 +857,7 @@
         "id": "1f938cf8-c2a3-4438-aab3-840d0d749725",
         "kind": "virtual",
         "name": "Living room shades",
-        "device_id": "2f491f12680f15617cfeb63c73540c04",
+        "device_id": "7f0e7b13e0c64c28fd2b6343d2dbc3a8",
         "identifiers": [
           [
             "home_keeper",
@@ -937,7 +882,7 @@
         "id": "23e02da0-0411-4b16-9a63-10126f2ca7e6",
         "kind": "virtual",
         "name": "Radio shade controller",
-        "device_id": "ea4e120e9928dc21aa8d4b8b807ffa64",
+        "device_id": "26d375b15e30a1eb87adaad48195c754",
         "identifiers": [
           [
             "home_keeper",
@@ -963,7 +908,7 @@
         "name": "Rain jacket",
         "kind": "virtual",
         "external_id": "",
-        "device_id": "3ad6cde8b08bec396cdc3cd3f3b81f4d",
+        "device_id": "7e1959d36f1295e876483782f8d3b44d",
         "area_id": null,
         "manufacturer": "Fjallraven",
         "model": "Keb Eco-Shell",

--- a/tests/integration/ha_config/.storage/home_keeper
+++ b/tests/integration/ha_config/.storage/home_keeper
@@ -61,7 +61,7 @@
         "recurrence_type": "floating",
         "interval": 12,
         "unit": "months",
-        "device_id": "b5c13a793fe3ac02f5c809a733e87e0d",
+        "device_id": "01c353cbab7c7bac40d0701fc14e4e40",
         "area_id": null,
         "enabled": true,
         "created": "2022-05-10T10:00:00-04:00",
@@ -449,7 +449,7 @@
         "name": "Replace T&P relief valve (Garage water heater)",
         "notes": "",
         "recurrence_type": "floating",
-        "device_id": "b5c13a793fe3ac02f5c809a733e87e0d",
+        "device_id": "01c353cbab7c7bac40d0701fc14e4e40",
         "area_id": null,
         "enabled": true,
         "completion_detail": "none",
@@ -640,7 +640,7 @@
         "name": "Wear rain jacket",
         "notes": "",
         "recurrence_type": "use",
-        "device_id": "7e1959d36f1295e876483782f8d3b44d",
+        "device_id": "3ad6cde8b08bec396cdc3cd3f3b81f4d",
         "area_id": null,
         "enabled": true,
         "completion_detail": "none",
@@ -674,13 +674,45 @@
         "name": "Renew DWR coating (Rain jacket)",
         "notes": "",
         "recurrence_type": "triggered",
-        "device_id": "7e1959d36f1295e876483782f8d3b44d",
+        "device_id": "3ad6cde8b08bec396cdc3cd3f3b81f4d",
         "area_id": null,
         "enabled": true,
         "completion_detail": "none",
         "completion_required_fields": [],
         "active_season": null,
         "next_due": null
+      },
+      "bdc97efa-a60d-4ccb-847c-924340af197b": {
+        "id": "bdc97efa-a60d-4ccb-847c-924340af197b",
+        "created": "2026-09-12T10:15:06.558253-04:00",
+        "last_completed": null,
+        "completions": [],
+        "skips": [],
+        "source": null,
+        "managed_by": null,
+        "external_id": "",
+        "labels": [],
+        "card_links": [],
+        "task_chips": [],
+        "tag_id": null,
+        "require_tag_scan": false,
+        "name": "Sensor watcher test",
+        "notes": "",
+        "recurrence_type": "sensor",
+        "device_id": null,
+        "area_id": null,
+        "enabled": true,
+        "completion_detail": "none",
+        "completion_required_fields": [],
+        "active_season": null,
+        "sensor": {
+          "entity_id": "input_number.hk_demo_meter",
+          "mode": "threshold",
+          "comparison": ">",
+          "value": 50.0,
+          "for_seconds": 15
+        },
+        "next_due": "2026-09-12T10:15:29.953594-04:00"
       }
     },
     "assets": {
@@ -688,7 +720,7 @@
         "id": "e8d76383-4067-415c-975f-2ee73f475fa1",
         "kind": "virtual",
         "name": "Garage water heater",
-        "device_id": "b5c13a793fe3ac02f5c809a733e87e0d",
+        "device_id": "01c353cbab7c7bac40d0701fc14e4e40",
         "identifiers": [
           [
             "home_keeper",
@@ -783,6 +815,29 @@
               }
             ],
             "archived_at": "2025-06-15T10:00:00-04:00"
+          },
+          {
+            "task_id": "72fafed5-81e4-4723-bc53-7fb8767badd5",
+            "task_name": "Usage interval attributes test",
+            "part_id": null,
+            "completions": [
+              {
+                "ts": "2026-08-13T14:27:39.198825+00:00",
+                "reading": 1200.0,
+                "meter_start": 1000.0
+              },
+              {
+                "ts": "2026-08-20T14:27:39.198825+00:00",
+                "reading": 1500.0,
+                "meter_start": 1200.0
+              },
+              {
+                "ts": "2026-08-27T14:27:39.198825+00:00",
+                "reading": 1900.0,
+                "meter_start": 1500.0
+              }
+            ],
+            "archived_at": "2026-09-12T10:27:49.255290-04:00"
           }
         ],
         "metadata": [
@@ -857,7 +912,7 @@
         "id": "1f938cf8-c2a3-4438-aab3-840d0d749725",
         "kind": "virtual",
         "name": "Living room shades",
-        "device_id": "7f0e7b13e0c64c28fd2b6343d2dbc3a8",
+        "device_id": "2f491f12680f15617cfeb63c73540c04",
         "identifiers": [
           [
             "home_keeper",
@@ -882,7 +937,7 @@
         "id": "23e02da0-0411-4b16-9a63-10126f2ca7e6",
         "kind": "virtual",
         "name": "Radio shade controller",
-        "device_id": "26d375b15e30a1eb87adaad48195c754",
+        "device_id": "ea4e120e9928dc21aa8d4b8b807ffa64",
         "identifiers": [
           [
             "home_keeper",
@@ -908,7 +963,7 @@
         "name": "Rain jacket",
         "kind": "virtual",
         "external_id": "",
-        "device_id": "7e1959d36f1295e876483782f8d3b44d",
+        "device_id": "3ad6cde8b08bec396cdc3cd3f3b81f4d",
         "area_id": null,
         "manufacturer": "Fjallraven",
         "model": "Keb Eco-Shell",

--- a/tests/integration/test_declarative_companion_sync.py
+++ b/tests/integration/test_declarative_companion_sync.py
@@ -516,19 +516,36 @@ def test_narrowing_the_selection_removes_the_task_and_widening_makes_a_new_one(
     assert second["name"] == "Fill HK demo water tank low"
 
 
-def test_disabling_the_spec_drops_its_tasks_and_enabling_brings_them_back(ha, specs):
-    """``enabled: false`` cleans up without deleting the recipe."""
+def test_disabling_the_spec_switches_its_tasks_off_and_keeps_their_history(ha, specs):
+    """``enabled: false`` stops the recipe without throwing away what it recorded.
+
+    The tasks used to be deleted, so a recipe switched off for a week came back with
+    every completion on its tasks gone. A disabled task is already ignored by the
+    watcher and by every due-date surface, which is all "off" has to mean.
+    """
     _set_flag(ha, False)
     spec = specs(_tank_spec())
-    _one_task(ha, spec["id"])
+    task = _one_task(ha, spec["id"])
+    _let_the_watcher_subscribe()
+
+    # Record real history first: the tank empties and is filled again, and the
+    # recipe's own clear-on-recover writes the completion.
+    _set_flag(ha, True)
+    _poll_task(ha, spec["id"], lambda t: t.get("next_due") is not None)
+    _set_flag(ha, False)
+    _poll_task(ha, spec["id"], lambda t: len(t.get("completions") or []) == 1)
 
     _update_spec(ha, spec["id"], {"enabled": False})
-    _poll_spec_tasks(ha, spec["id"], lambda tasks: tasks == [])
+    off = _poll_task(ha, spec["id"], lambda t: t.get("enabled") is False)
+    assert off["id"] == task["id"], "the task must survive, not be remade"
+    assert len(off["completions"]) == 1, "the history must survive the switch"
     stored = [s for s in _list_specs(ha) if s["id"] == spec["id"]]
     assert stored and stored[0]["enabled"] is False, "the recipe itself must survive"
 
     _update_spec(ha, spec["id"], {"enabled": True})
-    _one_task(ha, spec["id"])
+    back = _poll_task(ha, spec["id"], lambda t: t.get("enabled") is True)
+    assert back["id"] == task["id"]
+    assert len(back["completions"]) == 1
 
 
 # ── (d) deletion ─────────────────────────────────────────────────────────────

--- a/tests/integration/test_sensor_watcher.py
+++ b/tests/integration/test_sensor_watcher.py
@@ -743,6 +743,60 @@ def test_an_availability_hold_completes_while_the_entity_stays_away(ha):
         _set_meter(ha, 0)  # brings the entity back
 
 
+def test_a_hold_starts_again_after_the_entity_stops_reporting(ha):
+    """A gap in the readings must not be banked as hold time (#336).
+
+    The reporter kept the Device Pulse recipe's hour-long hold, and the task opened
+    anyway each time the monitored entity reached the trigger state for a minute. The
+    watcher skipped a task whose entity had no reading, so the crossing that started
+    the hold survived the whole blackout: the entity came back over the threshold, the
+    hold read as long spent, and the task armed at once.
+    """
+    _set_meter(ha, 10)
+    task_id = _add_sensor_task(
+        ha,
+        {
+            "entity_id": METER,
+            "mode": "threshold",
+            "comparison": ">",
+            "value": 50,
+            "for_seconds": HOLD_SECONDS,
+            "clear_on_recover": True,
+        },
+    )
+    try:
+        _poll_task(ha, task_id, lambda t: t.get("recurrence_type") == "sensor")
+
+        # A crossing, then the entity stops reporting before the hold is up.
+        _set_meter(ha, 100)
+        time.sleep(4)
+        _force_unavailable(ha, METER)
+        time.sleep(HOLD_SECONDS + 8)
+        assert _require_task(ha, task_id)["next_due"] is None, (
+            "an unreadable entity must never arm a task"
+        )
+
+        # It comes back over the threshold. That is a fresh crossing, so the hold
+        # runs from here — the blackout bought it nothing.
+        _set_meter(ha, 100)
+        time.sleep(6)
+        assert _require_task(ha, task_id)["next_due"] is None, (
+            "armed on the return: the blackout was banked as hold time"
+        )
+
+        # The hold still completes on its own once the reading really does hold.
+        armed = _poll_task(
+            ha,
+            task_id,
+            lambda t: t.get("next_due") is not None,
+            timeout=HOLD_SECONDS + 25,
+        )
+        assert armed["next_due"] is not None
+    finally:
+        _delete(ha, task_id)
+        _set_meter(ha, 0)
+
+
 # ── an explicit starting reading, and the reading recorded on completion (#235) ──
 
 

--- a/tests/integration/test_sensor_watcher.py
+++ b/tests/integration/test_sensor_watcher.py
@@ -769,9 +769,9 @@ def test_a_hold_starts_again_after_the_entity_stops_reporting(ha):
 
         # A crossing, then the entity stops reporting before the hold is up.
         _set_meter(ha, 100)
-        time.sleep(4)
+        time.sleep(3)
         _force_unavailable(ha, METER)
-        time.sleep(HOLD_SECONDS + 8)
+        time.sleep(HOLD_SECONDS + 5)
         assert _require_task(ha, task_id)["next_due"] is None, (
             "an unreadable entity must never arm a task"
         )
@@ -779,7 +779,7 @@ def test_a_hold_starts_again_after_the_entity_stops_reporting(ha):
         # It comes back over the threshold. That is a fresh crossing, so the hold
         # runs from here — the blackout bought it nothing.
         _set_meter(ha, 100)
-        time.sleep(6)
+        time.sleep(5)
         assert _require_task(ha, task_id)["next_due"] is None, (
             "armed on the return: the blackout was banked as hold time"
         )
@@ -792,6 +792,44 @@ def test_a_hold_starts_again_after_the_entity_stops_reporting(ha):
             timeout=HOLD_SECONDS + 25,
         )
         assert armed["next_due"] is not None
+    finally:
+        _delete(ha, task_id)
+        _set_meter(ha, 0)
+
+
+def test_editing_the_condition_arms_a_task_the_new_one_already_matches(ha):
+    """Carried edge state answers a question about one condition.
+
+    A task watching "above 90" on a meter reading 60 records "not met". Move the
+    limit to "above 50" and the meter is already past it, but the watcher used to
+    hold the answer it had reached against the old limit — the task stayed dormant
+    until the reading fell below 50 and climbed back through it. The binding is part
+    of what the edge state was measured against, so an edit retires it.
+    """
+    _set_meter(ha, 60)
+    task_id = _add_sensor_task(
+        ha, {"entity_id": METER, "mode": "threshold", "comparison": ">", "value": 90}
+    )
+    try:
+        task = _poll_task(ha, task_id, lambda t: t.get("recurrence_type") == "sensor")
+        assert task["next_due"] is None  # 60 is not over 90
+
+        call_service(
+            ha,
+            "home_keeper",
+            "update_task",
+            {
+                "task_id": task_id,
+                "sensor": {
+                    "entity_id": METER,
+                    "mode": "threshold",
+                    "comparison": ">",
+                    "value": 50,
+                },
+            },
+        )
+        armed = _poll_task(ha, task_id, lambda t: t.get("next_due") is not None)
+        assert armed["sensor"]["value"] == 50
     finally:
         _delete(ha, task_id)
         _set_meter(ha, 0)

--- a/tests/unit/test_declarative_companions.py
+++ b/tests/unit/test_declarative_companions.py
@@ -222,28 +222,25 @@ def test_normalize_id_list_rejects_non_strings():
         )
 
 
-def test_normalize_task_template_priority_coerces_to_int():
+def test_normalize_task_template_drops_the_keys_nothing_ever_read():
+    # ``category`` and ``priority`` were validated, stored and exported, and no task
+    # was ever stamped with either — a Home Keeper task has no such field. They are
+    # dropped rather than refused, so a spec saved while the service still advertised
+    # them still loads instead of being thrown away whole.
     spec = dc.normalize_declarative_companion(
         _spec(
             task_template={
                 "name_template": "Fix {{ friendly_name }}",
+                "category": "plumbing",
                 "priority": "3",
             }
         )
     )
-    assert spec["task_template"]["priority"] == 3
-
-
-def test_normalize_task_template_rejects_non_int_priority():
-    with pytest.raises(TaskValidationError):
-        dc.normalize_declarative_companion(
-            _spec(
-                task_template={
-                    "name_template": "Fix {{ friendly_name }}",
-                    "priority": "not-a-number",
-                }
-            )
-        )
+    assert spec["task_template"] == {
+        "name_template": "Fix {{ friendly_name }}",
+        "notes_template": "",
+        "labels": [],
+    }
 
 
 def test_normalize_enabled_coerces_bool():
@@ -506,6 +503,83 @@ def test_reconcile_creates_missing_tasks():
     assert created["managed_by"]["completion_blocked"] is True
 
 
+def _usage_match(entity_id, spec_id):
+    """A match whose binding is a meter, so the task carries a baseline."""
+    key, match = _match(entity_id, spec_id)
+    match["sensor"] = {"entity_id": entity_id, "mode": "usage", "target": 300}
+    return key, match
+
+
+def test_reconcile_keeps_the_meter_baseline_the_watcher_stamped():
+    # The recipe owns every key on the binding except this one: the watcher writes
+    # ``baseline`` from the first live reading and moves it on each completion.
+    # Rewriting the block wholesale dropped it on any registry event, so a "every 300
+    # hours" recipe restarted its meter over and over and could never come due.
+    spec = _normalized_spec()
+    key, m = _usage_match("sensor.printer_pages", spec["id"])
+    stored, _ops, _changed = dc.reconcile_declarative_tasks(
+        spec, {key: m}, {}, _rendered(key), config_entry_id=ENTRY, now=NOW
+    )
+    tid = next(iter(stored))
+    stored[tid]["sensor"]["baseline"] = 1000.0
+
+    new_tasks, ops, changed = dc.reconcile_declarative_tasks(
+        spec, {key: m}, stored, _rendered(key), config_entry_id=ENTRY, now=NOW
+    )
+    assert new_tasks[tid]["sensor"]["baseline"] == 1000.0
+    assert new_tasks[tid]["sensor"]["target"] == 300
+    # Nothing else moved, so the pass reports no change and writes nothing.
+    assert changed is False
+    assert ops == []
+
+
+def test_reconcile_drops_the_baseline_when_the_recipe_leaves_meter_mode():
+    # ``baseline`` is a usage-only field, so carrying it into a threshold binding
+    # would make the task fail validation on its next write.
+    spec = _normalized_spec()
+    key, m = _usage_match("sensor.printer_pages", spec["id"])
+    stored, _ops, _changed = dc.reconcile_declarative_tasks(
+        spec, {key: m}, {}, _rendered(key), config_entry_id=ENTRY, now=NOW
+    )
+    tid = next(iter(stored))
+    stored[tid]["sensor"]["baseline"] = 1000.0
+
+    m["sensor"] = {"entity_id": "sensor.printer_pages", "mode": "state", "state": "on"}
+    new_tasks, _ops, changed = dc.reconcile_declarative_tasks(
+        spec, {key: m}, stored, _rendered(key), config_entry_id=ENTRY, now=NOW
+    )
+    assert changed is True
+    assert "baseline" not in new_tasks[tid]["sensor"]
+
+
+def test_reconcile_seeds_a_baseline_the_recipe_states_only_on_a_fresh_task():
+    # A recipe may name a starting reading. It anchors the task it makes, and the
+    # watcher's own anchor wins from then on — otherwise every pass would drag the
+    # meter back to the seed.
+    spec = _normalized_spec()
+    key, m = _usage_match("sensor.printer_pages", spec["id"])
+    m["sensor"]["baseline"] = 50.0
+    stored, _ops, _changed = dc.reconcile_declarative_tasks(
+        spec, {key: m}, {}, _rendered(key), config_entry_id=ENTRY, now=NOW
+    )
+    tid = next(iter(stored))
+    assert stored[tid]["sensor"]["baseline"] == 50.0
+
+    stored[tid]["sensor"]["baseline"] = 900.0
+    new_tasks, _ops, _changed = dc.reconcile_declarative_tasks(
+        spec, {key: m}, stored, _rendered(key), config_entry_id=ENTRY, now=NOW
+    )
+    assert new_tasks[tid]["sensor"]["baseline"] == 900.0
+
+
+def test_merge_sensor_binding_takes_the_fresh_block_when_there_is_nothing_to_keep():
+    fresh = {"entity_id": "sensor.a", "mode": "usage", "target": 10}
+    # No stored binding at all, a stored one in another mode, and one with no anchor.
+    assert dc.merge_sensor_binding(None, fresh) == fresh
+    assert dc.merge_sensor_binding({"mode": "state", "baseline": 5}, fresh) == fresh
+    assert dc.merge_sensor_binding({"mode": "usage"}, fresh) == fresh
+
+
 def test_reconcile_deletes_orphaned_tasks():
     spec = _normalized_spec()
     key, m = _match("sensor.hub_total_failed_pings", spec["id"])
@@ -732,6 +806,83 @@ def test_collect_orphans_deletes_all_specs_tasks():
     assert len(ops) == 1
     assert ops[0][0] == "deleted"
     assert new_tasks == {}
+
+
+# --- Pausing a disabled recipe ----------------------------------------------
+
+
+def _stored_task(spec, entity_id="sensor.hub_total_failed_pings"):
+    """One materialized task, the way the reconciler makes it."""
+    key, m = _match(entity_id, spec["id"])
+    stored, _ops, _changed = dc.reconcile_declarative_tasks(
+        spec, {key: m}, {}, _rendered(key), config_entry_id=ENTRY, now=NOW
+    )
+    return stored, next(iter(stored)), key, m
+
+
+def test_pausing_a_recipe_switches_its_tasks_off_and_keeps_them():
+    # Disabling a recipe used to delete its tasks, and the completions recorded on
+    # them went too. Switching a recipe off for a week is not a request to forget the
+    # work it tracked.
+    spec = _normalized_spec()
+    stored, tid, _key, _m = _stored_task(spec)
+    stored[tid]["completions"] = [{"ts": NOW.isoformat()}]
+
+    new_tasks, ops, changed = dc.pause_spec_tasks(spec["id"], stored)
+    assert changed is True
+    assert [kind for kind, _task in ops] == ["updated"]
+    assert new_tasks[tid]["enabled"] is False
+    assert new_tasks[tid]["completions"] == [{"ts": NOW.isoformat()}]
+    assert new_tasks[tid]["source"]["declarative_companion"]["paused"] is True
+
+
+def test_pausing_twice_reports_no_change():
+    spec = _normalized_spec()
+    stored, _tid, _key, _m = _stored_task(spec)
+    paused, _ops, _changed = dc.pause_spec_tasks(spec["id"], stored)
+    _again, ops, changed = dc.pause_spec_tasks(spec["id"], paused)
+    assert changed is False
+    assert ops == []
+
+
+def test_pausing_leaves_another_specs_tasks_alone():
+    spec = _normalized_spec()
+    stored, tid, _key, _m = _stored_task(spec)
+    _new_tasks, ops, changed = dc.pause_spec_tasks("another-spec", stored)
+    assert (changed, ops) == (False, [])
+    assert stored[tid]["enabled"] is True
+
+
+def test_enabling_the_recipe_again_brings_back_the_tasks_it_paused():
+    spec = _normalized_spec()
+    stored, tid, key, m = _stored_task(spec)
+    paused, _ops, _changed = dc.pause_spec_tasks(spec["id"], stored)
+
+    resumed, ops, changed = dc.reconcile_declarative_tasks(
+        spec, {key: m}, paused, _rendered(key), config_entry_id=ENTRY, now=NOW
+    )
+    assert changed is True
+    # "resumed", not "updated": the watcher must treat it as a task made just now and
+    # arm it on a condition that became true while the recipe was off.
+    assert [kind for kind, _task in ops] == ["resumed"]
+    assert resumed[tid]["enabled"] is True
+    assert "paused" not in resumed[tid]["source"]["declarative_companion"]
+
+
+def test_a_task_switched_off_by_hand_stays_off_when_the_recipe_comes_back():
+    # No ``paused`` marker, so this one is the person's choice, not the recipe's.
+    spec = _normalized_spec()
+    stored, tid, key, m = _stored_task(spec)
+    stored[tid]["enabled"] = False
+
+    paused, _ops, changed = dc.pause_spec_tasks(spec["id"], stored)
+    assert changed is False
+    assert "paused" not in paused[tid]["source"]["declarative_companion"]
+
+    resumed, _ops, _changed = dc.reconcile_declarative_tasks(
+        spec, {key: m}, paused, _rendered(key), config_entry_id=ENTRY, now=NOW
+    )
+    assert resumed[tid]["enabled"] is False
 
 
 # --- Presets ----------------------------------------------------------------

--- a/tests/unit/test_declarative_companions.py
+++ b/tests/unit/test_declarative_companions.py
@@ -853,6 +853,21 @@ def test_pausing_leaves_another_specs_tasks_alone():
     assert stored[tid]["enabled"] is True
 
 
+def test_pausing_reaches_this_specs_tasks_past_a_foreign_one():
+    # A task belonging to another recipe sits first in the map. Walking past it has
+    # to be a skip, not a stop, or the recipe's own task keeps running.
+    spec = _normalized_spec()
+    other = dc.normalize_declarative_companion(_spec(name="Another recipe"))
+    foreign, _foreign_tid, _key, _m = _stored_task(other, "sensor.other_pings")
+    mine, tid, _key, _m = _stored_task(spec)
+    tasks = {**foreign, **mine}
+
+    new_tasks, ops, changed = dc.pause_spec_tasks(spec["id"], tasks)
+    assert changed is True
+    assert [task["id"] for _kind, task in ops] == [tid]
+    assert new_tasks[tid]["enabled"] is False
+
+
 def test_enabling_the_recipe_again_brings_back_the_tasks_it_paused():
     spec = _normalized_spec()
     stored, tid, key, m = _stored_task(spec)

--- a/tests/unit/test_declarative_companions.py
+++ b/tests/unit/test_declarative_companions.py
@@ -853,6 +853,34 @@ def test_pausing_leaves_another_specs_tasks_alone():
     assert stored[tid]["enabled"] is True
 
 
+def test_pausing_walks_past_a_task_that_is_already_off():
+    # One of the recipe's tasks was switched off by hand and sits before the rest.
+    # The pass has to carry on to them.
+    spec = _normalized_spec()
+    off, off_tid, _key, _m = _stored_task(spec, "sensor.first_pings")
+    on, on_tid, _key, _m = _stored_task(spec, "sensor.second_pings")
+    off[off_tid]["enabled"] = False
+    tasks = {**off, **on}
+
+    new_tasks, ops, changed = dc.pause_spec_tasks(spec["id"], tasks)
+    assert changed is True
+    assert [task["id"] for _kind, task in ops] == [on_tid]
+    assert new_tasks[on_tid]["enabled"] is False
+
+
+def test_pausing_a_task_that_never_stated_enabled_treats_it_as_on():
+    # An imported or hand-edited task can arrive without the key. Absent means on
+    # everywhere else in Home Keeper, so the recipe pauses it like any other.
+    spec = _normalized_spec()
+    stored, tid, _key, _m = _stored_task(spec)
+    del stored[tid]["enabled"]
+
+    new_tasks, _ops, changed = dc.pause_spec_tasks(spec["id"], stored)
+    assert changed is True
+    assert new_tasks[tid]["enabled"] is False
+    assert new_tasks[tid]["source"]["declarative_companion"]["paused"] is True
+
+
 def test_pausing_reaches_this_specs_tasks_past_a_foreign_one():
     # A task belonging to another recipe sits first in the map. Walking past it has
     # to be a skip, not a stop, or the recipe's own task keeps running.

--- a/tests/unit/test_models_sensor.py
+++ b/tests/unit/test_models_sensor.py
@@ -481,6 +481,26 @@ def test_usage_accepts_an_empty_hold_or_a_cleared_switch(field, value):
     assert field not in binding
 
 
+def test_usage_reads_an_empty_box_as_an_absent_one():
+    # A form sends "" for a box nobody filled in. A target is required, so an empty
+    # one is the same as no target; an empty starting reading and an empty backstop
+    # simply are not there.
+    with raises_exactly(m.TaskValidationError, "sensor.target must be a number"):
+        m.normalize_sensor({"entity_id": "sensor.x", "mode": "usage", "target": ""})
+    binding = m.normalize_sensor(
+        {
+            "entity_id": "sensor.x",
+            "mode": "usage",
+            "target": 500,
+            "baseline": "",
+            "also_every": "",
+        }
+    )
+    assert "baseline" not in binding
+    assert "also_every" not in binding
+    assert "combinator" not in binding
+
+
 @pytest.mark.parametrize("field", ["also_every", "combinator", "unit", "target"])
 def test_threshold_still_rejects_usage_only_fields(field):
     with raises_exactly(

--- a/tests/unit/test_models_sensor.py
+++ b/tests/unit/test_models_sensor.py
@@ -454,6 +454,33 @@ def test_state_rejects_fields_from_the_other_modes(field, value):
         )
 
 
+@pytest.mark.parametrize(
+    ("field", "value"), [("for_seconds", 600), ("clear_on_recover", True)]
+)
+def test_usage_rejects_the_fields_only_an_edge_mode_reads(field, value):
+    # The mirror of the rule above. A meter has no condition to hold or to recover
+    # from, so a hold saved onto one used to vanish without a word.
+    with raises_exactly(
+        m.TaskValidationError,
+        f"sensor.{field} is not valid for a usage-mode sensor task",
+    ):
+        m.normalize_sensor(
+            {"entity_id": "sensor.x", "mode": "usage", "target": 500, field: value}
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"), [("for_seconds", 0), ("clear_on_recover", False)]
+)
+def test_usage_accepts_an_empty_hold_or_a_cleared_switch(field, value):
+    # A form that always sends both keys is saying nothing, so refusing it would fail
+    # a save that asks for nothing.
+    binding = m.normalize_sensor(
+        {"entity_id": "sensor.x", "mode": "usage", "target": 500, field: value}
+    )
+    assert field not in binding
+
+
 @pytest.mark.parametrize("field", ["also_every", "combinator", "unit", "target"])
 def test_threshold_still_rejects_usage_only_fields(field):
     with raises_exactly(

--- a/tests/unit/test_release_issues.py
+++ b/tests/unit/test_release_issues.py
@@ -562,6 +562,7 @@ _KNOWN_ISSUES = frozenset(
         312,
         313,
         331,
+        336,
     }
 )
 

--- a/tests/unit/test_sensor_tasks.py
+++ b/tests/unit/test_sensor_tasks.py
@@ -824,6 +824,52 @@ def test_availability_dormant_missing_never_arms():
 # ── the hold's own timer (a hold ends while the entity is quiet) ─────────────
 
 
+# ── the fingerprint that retires carried edge state ─────────────────────────
+
+
+def test_the_fingerprint_changes_with_every_part_of_the_condition():
+    # Carried edge state is an answer about one condition. Change the condition and
+    # the answer is about a question nobody is asking, so the watcher starts over.
+    base = _threshold(">", 90)
+    assert s.condition_fingerprint(base) == s.condition_fingerprint(_threshold(">", 90))
+    for changed in (
+        _threshold(">", 50),  # a different limit
+        _threshold("<", 90),  # a different comparison
+        _state("on"),  # a different mode entirely
+    ):
+        assert s.condition_fingerprint(changed) != s.condition_fingerprint(base)
+    moved = _threshold(">", 90)
+    moved["sensor"]["entity_id"] = "sensor.another"
+    assert s.condition_fingerprint(moved) != s.condition_fingerprint(base)
+    attributed = _threshold(">", 90)
+    attributed["sensor"]["attribute"] = "humidity"
+    assert s.condition_fingerprint(attributed) != s.condition_fingerprint(base)
+
+
+def test_the_fingerprint_ignores_what_does_not_decide_the_condition():
+    # A longer hold applies to the crossing already running; auto-clear decides what
+    # happens after the condition, not whether it is true. Neither retires the edge.
+    base = _threshold(">", 90)
+    longer = _threshold(">", 90, for_seconds=600)
+    clearing = _threshold(">", 90)
+    clearing["sensor"]["clear_on_recover"] = True
+    assert s.condition_fingerprint(longer) == s.condition_fingerprint(base)
+    assert s.condition_fingerprint(clearing) == s.condition_fingerprint(base)
+
+
+def test_the_fingerprint_of_a_task_with_no_binding_is_still_comparable():
+    # A task that stopped being a sensor task has no condition. It must not raise:
+    # the watcher fingerprints whatever it is handed.
+    assert s.condition_fingerprint({"recurrence_type": "floating"}) == (
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+
+
 def test_hold_due_at_reports_the_moment_a_pending_hold_completes():
     # The watcher books a re-evaluation for this moment. Without it a hold only ran
     # out when the entity happened to send another state change.

--- a/tests/unit/test_sensor_tasks.py
+++ b/tests/unit/test_sensor_tasks.py
@@ -346,6 +346,64 @@ def test_threshold_hold_delays_arming():
     assert out["action"] == "arm"
 
 
+def test_threshold_no_reading_ends_a_pending_hold_and_decides_nothing():
+    # The reporter's mode (#336). A missing / unavailable / non-numeric entity reads
+    # as None. It never arms on bad data, and the seconds it spent unreadable are not
+    # seconds the reading was over the threshold, so the pending hold ends.
+    cross = dt(2026, 6, 1, 10, 0, 0)
+    task = _threshold(">", 90, for_seconds=300)
+    out = s.evaluate_threshold(
+        task,
+        reading=None,
+        condition_met_prev=True,
+        crossed_at=cross,
+        now=cross + timedelta(seconds=60),
+    )
+    assert out == {
+        "action": None,
+        "condition_met": False,
+        "crossed_at": None,
+        "hold_due_at": None,
+    }
+
+
+def test_threshold_hold_starts_again_after_a_gap_in_the_readings():
+    # The whole bug: the entity came back over the threshold after a long silence and
+    # armed at once, because the silence had been banked as hold time.
+    cross = dt(2026, 6, 1, 10, 0, 0)
+    task = _threshold(">", 90, for_seconds=300)
+    gap = s.evaluate_threshold(
+        task,
+        reading=None,
+        condition_met_prev=True,
+        crossed_at=cross,
+        now=cross + timedelta(seconds=60),
+    )
+    back = cross + timedelta(hours=1)
+    out = s.evaluate_threshold(
+        task,
+        reading=95,
+        condition_met_prev=gap["condition_met"],
+        crossed_at=gap["crossed_at"],
+        now=back,
+    )
+    assert out["action"] is None, "an hour with no reading is not an hour over 90"
+    assert out["crossed_at"] == back
+
+
+def test_threshold_no_reading_never_clears_an_armed_clear_on_recover_task():
+    # The mirror of the state mode's dropout trap: no reading is not a recovery, so
+    # an armed task that clears on recover must survive the entity going away.
+    now = dt(2026, 6, 1, 10)
+    task = _threshold(">", 90, armed=True)
+    task["sensor"]["clear_on_recover"] = True
+    out = s.evaluate_threshold(
+        task, reading=None, condition_met_prev=True, crossed_at=None, now=now
+    )
+    assert out["action"] is None
+    assert out["condition_met"] is True
+
+
 def test_threshold_hold_resets_if_it_dips_below():
     cross = dt(2026, 6, 1, 10, 0, 0)
     task = _threshold(">", 90, for_seconds=300)
@@ -464,10 +522,10 @@ def test_state_hold_resets_if_it_recovers_first():
 
 
 # ── the unavailable / dropout trap ───────────────────────────────────────────
-def test_state_none_holds_the_edge_and_decides_nothing():
+def test_state_none_ends_a_pending_hold_and_decides_nothing():
     # `unavailable`/`unknown`/missing arrives as None. It is neither a match nor a
-    # recovery: the carried edge state must survive untouched so a dropout mid-hold
-    # doesn't restart the timer or fabricate a crossing.
+    # recovery, so it decides nothing — and it ends the pending hold, because a hold
+    # counts time the condition was true and this is not that time (#336).
     cross = dt(2026, 6, 1, 10, 0, 0)
     task = _state("on", for_seconds=600)
     out = s.evaluate_state(
@@ -479,11 +537,67 @@ def test_state_none_holds_the_edge_and_decides_nothing():
     )
     assert out == {
         "action": None,
-        "condition_met": True,
-        "crossed_at": cross,
-        # The hold is still pending, so the booked re-evaluation survives the dropout.
-        "hold_due_at": cross + timedelta(minutes=10),
+        "condition_met": False,
+        "crossed_at": None,
+        "hold_due_at": None,
     }
+
+
+def test_state_hold_starts_again_after_a_dropout():
+    # The reporter's case (#336): the entity dropped out mid-hold and came back in
+    # the trigger state. It has been on for one second, so the 10-minute hold has to
+    # run from the return, not from the crossing an hour ago.
+    cross = dt(2026, 6, 1, 10, 0, 0)
+    task = _state("on", for_seconds=600)
+    gap = s.evaluate_state(
+        task,
+        state=None,
+        condition_met_prev=True,
+        crossed_at=cross,
+        now=cross + timedelta(minutes=2),
+    )
+    back = cross + timedelta(hours=1)
+    out = s.evaluate_state(
+        task,
+        state="on",
+        condition_met_prev=gap["condition_met"],
+        crossed_at=gap["crossed_at"],
+        now=back,
+    )
+    assert out["action"] is None, "the blackout must not count toward the hold"
+    assert out["crossed_at"] == back
+    assert out["hold_due_at"] == back + timedelta(seconds=600)
+    # And it still arms once the entity really does hold the state that long.
+    out = s.evaluate_state(
+        task,
+        state="on",
+        condition_met_prev=True,
+        crossed_at=back,
+        now=back + timedelta(minutes=10),
+    )
+    assert out["action"] == "arm"
+
+
+def test_state_none_leaves_a_task_with_no_pending_crossing_alone():
+    # No crossing to break: the condition was met without one (baselined at startup)
+    # or an arm consumed it. Carrying `condition_met` is what stops a dropout from
+    # re-arming a task the user already dealt with.
+    now = dt(2026, 6, 1, 10)
+    task = _state("on", for_seconds=600)
+    out = s.evaluate_state(
+        task, state=None, condition_met_prev=True, crossed_at=None, now=now
+    )
+    assert out == {
+        "action": None,
+        "condition_met": True,
+        "crossed_at": None,
+        "hold_due_at": None,
+    }
+    # Still met and still without a crossing, so the return to the state arms nothing.
+    out = s.evaluate_state(
+        task, state="on", condition_met_prev=True, crossed_at=None, now=now
+    )
+    assert out["action"] is None
 
 
 def test_state_none_never_arms_a_dormant_task():
@@ -639,12 +753,11 @@ def test_availability_missing_status_is_indeterminate():
     """A not-yet-restored entity must never fabricate an arm or clear."""
     now = dt(2026, 6, 1, 10)
     task = _availability(armed=True, clear_on_recover=True)
-    prior_cross = dt(2026, 5, 30, 10)
     out = s.evaluate_availability(
         task,
         status=s.AVAILABILITY_MISSING,
         condition_met_prev=True,
-        crossed_at=prior_cross,
+        crossed_at=None,
         now=now,
     )
     # The whole return dict is asserted so a mutated key name (e.g. ``crossed_at`` →
@@ -652,16 +765,16 @@ def test_availability_missing_status_is_indeterminate():
     assert out == {
         "action": None,
         "condition_met": True,
-        "crossed_at": prior_cross,
-        # The task is armed already, so no hold waits on a re-evaluation.
+        "crossed_at": None,
+        # The arm consumed the crossing, so no hold waits on a re-evaluation.
         "hold_due_at": None,
     }
 
 
-def test_availability_missing_keeps_a_pending_hold():
+def test_availability_missing_ends_a_pending_hold():
     # The entity left the state machine part-way through the hold. That decides
-    # nothing, so the booked re-evaluation stands: the entity may come back, and the
-    # hold still ends when it ends.
+    # nothing, and it ends the hold: an entity nobody can see is not an entity that
+    # is unavailable for 10 minutes, so the clock restarts when it comes back (#336).
     cross = dt(2026, 6, 1, 10, 0, 0)
     task = _availability(for_seconds=600)
     out = s.evaluate_availability(
@@ -673,10 +786,21 @@ def test_availability_missing_keeps_a_pending_hold():
     )
     assert out == {
         "action": None,
-        "condition_met": True,
-        "crossed_at": cross,
-        "hold_due_at": cross + timedelta(minutes=10),
+        "condition_met": False,
+        "crossed_at": None,
+        "hold_due_at": None,
     }
+    # The hold runs from the return, so an hour of "missing" arms nothing.
+    back = cross + timedelta(hours=1)
+    out = s.evaluate_availability(
+        task,
+        status=s.AVAILABILITY_UNAVAILABLE,
+        condition_met_prev=False,
+        crossed_at=None,
+        now=back,
+    )
+    assert out["action"] is None
+    assert out["crossed_at"] == back
 
 
 def test_availability_dormant_missing_never_arms():

--- a/tests/unit/test_sensor_tasks.py
+++ b/tests/unit/test_sensor_tasks.py
@@ -827,6 +827,31 @@ def test_availability_dormant_missing_never_arms():
 # ── the fingerprint that retires carried edge state ─────────────────────────
 
 
+def test_the_fingerprint_reads_the_keys_that_state_the_condition():
+    # Stated as a value, not as a comparison between two fingerprints: 2 sides of a
+    # comparison move together, so a fingerprint that read the wrong key — or read
+    # them in another order — would still agree with itself.
+    task = _threshold(">", 90)
+    task["sensor"]["attribute"] = "damp"
+    assert s.condition_fingerprint(task) == (
+        "sensor.humidity",
+        "damp",
+        "threshold",
+        ">",
+        90,
+        None,
+    )
+    tank = _state("on")
+    assert s.condition_fingerprint(tank) == (
+        "binary_sensor.vacuum_water_tank_low",
+        None,
+        "state",
+        None,
+        None,
+        "on",
+    )
+
+
 def test_the_fingerprint_changes_with_every_part_of_the_condition():
     # Carried edge state is an answer about one condition. Change the condition and
     # the answer is about a question nobody is asking, so the watcher starts over.


### PR DESCRIPTION
Fixes #336

## What changed

### 1. A hold no longer banks time the entity spent silent (#336)

`for_seconds` is meant to measure how long the condition has been **continuously**
true. An indeterminate reading — a missing, `unavailable` or `unknown` entity — kept
the pending crossing alive, so a device that dropped off the network banked the whole
blackout and armed its task the instant it came back in the trigger state. The
reporter kept the Device Pulse recipe's 3600 s hold and got a task for every
one-minute visit to the trigger condition.

Reproduced against the real container before the fix (a 20 s hold):

```
crossed  meter='100.0'       next_due=None                  <- crossing, hold pending
gap      meter='unavailable' next_due=None                  <- 28 s with no reading
back     meter='100.0'       next_due=2026-09-12T09:18:17   <- armed on the return
```

`sensor_tasks._evaluate_indeterminate` is now the one place the rule lives, and the
`threshold`, `state` and `availability` evaluators all delegate to it: decide nothing,
and end a pending hold so the next true reading starts a fresh one. A task with **no**
pending crossing keeps its carried `condition_met`, which is what still stops a dropout
from re-arming a task the user dealt with, or completing a `clear_on_recover` one.
`evaluate_threshold` takes `reading=None` instead of the watcher skipping the task —
the skip left the crossing *and* its hold timer in place.

### 2. Six more defects, from reviewing the rest of the feature

Each one has a test written first.

- **A recipe that meters a sensor lost its meter anchor.** The reconcile pass rewrites
  a materialized task's whole `sensor` block from the recipe, and `sensor.baseline` is
  the one key on it no recipe writes — the watcher stamps it from the first live
  reading. A pass runs on *any* entity, device or area registry event, so a `usage`
  recipe restarted its meter whenever anything in Home Assistant changed and could
  never reach its target. `merge_sensor_binding` carries a stored anchor forward; a
  recipe's own `baseline` now only seeds a task that has none.
- **Disabling a recipe deleted its tasks**, and the completions recorded on them went
  too. `pause_spec_tasks` switches them off and marks the provenance `paused`; the
  enabled pass clears the marker with a `"resumed"` op, which the store reports as a
  freshly-made id so the watcher arms a condition that became true while the recipe was
  off. A task switched off by hand carries no marker, so that choice survives.
- **Carried edge state outlived the condition it was decided against.** A task moved
  from "below 20%" to "below 50%" kept a `condition_met` measured against the old limit,
  so a battery already at 30% stayed dormant until it rose above 50% and fell back
  through it. The edge is stamped with `sensor_tasks.condition_fingerprint` and retired
  when the binding's condition changes — not for a hold or `clear_on_recover` change,
  which decide nothing about whether the condition is true.
- **Nothing debounced the reconciler.** Home Assistant fires one entity-registry event
  per entity and each one ran a full pass: every spec over every entity, a Jinja render
  per match, a store write. The docstring claimed the dispatcher already coalesced them,
  and no `Debouncer` existed anywhere in the component. One does now (`immediate=True`,
  so a saved recipe still shows its tasks at once), shut down with the listeners.
- **`task_template.category` and `task_template.priority` did nothing.** Validated,
  stored, exported and advertised by the service, and a task has no such field. Dropped
  from the normalized shape and from `services.yaml` — but not refused, so a spec that
  carries them still loads instead of being thrown away.
- **A usage binding silently dropped `for_seconds` and `clear_on_recover`**, which is
  the thing `_reject_fields` exists to stop. Refused now, and only when truthy: a form
  that always sends `for_seconds: 0` is saying nothing.

### 3. Two CI budgets that had run out

Neither is a test failure. Both are caps that a growing suite had caught up with, and
both bit this PR.

- **`integration.yml` cancelled a run whose 216 tests had all passed.** The tier takes
  ~9.5 minutes at main HEAD (9:26–9:54 on the last 4 runs) against a 10-minute job cap,
  so any PR adding a test was one cancelled run away. Raised to 20, and the #336 test
  waits a little less.
- **The walkthrough tour outgrew its 240 s test budget.** The desktop tour took 3.4m on
  CI on this branch's previous push and 3.9m on the next one, whose first retry hit the
  cap outright — the same tour, and `tests/e2e/` and the panel are identical to main on
  this branch, so the spread is the runner. The config's own note says to suspect the
  margin first and to move the number against a fresh measurement: 204 s and 234 s on
  CI, 210 s in the dev container, so 360 s is the highest of those plus ~54%. The tour
  passes locally, desktop and phone, and the sticky comment on this PR now renders both.

## Tests

- `tests/unit/test_sensor_tasks.py` — the hold restarts after a gap in all 3 edge
  modes; a missing threshold reading never arms and never clears an armed
  `clear_on_recover` task; the fingerprint's own value, and what does and does not
  change it. Two tests that pinned the old carry-through-a-dropout behaviour are
  rewritten.
- `tests/unit/test_declarative_companions.py` — the meter anchor survives a pass,
  is dropped on a mode change, and a recipe's seed loses to a stored one; pause and
  resume, including a task switched off by hand and one that never stated `enabled`.
- `tests/unit/test_models_sensor.py` — a usage binding refuses a hold and an auto-clear
  switch, accepts an empty one, and reads an empty box as an absent one.
- `tests/integration/test_sensor_watcher.py` — the reporter's sequence against the real
  container (failed on `main` with `armed on the return: the blackout was banked as
  hold time`), and editing a condition to one the meter already meets arms the task.
- `tests/integration/test_declarative_companion_sync.py` — disabling a recipe keeps its
  task and the completion recorded on it, and enabling brings it back.

Run locally: `tests/unit` (2424 passed), `tests/integration/test_sensor_watcher.py` +
`test_declarative_companion_sync.py` (38 passed), `ci/test-frontend.sh` (1457 passed),
the walkthrough capture (desktop and phone), ruff, vale on the changed prose, and
`ci/test-mutation-python.sh` — **93.74 %**, threshold 80 %.

## One-way doors

- **`source.declarative_companion.paused`** — a boolean marker on a managed task's
  provenance block, written when the recipe that owns the task is switched off and
  cleared when it comes back. It is stored, and it travels in an export like the rest
  of `source`. Nothing outside Home Keeper is expected to write it, but an automation
  reading a task's `source` will see it.
- **`task_template.category` / `task_template.priority`** stop being part of the
  `add_declarative_companion` payload. A caller that sends them is not refused; the
  values are dropped, as they effectively were before.
- **A usage-mode `sensor` binding now refuses a truthy `for_seconds` or
  `clear_on_recover`.** A service call that used to be accepted (and silently
  stripped) now returns an error.

Two of these are behaviour changes rather than pure fixes — a disabled recipe keeping
its tasks, and the usage binding refusing what it used to strip. Both are easy to drop
from this PR if you would rather they landed on their own.

## Checklist

- [x] Tests run locally (`pytest tests/unit -v`, integration, frontend, mutation)
- [x] `CHANGELOG.md` updated with `(Fixes #336)`; version bumped to `0.24.0b5`
      because `0.24.0b4` already shipped
- [x] Panel UI unchanged — no screenshots needed
- [x] No new user-facing UI surface — the walkthrough tour is unchanged
- [x] Conventions written into `.amazonq/rules/architecture-and-code.md`
- [x] Bug fixes only — no `preview-release` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WaVi7EecopC2ogFKnyZEW
