### PR TITLE
chore: deny the 2 scheduling tools that prompt on every call

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,21 +3,23 @@
   "permissions": {
     "allow": [
       "mcp__Claude_Code_Remote__archive_session",
-      "mcp__Claude_Code_Remote__create_trigger",
       "mcp__Claude_Code_Remote__delete_trigger",
       "mcp__Claude_Code_Remote__list_triggers",
-      "mcp__Claude_Code_Remote__send_later",
       "mcp__Claude_Code_Remote__subscribe_pr_activity",
       "mcp__Claude_Code_Remote__unsubscribe_pr_activity",
       "mcp__claude-code-remote__archive_session",
-      "mcp__claude-code-remote__create_trigger",
       "mcp__claude-code-remote__delete_trigger",
       "mcp__claude-code-remote__list_triggers",
-      "mcp__claude-code-remote__send_later",
       "mcp__claude-code-remote__subscribe_pr_activity",
       "mcp__claude-code-remote__unsubscribe_pr_activity",
       "mcp__github__subscribe_pr_activity",
       "mcp__github__unsubscribe_pr_activity"
+    ],
+    "deny": [
+      "mcp__Claude_Code_Remote__create_trigger",
+      "mcp__Claude_Code_Remote__send_later",
+      "mcp__claude-code-remote__create_trigger",
+      "mcp__claude-code-remote__send_later"
     ]
   },
   "hooks": {


### PR DESCRIPTION
No issue — this came out of debugging why the allow entries in `.claude/settings.json` weren't stopping the permission prompts in session 337's cloud session.

## What changed

`.claude/settings.json` only. `send_later` and `create_trigger` move from `allow` to `deny`, in both server-name spellings.

Those 2 allow entries never did anything. The MCP server marks both tools
`_meta["anthropic/requiresUserInteraction"]`, and for such a tool [Claude Code
shows](https://code.claude.com/docs/en/mcp#require-approval-for-a-specific-tool) "that tool's
permission prompt on every call, even in `acceptEdits`, `auto`, and `bypassPermissions`
permission modes… **Allow rules that match the tool don't skip the prompt either.**" So every
self check-in on a watched PR cost an approval, and the session sat waiting for one.

A deny rule fixes what an allow rule cannot. Per [Configure
permissions](https://code.claude.com/docs/en/permissions), rules are "evaluated in order: deny,
then ask, then allow", and "a bare tool name like `Bash` removes the tool from Claude's context
entirely, so Claude never sees it". The agent then never reaches for the tool and never stalls.

Verified live: both tools dropped out of the running session's toolset the moment the file was
written, before this commit existed.

## What this gives up

The self check-in that re-verified a watched PR on a timer. `subscribe_pr_activity` still wakes
the session on CI failures and review comments, so the events that mattered on #337 still arrive.
What goes is the fallback for what webhooks don't reliably deliver: CI *success*, new pushes, and
merge-conflict transitions. Worth knowing if a future session is asked to babysit a PR — it will
notice a red check but not a silently-green one.

The other entries stay as they are: `subscribe_pr_activity`, `unsubscribe_pr_activity`,
`list_triggers`, `delete_trigger` and `archive_session` are not flagged and their allow rules
work.

## One-way doors

None. Settings-only, reversible by editing the same file.

## Checklist

- [ ] Tests run locally — n/a, no code changed
- [ ] `CHANGELOG.md` updated — n/a, developer-only change
- [ ] Panel UI changed → screenshots — n/a
- [ ] New user-facing UI surface → walkthrough extended — n/a
- [ ] New user-facing feature → beta bump — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WaVi7EecopC2ogFKnyZEW
